### PR TITLE
Fix TrainerLab simulation failure event handling and retry UI

### DIFF
--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
@@ -36,14 +36,14 @@ public struct AppShellRootView: View {
                             },
                             onExit: {
                                 self.selectedApp = nil
-                            },
+                            }
                         )
                     case .trainerLab:
                         TrainerLabWorkspace(
                             model: model,
                             onExit: {
                                 self.selectedApp = nil
-                            },
+                            }
                         )
                     }
                 } else {
@@ -57,7 +57,7 @@ public struct AppShellRootView: View {
                         onSignOut: {
                             selectedApp = nil
                             Task { await model.authViewModel.signOut() }
-                        },
+                        }
                     )
                 }
             } else {
@@ -68,7 +68,7 @@ public struct AppShellRootView: View {
                     environmentLabel: "Env: \(model.environmentStore.selection.rawValue) | \(model.environmentStore.baseURL.host() ?? "unknown")",
                     onOpenEnvironmentSwitcher: {
                         showEnvironment = true
-                    },
+                    }
                 )
             }
         }
@@ -102,7 +102,7 @@ private struct TrainerLabWorkspace: View {
                             selectedSession = nil
                             Task { await model.sessionHubViewModel.loadSessions() }
                         },
-                        onOpenSummary: { showSummary = true },
+                        onOpenSummary: { showSummary = true }
                     )
                 } else {
                     SessionHubView(
@@ -112,7 +112,7 @@ private struct TrainerLabWorkspace: View {
                         },
                         onOpenPresets: {
                             showPresets = true
-                        },
+                        }
                     )
                     .toolbar {
                         ToolbarItem(placement: .automatic) {
@@ -147,7 +147,7 @@ private struct RunConsoleScreen: View {
         model: AppShellModel,
         session: TrainerSessionDTO,
         onBack: @escaping () -> Void,
-        onOpenSummary: @escaping () -> Void,
+        onOpenSummary: @escaping () -> Void
     ) {
         self.model = model
         self.session = session
@@ -187,14 +187,14 @@ private struct MainMenuView: View {
                         title: "TrainerLab",
                         subtitle: "Run and manage live trainer sessions",
                         systemImage: "waveform.path.ecg",
-                        action: onOpenTrainerLab,
+                        action: onOpenTrainerLab
                     )
 
                     menuButton(
                         title: "ChatLab",
                         subtitle: "Work simulations through the messaging runtime",
                         systemImage: "message.badge",
-                        action: onOpenChatLab,
+                        action: onOpenChatLab
                     )
                 }
                 .padding(.top, 8)

--- a/apps/trainerlab-ios/Sources/Networking/TrainerLabService.swift
+++ b/apps/trainerlab-ios/Sources/Networking/TrainerLabService.swift
@@ -86,7 +86,7 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         }
         return try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/", query: query),
-            as: PaginatedResponse<TrainerSessionDTO>.self,
+            as: PaginatedResponse<TrainerSessionDTO>.self
         )
     }
 
@@ -97,22 +97,22 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/",
                 method: .post,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerSessionDTO.self,
+            as: TrainerSessionDTO.self
         )
     }
 
     public func getSession(simulationID: Int) async throws -> TrainerSessionDTO {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/\(simulationID)/"),
-            as: TrainerSessionDTO.self,
+            as: TrainerSessionDTO.self
         )
     }
 
     public func retryInitialSimulation(simulationID: Int) async throws -> TrainerSessionDTO {
         _ = try await apiClient.requestData(
-            Endpoint(path: "/api/v1/simulations/\(simulationID)/retry-initial/", method: .post, body: Data()),
+            Endpoint(path: "/api/v1/simulations/\(simulationID)/retry-initial/", method: .post, body: Data())
         )
         return try await getSession(simulationID: simulationID)
     }
@@ -120,30 +120,30 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
     public func getRuntimeState(simulationID: Int) async throws -> TrainerRuntimeStateOut {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/\(simulationID)/state/"),
-            as: TrainerRuntimeStateOut.self,
+            as: TrainerRuntimeStateOut.self
         )
     }
 
     public func getControlPlaneDebug(simulationID: Int) async throws -> ControlPlaneDebugOut {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/\(simulationID)/control-plane/"),
-            as: ControlPlaneDebugOut.self,
+            as: ControlPlaneDebugOut.self
         )
     }
 
     public func runCommand(
         simulationID: Int,
         command: RunCommand,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerSessionDTO {
         try await apiClient.request(
             Endpoint(
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/run/\(command.rawValue)/",
                 method: .post,
                 body: Data(),
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerSessionDTO.self,
+            as: TrainerSessionDTO.self
         )
     }
 
@@ -153,9 +153,9 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/run/tick/",
                 method: .post,
                 body: Data(),
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerCommandAck.self,
+            as: TrainerCommandAck.self
         )
     }
 
@@ -165,16 +165,16 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/run/tick/vitals/",
                 method: .post,
                 body: Data(),
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerCommandAck.self,
+            as: TrainerCommandAck.self
         )
     }
 
     public func listEvents(
         simulationID: Int,
         cursor: String?,
-        limit: Int,
+        limit: Int
     ) async throws -> PaginatedResponse<EventEnvelope> {
         var query = [URLQueryItem(name: "limit", value: String(limit))]
         if let cursor {
@@ -182,14 +182,14 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         }
         return try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/\(simulationID)/events/", query: query),
-            as: PaginatedResponse<EventEnvelope>.self,
+            as: PaginatedResponse<EventEnvelope>.self
         )
     }
 
     public func getRunSummary(simulationID: Int) async throws -> RunSummary {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/\(simulationID)/summary/"),
-            as: RunSummary.self,
+            as: RunSummary.self
         )
     }
 
@@ -200,16 +200,16 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/adjust/",
                 method: .post,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: SimulationAdjustAck.self,
+            as: SimulationAdjustAck.self
         )
     }
 
     public func steerPrompt(
         simulationID: Int,
         request: SteerPromptRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         let body = try encoder.encode(request)
         return try await apiClient.request(
@@ -217,117 +217,117 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/steer/prompt/",
                 method: .post,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerCommandAck.self,
+            as: TrainerCommandAck.self
         )
     }
 
     public func injectInjuryEvent(
         simulationID: Int,
         request: InjuryEventRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/injuries/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func injectIllnessEvent(
         simulationID: Int,
         request: IllnessEventRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/illnesses/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func createProblem(
         simulationID: Int,
         request: ProblemCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/problems/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func createAssessmentFinding(
         simulationID: Int,
         request: AssessmentFindingCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/assessment-findings/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func createDiagnosticResult(
         simulationID: Int,
         request: DiagnosticResultCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/diagnostic-results/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func createResourceState(
         simulationID: Int,
         request: ResourceStateCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/resources/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func createDispositionState(
         simulationID: Int,
         request: DispositionStateCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/disposition/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func injectVitalEvent(
         simulationID: Int,
         request: VitalEventRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/vitals/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
     public func injectInterventionEvent(
         simulationID: Int,
         request: InterventionEventRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         try await injectEvent(
             path: "/api/v1/trainerlab/simulations/\(simulationID)/events/interventions/",
             request: request,
-            idempotencyKey: idempotencyKey,
+            idempotencyKey: idempotencyKey
         )
     }
 
@@ -335,7 +335,7 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         let body = try encoder.encode(request)
         return try await apiClient.request(
             Endpoint(path: path, method: .post, body: body, idempotencyKey: idempotencyKey),
-            as: TrainerCommandAck.self,
+            as: TrainerCommandAck.self
         )
     }
 
@@ -346,7 +346,7 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         }
         return try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/presets/", query: query),
-            as: PaginatedResponse<ScenarioInstruction>.self,
+            as: PaginatedResponse<ScenarioInstruction>.self
         )
     }
 
@@ -354,14 +354,14 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         let body = try encoder.encode(request)
         return try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/presets/", method: .post, body: body),
-            as: ScenarioInstruction.self,
+            as: ScenarioInstruction.self
         )
     }
 
     public func getPreset(presetID: Int) async throws -> ScenarioInstruction {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/"),
-            as: ScenarioInstruction.self,
+            as: ScenarioInstruction.self
         )
     }
 
@@ -369,20 +369,20 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         let body = try encoder.encode(request)
         return try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/", method: .patch, body: body),
-            as: ScenarioInstruction.self,
+            as: ScenarioInstruction.self
         )
     }
 
     public func deletePreset(presetID: Int) async throws {
         _ = try await apiClient.requestData(
-            Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/", method: .delete),
+            Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/", method: .delete)
         )
     }
 
     public func duplicatePreset(presetID: Int) async throws -> ScenarioInstruction {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/duplicate/", method: .post, body: Data()),
-            as: ScenarioInstruction.self,
+            as: ScenarioInstruction.self
         )
     }
 
@@ -390,14 +390,14 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         let body = try encoder.encode(request)
         return try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/share/", method: .post, body: body),
-            as: ScenarioInstructionPermission.self,
+            as: ScenarioInstructionPermission.self
         )
     }
 
     public func unsharePreset(presetID: Int, request: ScenarioInstructionUnshareRequest) async throws {
         let body = try encoder.encode(request)
         _ = try await apiClient.requestData(
-            Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/unshare/", method: .post, body: body),
+            Endpoint(path: "/api/v1/trainerlab/presets/\(presetID)/unshare/", method: .post, body: body)
         )
     }
 
@@ -408,9 +408,9 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/presets/\(presetID)/apply/",
                 method: .post,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerCommandAck.self,
+            as: TrainerCommandAck.self
         )
     }
 
@@ -432,7 +432,7 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         }
         return try await apiClient.request(
             Endpoint(path: "/api/v1/account/list/", query: queryItems),
-            as: PaginatedResponse<AccountListUser>.self,
+            as: PaginatedResponse<AccountListUser>.self
         )
     }
 
@@ -440,7 +440,7 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
         simulationID: Int,
         problemID: Int,
         request: ProblemStatusUpdateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> ProblemStatusOut {
         let body = try encoder.encode(request)
         return try await apiClient.request(
@@ -448,16 +448,16 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/problems/\(problemID)/",
                 method: .patch,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: ProblemStatusOut.self,
+            as: ProblemStatusOut.self
         )
     }
 
     public func createNoteEvent(
         simulationID: Int,
         request: SimulationNoteCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> TrainerCommandAck {
         let body = try encoder.encode(request)
         return try await apiClient.request(
@@ -465,16 +465,16 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/events/notes/",
                 method: .post,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: TrainerCommandAck.self,
+            as: TrainerCommandAck.self
         )
     }
 
     public func createAnnotation(
         simulationID: Int,
         request: AnnotationCreateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> AnnotationOut {
         let body = try encoder.encode(request)
         return try await apiClient.request(
@@ -482,23 +482,23 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/annotations/",
                 method: .post,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: AnnotationOut.self,
+            as: AnnotationOut.self
         )
     }
 
     public func listAnnotations(simulationID: Int) async throws -> [AnnotationOut] {
         try await apiClient.request(
             Endpoint(path: "/api/v1/trainerlab/simulations/\(simulationID)/annotations/"),
-            as: [AnnotationOut].self,
+            as: [AnnotationOut].self
         )
     }
 
     public func updateScenarioBrief(
         simulationID: Int,
         request: ScenarioBriefUpdateRequest,
-        idempotencyKey: String,
+        idempotencyKey: String
     ) async throws -> ScenarioBriefOut {
         let body = try encoder.encode(request)
         return try await apiClient.request(
@@ -506,16 +506,16 @@ public final class TrainerLabService: TrainerLabServiceProtocol, @unchecked Send
                 path: "/api/v1/trainerlab/simulations/\(simulationID)/scenario-brief/",
                 method: .patch,
                 body: body,
-                idempotencyKey: idempotencyKey,
+                idempotencyKey: idempotencyKey
             ),
-            as: ScenarioBriefOut.self,
+            as: ScenarioBriefOut.self
         )
     }
 
     public func replayPending(endpoint: String, method: String, body: Data?, idempotencyKey: String) async throws {
         let requestMethod = HTTPMethod(rawValue: method.uppercased()) ?? .post
         _ = try await apiClient.requestData(
-            Endpoint(path: endpoint, method: requestMethod, body: body, idempotencyKey: idempotencyKey),
+            Endpoint(path: endpoint, method: requestMethod, body: body, idempotencyKey: idempotencyKey)
         )
     }
 }

--- a/apps/trainerlab-ios/Sources/Realtime/SSETransport.swift
+++ b/apps/trainerlab-ios/Sources/Realtime/SSETransport.swift
@@ -49,7 +49,7 @@ public final class SSETransport: SSETransportProtocol, @unchecked Sendable {
         baseURLProvider: @escaping () -> URL,
         tokenProvider: AuthTokenProvider,
         session: URLSession = .shared,
-        staleThresholdSeconds: TimeInterval = 45,
+        staleThresholdSeconds: TimeInterval = 45
     ) {
         self.baseURLProvider = baseURLProvider
         self.tokenProvider = tokenProvider
@@ -190,7 +190,7 @@ public final class SSETransport: SSETransportProtocol, @unchecked Sendable {
             return try decoder.decode(EventEnvelope.self, from: data)
         } catch {
             logger.error(
-                "Failed to decode trainer SSE event: \(error.localizedDescription, privacy: .public). Payload prefix: \(String(dataString.prefix(256)), privacy: .public)",
+                "Failed to decode trainer SSE event: \(error.localizedDescription, privacy: .public). Payload prefix: \(String(dataString.prefix(256)), privacy: .public)"
             )
             throw error
         }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -67,7 +67,7 @@ public struct RunConsoleView: View {
     public init(
         store: RunSessionStore,
         onBack: @escaping () -> Void,
-        onOpenSummary: @escaping () -> Void,
+        onOpenSummary: @escaping () -> Void
     ) {
         self.store = store
         self.onBack = onBack
@@ -78,11 +78,11 @@ public struct RunConsoleView: View {
         GeometryReader { proxy in
             let layoutMode = RunConsoleLayoutMode.resolve(
                 width: proxy.size.width,
-                horizontalSizeClass: horizontalSizeClass,
+                horizontalSizeClass: horizontalSizeClass
             )
             let compactMetrics = RunConsoleCompactMetrics.resolve(
                 width: proxy.size.width,
-                layoutMode: layoutMode,
+                layoutMode: layoutMode
             )
 
             ZStack {
@@ -125,7 +125,7 @@ public struct RunConsoleView: View {
                 onSubmit: {
                     addTrainerNote()
                     showNoteSheet = false
-                },
+                }
             )
             .presentationDetents([.height(180)])
             .presentationDragIndicator(.visible)
@@ -135,7 +135,7 @@ public struct RunConsoleView: View {
                 store.createDebriefAnnotation(
                     observationText: observationText,
                     learningObjective: learningObjective,
-                    outcome: outcome,
+                    outcome: outcome
                 )
                 showAnnotationSheet = false
             }
@@ -217,7 +217,7 @@ public struct RunConsoleView: View {
 
     private func topVitalsTable(
         layoutMode: RunConsoleLayoutMode,
-        compactMetrics: RunConsoleCompactMetrics,
+        compactMetrics: RunConsoleCompactMetrics
     ) -> some View {
         VStack(alignment: .leading, spacing: layoutMode == .compact ? 6 : 4) {
             Text("Patient Vitals")
@@ -243,7 +243,7 @@ public struct RunConsoleView: View {
             } else {
                 LazyVGrid(
                     columns: compactVitalsColumns(for: compactMetrics),
-                    spacing: compactMetrics.gridSpacing,
+                    spacing: compactMetrics.gridSpacing
                 ) {
                     ForEach(orderedVitals) { vital in
                         compactVitalCell(vital, compactMetrics: compactMetrics)
@@ -254,8 +254,8 @@ public struct RunConsoleView: View {
         .modifier(
             RunConsoleCardModifier(
                 background: TrainerLabTheme.tacticalSurfaceElevated,
-                padding: layoutMode == .compact ? compactMetrics.cardPadding : 8,
-            ),
+                padding: layoutMode == .compact ? compactMetrics.cardPadding : 8
+            )
         )
     }
 
@@ -312,7 +312,7 @@ public struct RunConsoleView: View {
     private func compactCommandPanel(compactMetrics: RunConsoleCompactMetrics) -> some View {
         let controlPresentation = RunConsoleCompactControlPresentation.resolve(
             layoutMode: .compact,
-            horizontalSizeClass: horizontalSizeClass,
+            horizontalSizeClass: horizontalSizeClass
         )
 
         return VStack(alignment: .leading, spacing: compactMetrics.sectionSpacing) {
@@ -324,7 +324,7 @@ public struct RunConsoleView: View {
 
                     LazyVGrid(
                         columns: compactControlColumns(for: compactMetrics),
-                        spacing: compactMetrics.gridSpacing,
+                        spacing: compactMetrics.gridSpacing
                     ) {
                         compactBackAction(compactMetrics: compactMetrics, controlPresentation: controlPresentation)
                             .frame(maxWidth: .infinity)
@@ -333,7 +333,7 @@ public struct RunConsoleView: View {
                                 action,
                                 compact: true,
                                 compactMetrics: compactMetrics,
-                                controlPresentation: controlPresentation,
+                                controlPresentation: controlPresentation
                             )
                             .frame(maxWidth: .infinity)
                         }
@@ -348,7 +348,7 @@ public struct RunConsoleView: View {
 
                 LazyVGrid(
                     columns: compactControlColumns(for: compactMetrics),
-                    spacing: compactMetrics.gridSpacing,
+                    spacing: compactMetrics.gridSpacing
                 ) {
                     compactScenarioAction(
                         "Add Intervention", systemImage: "cross.vial.fill",
@@ -357,43 +357,43 @@ public struct RunConsoleView: View {
                             interventionTargetProblemID = nil
                             showInterventionSheet = true
                         },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                     compactScenarioAction(
                         "Add Event", systemImage: "bolt.heart.fill",
                         compactMetrics: compactMetrics,
                         action: { showEventSheet = true },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                     compactScenarioAction(
                         "Steer AI", systemImage: "wand.and.sparkles",
                         compactMetrics: compactMetrics,
                         action: { showSteerSheet = true },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                     compactScenarioAction(
                         "Add Note", systemImage: "note.text.badge.plus",
                         compactMetrics: compactMetrics,
                         action: { showNoteSheet = true },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                     compactScenarioAction(
                         "Add Annotation", systemImage: "text.badge.plus",
                         compactMetrics: compactMetrics,
                         action: { showAnnotationSheet = true },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                     compactScenarioAction(
                         "Tick AI", systemImage: "timer",
                         compactMetrics: compactMetrics,
                         action: { store.triggerRunTick() },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                     compactScenarioAction(
                         "Tick Vitals", systemImage: "heart.text.square",
                         compactMetrics: compactMetrics,
                         action: { store.triggerVitalsTick() },
-                        controlPresentation: controlPresentation,
+                        controlPresentation: controlPresentation
                     )
                 }
             }
@@ -426,8 +426,8 @@ public struct RunConsoleView: View {
         .modifier(
             RunConsoleCardModifier(
                 background: TrainerLabTheme.tacticalSurfaceElevated,
-                padding: compactMetrics.cardPadding,
-            ),
+                padding: compactMetrics.cardPadding
+            )
         )
     }
 
@@ -465,7 +465,7 @@ public struct RunConsoleView: View {
                     if let problemID = problem.problemID {
                         store.updateProblemStatus(problemID: problemID, status: status)
                     }
-                },
+                }
             )
             .frame(minHeight: 380, maxHeight: .infinity)
 
@@ -1004,7 +1004,7 @@ public struct RunConsoleView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .stroke(TrainerLabTheme.tacticalBorder.opacity(0.6), lineWidth: 1),
+                        .stroke(TrainerLabTheme.tacticalBorder.opacity(0.6), lineWidth: 1)
                 )
                 .opacity(isSuperseded ? 0.65 : 1.0)
             }
@@ -1156,7 +1156,7 @@ public struct RunConsoleView: View {
             .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .stroke(terminalCardColor(card.status).opacity(0.4), lineWidth: 1),
+                    .stroke(terminalCardColor(card.status).opacity(0.4), lineWidth: 1)
             )
             .padding(16)
             .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -1217,7 +1217,7 @@ public struct RunConsoleView: View {
             dictionary: store.interventionDictionary,
             problems: store.state.problemAnnotations,
             prefilledTargetProblemID: interventionTargetProblemID,
-            canMutate: canMutate,
+            canMutate: canMutate
         ) { type, siteCode, targetProblemID, status, effectiveness, notes in
             store.addIntervention(
                 interventionType: type,
@@ -1225,7 +1225,7 @@ public struct RunConsoleView: View {
                 targetProblemID: targetProblemID,
                 status: status,
                 effectiveness: effectiveness,
-                notes: notes,
+                notes: notes
             )
             showInterventionSheet = false
         }
@@ -1235,14 +1235,14 @@ public struct RunConsoleView: View {
         InjuryQuickActionSheet(
             injury: injury,
             dictionary: store.interventionDictionary,
-            canMutate: canMutate,
+            canMutate: canMutate
         ) { type, siteCode, status, effectiveness in
             store.addIntervention(
                 interventionType: type,
                 siteCode: siteCode,
                 targetProblemID: store.state.problemAnnotations.first(where: { $0.causeID == injury.causeID })?.problemID,
                 status: status,
-                effectiveness: effectiveness,
+                effectiveness: effectiveness
             )
         }
     }
@@ -1702,7 +1702,7 @@ public struct RunConsoleView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(selectedAVPU == stateValue ? Color.white : Color.clear, lineWidth: 2),
+                        .stroke(selectedAVPU == stateValue ? Color.white : Color.clear, lineWidth: 2)
                 )
         }
         .buttonStyle(.plain)
@@ -1847,7 +1847,7 @@ public struct RunConsoleView: View {
         _ action: RunConsoleLifecycleAction,
         compact: Bool,
         compactMetrics: RunConsoleCompactMetrics = .standard,
-        controlPresentation: RunConsoleCompactControlPresentation = .labeled,
+        controlPresentation: RunConsoleCompactControlPresentation = .labeled
     ) -> some View {
         quickAction(action.title, systemImage: action.systemImage, enabled: canMutate, compact: compact, compactMetrics: compactMetrics, controlPresentation: controlPresentation) {
             switch action {
@@ -1869,7 +1869,7 @@ public struct RunConsoleView: View {
         _ title: String, systemImage: String,
         compactMetrics: RunConsoleCompactMetrics,
         action: @escaping () -> Void,
-        controlPresentation: RunConsoleCompactControlPresentation,
+        controlPresentation: RunConsoleCompactControlPresentation
     ) -> some View {
         quickAction(title, systemImage: systemImage, enabled: canMutate, compact: true, compactMetrics: compactMetrics, controlPresentation: controlPresentation, action: action)
             .frame(maxWidth: .infinity)
@@ -1880,7 +1880,7 @@ public struct RunConsoleView: View {
         compact: Bool = false,
         compactMetrics: RunConsoleCompactMetrics = .standard,
         controlPresentation: RunConsoleCompactControlPresentation = .labeled,
-        action: @escaping () -> Void,
+        action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
             if compact, controlPresentation == .iconOnly {
@@ -2024,7 +2024,7 @@ private struct InterventionPickerSheet: View {
                                         .foregroundStyle(.secondary)
                                     LazyVGrid(
                                         columns: [GridItem(.adaptive(minimum: 140), spacing: 8)],
-                                        spacing: 8,
+                                        spacing: 8
                                     ) {
                                         ForEach(types) { group in
                                             typeChip(group)
@@ -2063,7 +2063,7 @@ private struct InterventionPickerSheet: View {
                         } else {
                             LazyVGrid(
                                 columns: [GridItem(.adaptive(minimum: 110), spacing: 8)],
-                                spacing: 8,
+                                spacing: 8
                             ) {
                                 ForEach(locationGroups, id: \.location) { entry in
                                     locationChip(entry.location)
@@ -2402,7 +2402,7 @@ private struct RunConsoleCardModifier: ViewModifier {
             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
+                    .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1)
             )
     }
 }
@@ -2427,7 +2427,7 @@ private struct VitalValueCell: View {
         vital: VitalStatusSnapshot,
         valueText: String,
         font: Font = .subheadline.monospacedDigit(),
-        verticalPadding: CGFloat = 6,
+        verticalPadding: CGFloat = 6
     ) {
         self.vital = vital
         self.valueText = valueText
@@ -2463,8 +2463,8 @@ private struct VitalValueCell: View {
                             LinearGradient(
                                 colors: [.clear, Color.white.opacity(0.12), Color.white.opacity(0.35), Color.white.opacity(0.12), .clear],
                                 startPoint: .leading,
-                                endPoint: .trailing,
-                            ),
+                                endPoint: .trailing
+                            )
                         )
                         .frame(width: width)
                         .offset(x: shimmerOffset * proxy.size.width)
@@ -2649,7 +2649,7 @@ private struct DebriefAnnotationSheet: View {
                         onSubmit(
                             observationText.trimmingCharacters(in: .whitespacesAndNewlines),
                             learningObjective,
-                            outcome,
+                            outcome
                         )
                         dismiss()
                     }
@@ -2729,7 +2729,7 @@ private struct ScenarioBriefEditSheet: View {
                             threatContext: threatContext.isEmpty ? nil : threatContext,
                             evacuationOptions: parseList(from: evacuationOptions),
                             evacuationTime: evacuationTime.isEmpty ? nil : evacuationTime,
-                            specialConsiderations: parseList(from: specialConsiderations),
+                            specialConsiderations: parseList(from: specialConsiderations)
                         ))
                     }
                     .disabled(readAloudBrief.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -34,7 +34,7 @@ public final class RunSessionStore: ObservableObject {
     public init(
         service: TrainerLabServiceProtocol,
         realtimeClient: RealtimeClientProtocol,
-        commandQueue: CommandQueueStoreProtocol,
+        commandQueue: CommandQueueStoreProtocol
     ) {
         self.service = service
         self.realtimeClient = realtimeClient
@@ -257,7 +257,7 @@ public final class RunSessionStore: ObservableObject {
                 avpuState: avpu.rawValue,
                 interventionCode: nil,
                 note: "Set AVPU to \(avpu.rawValue)",
-                metadata: [:],
+                metadata: [:]
             )
             let path = "/api/v1/trainerlab/simulations/\(session.simulationID)/adjust/"
             let body = try? JSONEncoder().encode(request)
@@ -277,7 +277,7 @@ public final class RunSessionStore: ObservableObject {
         effectiveness: InterventionEffectiveness = .unknown,
         notes: String = "",
         details: [String: JSONValue]? = nil,
-        supersedesEventID: Int? = nil,
+        supersedesEventID: Int? = nil
     ) {
         guard canMutateCommands else { return }
         guard let targetProblemID else {
@@ -295,7 +295,7 @@ public final class RunSessionStore: ObservableObject {
                 effectiveness: effectiveness,
                 notes: notes,
                 details: details,
-                supersedesEventID: supersedesEventID,
+                supersedesEventID: supersedesEventID
             )
             let path = "/api/v1/trainerlab/simulations/\(simulationID)/events/interventions/"
             let body = try? JSONEncoder().encode(request)
@@ -321,7 +321,7 @@ public final class RunSessionStore: ObservableObject {
                     "site_code": siteCode,
                     "effectiveness": effectiveness.rawValue,
                     "intervention_status": status.rawValue,
-                ],
+                ]
             )
 
             await executeQueuedAckCommand(envelope: envelope) {
@@ -339,7 +339,7 @@ public final class RunSessionStore: ObservableObject {
                 injuryLocation: location,
                 injuryKind: kind,
                 injuryDescription: description,
-                description: description,
+                description: description
             )
             let path = "/api/v1/trainerlab/simulations/\(simulationID)/events/injuries/"
             let body = try? JSONEncoder().encode(request)
@@ -350,7 +350,7 @@ public final class RunSessionStore: ObservableObject {
                 locationCode: location,
                 category: category,
                 kind: kind,
-                summary: description,
+                summary: description
             )
 
             await executeQueuedAckCommand(envelope: envelope) {
@@ -384,7 +384,7 @@ public final class RunSessionStore: ObservableObject {
                 minValue: min,
                 maxValue: max,
                 minDiastolic: nil,
-                maxDiastolic: nil,
+                maxDiastolic: nil
             )
             upsertVital(
                 VitalStatusSnapshot(
@@ -395,8 +395,8 @@ public final class RunSessionStore: ObservableObject {
                     maxValueDiastolic: nil,
                     lockValue: false,
                     currentValue: seeded.primary,
-                    currentDiastolicValue: seeded.secondary,
-                ),
+                    currentDiastolicValue: seeded.secondary
+                )
             )
 
             let request = VitalEventRequest(
@@ -406,7 +406,7 @@ public final class RunSessionStore: ObservableObject {
                 lockValue: false,
                 minValueDiastolic: nil,
                 maxValueDiastolic: nil,
-                supersedesEventID: nil,
+                supersedesEventID: nil
             )
             let path = "/api/v1/trainerlab/simulations/\(simulationID)/events/vitals/"
             let body = try? JSONEncoder().encode(request)
@@ -429,7 +429,7 @@ public final class RunSessionStore: ObservableObject {
             kind: .note,
             title: "Trainer Note",
             message: trimmed,
-            createdAt: Date(),
+            createdAt: Date()
         )
 
         guard canMutateCommands else { return }
@@ -444,7 +444,7 @@ public final class RunSessionStore: ObservableObject {
                 try await self.service.createNoteEvent(
                     simulationID: simulationID,
                     request: request,
-                    idempotencyKey: envelope.idempotencyKey,
+                    idempotencyKey: envelope.idempotencyKey
                 )
             }
         }
@@ -454,7 +454,7 @@ public final class RunSessionStore: ObservableObject {
         observationText: String,
         learningObjective: AnnotationLearningObjective,
         outcome: AnnotationOutcome,
-        linkedEventID: Int? = nil,
+        linkedEventID: Int? = nil
     ) {
         let trimmed = observationText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
@@ -467,14 +467,14 @@ public final class RunSessionStore: ObservableObject {
                 learningObjective: learningObjective,
                 outcome: outcome,
                 linkedEventID: linkedEventID,
-                elapsedSecondsAt: state.stopwatchElapsedSeconds,
+                elapsedSecondsAt: state.stopwatchElapsedSeconds
             )
 
             do {
                 let created = try await service.createAnnotation(
                     simulationID: simulationID,
                     request: request,
-                    idempotencyKey: UUID().uuidString,
+                    idempotencyKey: UUID().uuidString
                 )
                 debriefAnnotations.insert(created, at: 0)
             } catch {
@@ -494,7 +494,7 @@ public final class RunSessionStore: ObservableObject {
             _ = try? await service.steerPrompt(
                 simulationID: simulationID,
                 request: request,
-                idempotencyKey: key,
+                idempotencyKey: key
             )
         }
     }
@@ -508,7 +508,7 @@ public final class RunSessionStore: ObservableObject {
             await executeQueuedAckCommand(envelope: envelope) {
                 try await self.service.triggerRunTick(
                     simulationID: simulationID,
-                    idempotencyKey: envelope.idempotencyKey,
+                    idempotencyKey: envelope.idempotencyKey
                 )
             }
             await loadRuntimeState()
@@ -525,7 +525,7 @@ public final class RunSessionStore: ObservableObject {
             await executeQueuedAckCommand(envelope: envelope) {
                 try await self.service.triggerVitalsTick(
                     simulationID: simulationID,
-                    idempotencyKey: envelope.idempotencyKey,
+                    idempotencyKey: envelope.idempotencyKey
                 )
             }
             await loadRuntimeState()
@@ -552,7 +552,7 @@ public final class RunSessionStore: ObservableObject {
                         endpoint: envelope.endpoint,
                         method: envelope.method,
                         body: data,
-                        idempotencyKey: envelope.idempotencyKey,
+                        idempotencyKey: envelope.idempotencyKey
                     )
                     try await commandQueue.markAcked(idempotencyKey: envelope.idempotencyKey)
                 } catch {
@@ -560,7 +560,7 @@ public final class RunSessionStore: ObservableObject {
                     try await commandQueue.markFailed(
                         idempotencyKey: envelope.idempotencyKey,
                         error: error.localizedDescription,
-                        nextRetryAt: nextRetryAt,
+                        nextRetryAt: nextRetryAt
                     )
                 }
             }
@@ -590,7 +590,7 @@ public final class RunSessionStore: ObservableObject {
 
     private func executeQueuedSessionCommand(
         envelope: PendingCommandEnvelope,
-        run: @escaping @Sendable () async throws -> TrainerSessionDTO,
+        run: @escaping @Sendable () async throws -> TrainerSessionDTO
     ) async {
         do {
             try await commandQueue.enqueue(envelope)
@@ -609,7 +609,7 @@ public final class RunSessionStore: ObservableObject {
 
     private func executeQueuedAckCommand(
         envelope: PendingCommandEnvelope,
-        run: @escaping @Sendable () async throws -> some Sendable,
+        run: @escaping @Sendable () async throws -> some Sendable
     ) async {
         do {
             try await commandQueue.enqueue(envelope)
@@ -633,7 +633,7 @@ public final class RunSessionStore: ObservableObject {
             try await commandQueue.markFailed(
                 idempotencyKey: envelope.idempotencyKey,
                 error: error.localizedDescription,
-                nextRetryAt: nextRetryAt,
+                nextRetryAt: nextRetryAt
             )
             await refreshPendingCount()
         } catch {
@@ -680,14 +680,14 @@ public final class RunSessionStore: ObservableObject {
 
             if let payloadSimulationID = payload.simulationID, payloadSimulationID != session.simulationID {
                 logger.warning(
-                    "Ignoring simulation.state_changed for simulation \(payloadSimulationID, privacy: .public); bound simulation is \(session.simulationID, privacy: .public)",
+                    "Ignoring simulation.state_changed for simulation \(payloadSimulationID, privacy: .public); bound simulation is \(session.simulationID, privacy: .public)"
                 )
                 return
             }
 
             guard payload.status.lowercased() == "failed" else {
                 logger.debug(
-                    "Unhandled simulation.state_changed status \(payload.status, privacy: .public) for simulation \(session.simulationID, privacy: .public)",
+                    "Unhandled simulation.state_changed status \(payload.status, privacy: .public) for simulation \(session.simulationID, privacy: .public)"
                 )
                 return
             }
@@ -707,16 +707,16 @@ public final class RunSessionStore: ObservableObject {
                 modifiedAt: max(session.modifiedAt, event.createdAt),
                 terminalReasonCode: payload.terminalReasonCode ?? session.terminalReasonCode,
                 terminalReasonText: payload.terminalReasonText ?? session.terminalReasonText,
-                retryable: payload.retryable ?? session.retryable,
+                retryable: payload.retryable ?? session.retryable
             )
 
             state = RunSessionReducer.reduce(state: state, action: .sessionLoaded(failedSession))
             logger.warning(
-                "Simulation \(failedSession.simulationID, privacy: .public) transitioned to failed state: \(failedSession.terminalReasonText ?? "Simulation failed.", privacy: .public)",
+                "Simulation \(failedSession.simulationID, privacy: .public) transitioned to failed state: \(failedSession.terminalReasonText ?? "Simulation failed.", privacy: .public)"
             )
         } catch {
             logger.error(
-                "Failed to decode simulation.state_changed payload for simulation \(session.simulationID, privacy: .public): \(error.localizedDescription, privacy: .public)",
+                "Failed to decode simulation.state_changed payload for simulation \(session.simulationID, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
         }
     }
@@ -730,7 +730,7 @@ public final class RunSessionStore: ObservableObject {
                 kind: .lifecycle,
                 title: lifecycleTitle,
                 message: lifecycleMessage(for: eventType),
-                createdAt: event.createdAt,
+                createdAt: event.createdAt
             )
             return
         }
@@ -745,7 +745,7 @@ public final class RunSessionStore: ObservableObject {
                 kind: .cause,
                 title: kindTitle,
                 message: location.map { "\($0): \(summary)" } ?? summary,
-                createdAt: event.createdAt,
+                createdAt: event.createdAt
             )
             return
         }
@@ -762,7 +762,7 @@ public final class RunSessionStore: ObservableObject {
                 title: "Problem",
                 message: message,
                 createdAt: event.createdAt,
-                metadata: ["status": status],
+                metadata: ["status": status]
             )
             return
         }
@@ -779,7 +779,7 @@ public final class RunSessionStore: ObservableObject {
                 title: "Recommendation",
                 message: label,
                 createdAt: event.createdAt,
-                metadata: metadata,
+                metadata: metadata
             )
             return
         }
@@ -793,7 +793,7 @@ public final class RunSessionStore: ObservableObject {
                 kind: .note,
                 title: "Trainer Note",
                 message: content,
-                createdAt: event.createdAt,
+                createdAt: event.createdAt
             )
             return
         }
@@ -835,7 +835,7 @@ public final class RunSessionStore: ObservableObject {
                 title: "Intervention",
                 message: message,
                 createdAt: event.createdAt,
-                metadata: meta,
+                metadata: meta
             )
             return
         }
@@ -849,7 +849,7 @@ public final class RunSessionStore: ObservableObject {
                 kind: .loc,
                 title: "LOC Change",
                 message: "AVPU set to \(stateText.capitalized)",
-                createdAt: event.createdAt,
+                createdAt: event.createdAt
             )
             return
         }
@@ -864,7 +864,7 @@ public final class RunSessionStore: ObservableObject {
                     threatContext: jsonString(event.payload["threat_context"]),
                     evacuationOptions: jsonStringArray(event.payload["evacuation_options"]),
                     evacuationTime: jsonString(event.payload["evacuation_time"]),
-                    specialConsiderations: jsonStringArray(event.payload["special_considerations"]),
+                    specialConsiderations: jsonStringArray(event.payload["special_considerations"])
                 )
                 scenarioBrief = brief
             }
@@ -877,7 +877,7 @@ public final class RunSessionStore: ObservableObject {
         title: String,
         message: String,
         createdAt: Date,
-        metadata: [String: String] = [:],
+        metadata: [String: String] = [:]
     ) {
         if state.clinicalTimelineEntries.contains(where: { $0.dedupeKey == dedupeKey }) {
             return
@@ -890,9 +890,9 @@ public final class RunSessionStore: ObservableObject {
                 title: title,
                 message: message,
                 createdAt: createdAt,
-                metadata: metadata,
+                metadata: metadata
             ),
-            at: 0,
+            at: 0
         )
 
         if state.clinicalTimelineEntries.count > 400 {
@@ -915,7 +915,7 @@ public final class RunSessionStore: ObservableObject {
             title: entry.title,
             message: entry.message,
             createdAt: entry.createdAt,
-            metadata: meta,
+            metadata: meta
         )
     }
 
@@ -946,7 +946,7 @@ public final class RunSessionStore: ObservableObject {
             minValue: minValue,
             maxValue: maxValue,
             minDiastolic: minDiastolic,
-            maxDiastolic: maxDiastolic,
+            maxDiastolic: maxDiastolic
         )
 
         let existing = state.vitals.first(where: { $0.key == vitalType })
@@ -963,7 +963,7 @@ public final class RunSessionStore: ObservableObject {
             currentDiastolicValue: sampled.secondary,
             trend: .flat,
             changeToken: existing?.changeToken ?? 0,
-            lastUpdatedAt: event.createdAt,
+            lastUpdatedAt: event.createdAt
         )
         upsertVital(snapshot)
     }
@@ -998,7 +998,7 @@ public final class RunSessionStore: ObservableObject {
                 minDiastolic: state.vitals[index].minValueDiastolic,
                 maxDiastolic: state.vitals[index].maxValueDiastolic,
                 currentPrimary: oldPrimary,
-                currentSecondary: oldSecondary,
+                currentSecondary: oldSecondary
             )
 
             state.vitals[index].previousValue = oldPrimary
@@ -1009,7 +1009,7 @@ public final class RunSessionStore: ObservableObject {
                 oldPrimary: oldPrimary,
                 oldSecondary: oldSecondary,
                 newPrimary: sampled.primary,
-                newSecondary: sampled.secondary,
+                newSecondary: sampled.secondary
             )
             if sampled.primary != oldPrimary || sampled.secondary != oldSecondary {
                 state.vitals[index].changeToken += 1
@@ -1025,19 +1025,19 @@ public final class RunSessionStore: ObservableObject {
         minDiastolic: Int?,
         maxDiastolic: Int?,
         currentPrimary: Int? = nil,
-        currentSecondary: Int? = nil,
+        currentSecondary: Int? = nil
     ) -> (primary: Int, secondary: Int?) {
         let primary = constrainedRandom(
             low: min(minValue, maxValue),
             high: max(minValue, maxValue),
-            current: currentPrimary,
+            current: currentPrimary
         )
 
         if key == "blood_pressure", let minDiastolic, let maxDiastolic {
             let secondary = constrainedRandom(
                 low: min(minDiastolic, maxDiastolic),
                 high: max(minDiastolic, maxDiastolic),
-                current: currentSecondary,
+                current: currentSecondary
             )
             return (primary, secondary)
         }
@@ -1062,7 +1062,7 @@ public final class RunSessionStore: ObservableObject {
         oldPrimary: Int,
         oldSecondary: Int?,
         newPrimary: Int,
-        newSecondary: Int?,
+        newSecondary: Int?
     ) -> VitalTrendDirection {
         if newPrimary > oldPrimary {
             return .up
@@ -1086,7 +1086,7 @@ public final class RunSessionStore: ObservableObject {
             state.terminalCard = TerminalCard(
                 status: status!,
                 reasonText: state.session?.terminalReasonText,
-                completedAt: state.session?.runCompletedAt,
+                completedAt: state.session?.runCompletedAt
             )
         } else if !isTerminal {
             state.terminalCard = nil
@@ -1146,7 +1146,7 @@ public final class RunSessionStore: ObservableObject {
         guard
             let locationCode = resolvedAnatomicLocationCode(
                 primary: jsonString(event.payload["anatomical_location"]) ?? jsonString(event.payload["injury_location"]),
-                fallback: nil,
+                fallback: nil
             ),
             let zone = injuryZone(for: locationCode)
         else {
@@ -1193,7 +1193,7 @@ public final class RunSessionStore: ObservableObject {
             source: jsonString(event.payload["source"]) ?? jsonString(event.payload["origin"]),
             supersedesEventID: supersedes,
             hiddenAfter: nil,
-            updatedAt: event.createdAt,
+            updatedAt: event.createdAt
         )
 
         upsertInjury(annotation)
@@ -1204,7 +1204,7 @@ public final class RunSessionStore: ObservableObject {
         locationCode: String,
         category: String,
         kind: String,
-        summary: String,
+        summary: String
     ) {
         guard let zone = injuryZone(for: locationCode) else {
             return
@@ -1220,7 +1220,7 @@ public final class RunSessionStore: ObservableObject {
             kind: kind,
             summary: summary,
             status: .pending,
-            updatedAt: Date(),
+            updatedAt: Date()
         )
         upsertInjury(annotation)
     }
@@ -1296,7 +1296,7 @@ public final class RunSessionStore: ObservableObject {
             y: zone.y,
             effectiveness: effectiveness,
             status: status,
-            updatedAt: event.createdAt,
+            updatedAt: event.createdAt
         )
 
         if let idx = state.interventionAnnotations.firstIndex(where: { $0.id == annotation.id }) {
@@ -1332,7 +1332,7 @@ public final class RunSessionStore: ObservableObject {
             primary: jsonString(event.payload["anatomical_location"]) ?? jsonString(event.payload["injury_location"]),
             fallback: jsonInt(event.payload["cause_id"]).flatMap { causeID in
                 state.causeAnnotations.first(where: { $0.causeID == causeID })?.locationCode
-            },
+            }
         )
 
         let zone = locationCode.flatMap { injuryZone(for: $0) }
@@ -1356,7 +1356,7 @@ public final class RunSessionStore: ObservableObject {
             causeKind: jsonString(event.payload["cause_kind"]),
             recommendedInterventionIDs: jsonIntArray(event.payload["recommended_interventions"]),
             adjudicationReason: jsonString(event.payload["adjudication_reason"]),
-            updatedAt: event.createdAt,
+            updatedAt: event.createdAt
         )
 
         if let idx = state.problemAnnotations.firstIndex(where: { $0.id == annotation.id }) {
@@ -1388,7 +1388,7 @@ public final class RunSessionStore: ObservableObject {
             siteCode: jsonString(event.payload["site_code"]),
             siteLabel: jsonString(event.payload["site_label"]),
             warnings: jsonStringArray(event.payload["warnings"]),
-            contraindications: jsonStringArray(event.payload["contraindications"]),
+            contraindications: jsonStringArray(event.payload["contraindications"])
         )
 
         if let idx = state.recommendedInterventions.firstIndex(where: { $0.recommendationID == recommendationID }) {
@@ -1437,7 +1437,7 @@ public final class RunSessionStore: ObservableObject {
             conditionDescription: jsonString(event.payload["condition_description"]) ?? "dry",
             temperatureNormal: jsonBool(event.payload["temperature_normal"]) ?? true,
             temperatureDescription: jsonString(event.payload["temperature_description"]) ?? "warm",
-            updatedAt: event.createdAt,
+            updatedAt: event.createdAt
         )
 
         if let idx = state.pulseAnnotations.firstIndex(where: { $0.location == location }) {
@@ -1456,7 +1456,7 @@ public final class RunSessionStore: ObservableObject {
             guard let simulationID = state.session?.simulationID else { return }
             let request = ProblemStatusUpdateRequest(
                 isTreated: status == .active ? false : true,
-                isResolved: status == .resolved,
+                isResolved: status == .resolved
             )
             let path = "/api/v1/trainerlab/simulations/\(simulationID)/problems/\(problemID)/"
             let body = try? JSONEncoder().encode(request)
@@ -1466,7 +1466,7 @@ public final class RunSessionStore: ObservableObject {
                     simulationID: simulationID,
                     problemID: problemID,
                     request: request,
-                    idempotencyKey: envelope.idempotencyKey,
+                    idempotencyKey: envelope.idempotencyKey
                 )
             }
         }
@@ -1484,7 +1484,7 @@ public final class RunSessionStore: ObservableObject {
                 let updated = try await service.updateScenarioBrief(
                     simulationID: simulationID,
                     request: request,
-                    idempotencyKey: key,
+                    idempotencyKey: key
                 )
                 scenarioBrief = updated
             } catch {
@@ -1528,7 +1528,7 @@ public final class RunSessionStore: ObservableObject {
                 minValue: vitalState.minValue,
                 maxValue: vitalState.maxValue,
                 minDiastolic: vitalState.minValueDiastolic,
-                maxDiastolic: vitalState.maxValueDiastolic,
+                maxDiastolic: vitalState.maxValueDiastolic
             )
             upsertVital(VitalStatusSnapshot(
                 key: vitalState.vitalType,
@@ -1538,7 +1538,7 @@ public final class RunSessionStore: ObservableObject {
                 maxValueDiastolic: vitalState.maxValueDiastolic,
                 lockValue: vitalState.lockValue,
                 currentValue: sampled.primary,
-                currentDiastolicValue: sampled.secondary,
+                currentDiastolicValue: sampled.secondary
             ))
         }
 
@@ -1555,11 +1555,11 @@ public final class RunSessionStore: ObservableObject {
 
     private func makeCauseAnnotation(
         from cause: RuntimeCauseState,
-        fallbackProblem: RuntimeProblemState?,
+        fallbackProblem: RuntimeProblemState?
     ) -> CauseAnnotation? {
         let locationCode = resolvedAnatomicLocationCode(
             primary: cause.anatomicalLocation ?? cause.injuryLocation,
-            fallback: fallbackProblem?.anatomicalLocation,
+            fallback: fallbackProblem?.anatomicalLocation
         )
         guard let locationCode, let zone = injuryZone(for: locationCode) else {
             return nil
@@ -1587,18 +1587,18 @@ public final class RunSessionStore: ObservableObject {
             source: cause.source,
             supersedesEventID: nil,
             hiddenAfter: nil,
-            updatedAt: parseISODate(cause.timestamp) ?? Date(),
+            updatedAt: parseISODate(cause.timestamp) ?? Date()
         )
     }
 
     private func makeProblemAnnotation(
         from problem: RuntimeProblemState,
-        causesByID: [Int: RuntimeCauseState],
+        causesByID: [Int: RuntimeCauseState]
     ) -> ProblemAnnotation {
         let linkedCause = problem.causeID.flatMap { causesByID[$0] }
         let locationCode = resolvedAnatomicLocationCode(
             primary: problem.anatomicalLocation,
-            fallback: linkedCause?.anatomicalLocation ?? linkedCause?.injuryLocation,
+            fallback: linkedCause?.anatomicalLocation ?? linkedCause?.injuryLocation
         )
         let zone = locationCode.flatMap(injuryZone(for:))
         let id = problem.problemID.map(String.init) ?? problem.primaryLabel
@@ -1621,13 +1621,13 @@ public final class RunSessionStore: ObservableObject {
             causeKind: problem.causeKind,
             recommendedInterventionIDs: problem.recommendedInterventionIDs,
             adjudicationReason: problem.adjudicationReason,
-            updatedAt: problem.resolvedAt ?? problem.controlledAt ?? problem.treatedAt ?? Date(),
+            updatedAt: problem.resolvedAt ?? problem.controlledAt ?? problem.treatedAt ?? Date()
         )
     }
 
     private func makeRecommendedInterventionItem(
         from recommendation: RuntimeRecommendedInterventionState,
-        problemsByID: [Int: RuntimeProblemState],
+        problemsByID: [Int: RuntimeProblemState]
     ) -> RecommendedInterventionItem {
         let fallbackTitle = recommendation.primaryLabel
         let linkedProblemTitle = recommendation.targetProblemID
@@ -1650,7 +1650,7 @@ public final class RunSessionStore: ObservableObject {
             siteCode: recommendation.siteCode,
             siteLabel: recommendation.siteLabel,
             warnings: recommendation.warnings,
-            contraindications: recommendation.contraindications,
+            contraindications: recommendation.contraindications
         )
     }
 
@@ -1681,7 +1681,7 @@ public final class RunSessionStore: ObservableObject {
             y: zone.y,
             effectiveness: intervention.effectiveness ?? "unknown",
             status: intervention.status ?? "applied",
-            updatedAt: parseISODate(intervention.timestamp) ?? Date(),
+            updatedAt: parseISODate(intervention.timestamp) ?? Date()
         )
     }
 
@@ -1707,7 +1707,7 @@ public final class RunSessionStore: ObservableObject {
             conditionDescription: pulse.conditionDescription ?? "dry",
             temperatureNormal: pulse.temperatureNormal ?? true,
             temperatureDescription: pulse.temperatureDescription ?? "warm",
-            updatedAt: parseISODate(pulse.timestamp) ?? Date(),
+            updatedAt: parseISODate(pulse.timestamp) ?? Date()
         )
     }
 
@@ -1750,7 +1750,7 @@ public final class RunSessionStore: ObservableObject {
             conditionDescription: jsonString(event.payload["condition_description"]) ?? "dry",
             temperatureNormal: jsonBool(event.payload["temperature_normal"]) ?? true,
             temperatureDescription: jsonString(event.payload["temperature_description"]) ?? "warm",
-            updatedAt: event.createdAt,
+            updatedAt: event.createdAt
         )
     }
 

--- a/apps/trainerlab-ios/Sources/SharedModels/Contracts.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/Contracts.swift
@@ -127,7 +127,7 @@ public struct TrainerSessionDTO: Codable, Equatable, Identifiable, Sendable {
         modifiedAt: Date,
         terminalReasonCode: String? = nil,
         terminalReasonText: String? = nil,
-        retryable: Bool? = nil,
+        retryable: Bool? = nil
     ) {
         self.simulationID = simulationID
         self.status = status
@@ -179,7 +179,7 @@ public struct SimulationStateChangedPayload: Codable, Equatable, Sendable {
         terminalAt: Date? = nil,
         simulationID: Int? = nil,
         terminalReasonCode: String? = nil,
-        terminalReasonText: String? = nil,
+        terminalReasonText: String? = nil
     ) {
         self.status = status
         self.retryable = retryable
@@ -215,7 +215,7 @@ public struct EventEnvelope: Codable, Equatable, Identifiable, Sendable {
         eventType: String,
         createdAt: Date,
         correlationID: String?,
-        payload: [String: JSONValue],
+        payload: [String: JSONValue]
     ) {
         self.eventID = eventID
         self.eventType = eventType
@@ -300,7 +300,7 @@ public struct RunSummary: Codable, Sendable {
         timelineHighlights: [SummaryTimelineEntry],
         commandLog: [SummaryCommandLog],
         aiRationaleNotes: [JSONValue],
-        aiDebrief: RunDebriefOutput? = nil,
+        aiDebrief: RunDebriefOutput? = nil
     ) {
         self.simulationID = simulationID
         self.status = status
@@ -391,7 +391,7 @@ public struct SimulationAdjustRequest: Codable, Sendable {
         avpuState: String?,
         interventionCode: String?,
         note: String?,
-        metadata: [String: JSONValue] = [:],
+        metadata: [String: JSONValue] = [:]
     ) {
         self.target = target
         self.direction = direction
@@ -497,7 +497,7 @@ public struct ScenarioInstructionCreateRequest: Codable, Sendable {
         instructionText: String,
         injuries: [String],
         severity: String,
-        metadata: [String: JSONValue] = [:],
+        metadata: [String: JSONValue] = [:]
     ) {
         self.title = title
         self.description = description
@@ -533,7 +533,7 @@ public struct ScenarioInstructionUpdateRequest: Codable, Sendable {
         injuries: [String]? = nil,
         severity: String? = nil,
         metadata: [String: JSONValue]? = nil,
-        isActive: Bool? = nil,
+        isActive: Bool? = nil
     ) {
         self.title = title
         self.description = description
@@ -569,7 +569,7 @@ public struct ScenarioInstructionShareRequest: Codable, Sendable {
         canEdit: Bool = false,
         canDelete: Bool = false,
         canShare: Bool = false,
-        canDuplicate: Bool = true,
+        canDuplicate: Bool = true
     ) {
         self.userID = userID
         self.canRead = canRead
@@ -699,7 +699,7 @@ public struct ScenarioBriefOut: Codable, Sendable {
         threatContext: String? = nil,
         evacuationOptions: [String] = [],
         evacuationTime: String? = nil,
-        specialConsiderations: [String] = [],
+        specialConsiderations: [String] = []
     ) {
         self.readAloudBrief = readAloudBrief
         self.environment = environment
@@ -760,7 +760,7 @@ public struct RuntimePatientStatus: Codable, Sendable {
         impendingPneumothorax: Bool = false,
         tensionPneumothorax: Bool = false,
         narrative: String = "",
-        teachingFlags: [String] = [],
+        teachingFlags: [String] = []
     ) {
         self.avpu = avpu
         self.respiratoryDistress = respiratoryDistress
@@ -1240,7 +1240,7 @@ public struct TrainerRuntimeSnapshot: Codable, Sendable {
         disposition: RuntimeDispositionState? = nil,
         vitals: [RuntimeVitalState] = [],
         pulses: [RuntimePulseState] = [],
-        patientStatus: RuntimePatientStatus = .init(),
+        patientStatus: RuntimePatientStatus = .init()
     ) {
         self.causes = causes
         self.problems = problems
@@ -1389,7 +1389,7 @@ public struct InjuryEventRequest: Codable, Sendable {
         injuryDescription: String,
         description: String = "",
         metadata: [String: JSONValue]? = nil,
-        supersedesEventID: Int? = nil,
+        supersedesEventID: Int? = nil
     ) {
         self.injuryLocation = injuryLocation
         self.injuryKind = injuryKind
@@ -1423,7 +1423,7 @@ public struct IllnessEventRequest: Codable, Sendable {
         anatomicalLocation: String = "",
         laterality: String = "",
         metadata: [String: JSONValue]? = nil,
-        supersedesEventID: Int? = nil,
+        supersedesEventID: Int? = nil
     ) {
         self.name = name
         self.description = description
@@ -1465,7 +1465,7 @@ public struct InterventionEventRequest: Codable, Sendable {
         details: [String: JSONValue]? = nil,
         initiatedByType: String = "instructor",
         initiatedByID: Int? = nil,
-        supersedesEventID: Int? = nil,
+        supersedesEventID: Int? = nil
     ) {
         self.interventionType = interventionType
         self.siteCode = siteCode
@@ -1512,7 +1512,7 @@ public struct VitalEventRequest: Codable, Sendable {
         lockValue: Bool,
         minValueDiastolic: Int?,
         maxValueDiastolic: Int?,
-        supersedesEventID: Int?,
+        supersedesEventID: Int?
     ) {
         self.vitalType = vitalType
         self.minValue = minValue
@@ -1635,7 +1635,7 @@ public struct ProblemCreateRequest: Codable, Sendable {
         laterality: String = "",
         status: ProblemLifecycleState = .active,
         metadata: [String: JSONValue]? = nil,
-        supersedesEventID: Int? = nil,
+        supersedesEventID: Int? = nil
     ) {
         self.causeKind = causeKind
         self.causeID = causeID
@@ -1854,7 +1854,7 @@ public struct AnnotationCreateRequest: Codable, Sendable {
         learningObjective: AnnotationLearningObjective = .other,
         outcome: AnnotationOutcome = .pending,
         linkedEventID: Int? = nil,
-        elapsedSecondsAt: Int? = nil,
+        elapsedSecondsAt: Int? = nil
     ) {
         self.learningObjective = learningObjective
         self.observationText = observationText
@@ -1960,7 +1960,7 @@ public struct ScenarioBriefUpdateRequest: Codable, Sendable {
         threatContext: String? = nil,
         evacuationOptions: [String]? = nil,
         evacuationTime: String? = nil,
-        specialConsiderations: [String]? = nil,
+        specialConsiderations: [String]? = nil
     ) {
         self.readAloudBrief = readAloudBrief
         self.environment = environment

--- a/apps/trainerlab-ios/Tests/AuthTests/AuthViewModelTests.swift
+++ b/apps/trainerlab-ios/Tests/AuthTests/AuthViewModelTests.swift
@@ -18,7 +18,7 @@ private enum MockError: Error, LocalizedError {
 
 private final class MockAuthService: AuthServiceProtocol, @unchecked Sendable {
     var signInResult: Result<AuthTokens, Error> = .success(
-        AuthTokens(accessToken: "a", refreshToken: "r", expiresIn: 3600, tokenType: "Bearer"),
+        AuthTokens(accessToken: "a", refreshToken: "r", expiresIn: 3600, tokenType: "Bearer")
     )
     var signOutCalled = false
     var hasActiveTokensValue = false

--- a/apps/trainerlab-ios/Tests/NetworkingTests/TrainerLabContractTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/TrainerLabContractTests.swift
@@ -173,7 +173,7 @@ final class TrainerLabContractTests: XCTestCase {
             targetProblemID: 19,
             status: .applied,
             effectiveness: .effective,
-            notes: "Applied high and tight",
+            notes: "Applied high and tight"
         )
         let data = try JSONEncoder().encode(request)
         let object = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
@@ -189,7 +189,7 @@ final class TrainerLabContractTests: XCTestCase {
         let request = SimulationNoteCreateRequest(
             content: "Observe airway",
             sendToAI: true,
-            performedByRole: "instructor",
+            performedByRole: "instructor"
         )
         let data = try JSONEncoder().encode(request)
         let object = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
@@ -212,7 +212,7 @@ final class TrainerLabContractTests: XCTestCase {
         XCTAssertEqual(api.capturedEndpoints.last?.requiresAuth, false)
         XCTAssertEqual(
             try? decodeJSONBody(api.capturedEndpoints.last?.body)?["refresh_token"] as? String,
-            "r",
+            "r"
         )
         XCTAssertTrue(tokenProvider.cleared)
     }
@@ -237,7 +237,7 @@ final class TrainerLabContractTests: XCTestCase {
         }
         XCTAssertEqual(
             api.capturedEndpoints.last?.path,
-            "/api/v1/trainerlab/simulations/7/run/start/",
+            "/api/v1/trainerlab/simulations/7/run/start/"
         )
 
         do {
@@ -251,9 +251,9 @@ final class TrainerLabContractTests: XCTestCase {
                     injuryRegion: nil,
                     avpuState: "alert",
                     interventionCode: nil,
-                    note: nil,
+                    note: nil
                 ),
-                idempotencyKey: "k2",
+                idempotencyKey: "k2"
             )
             XCTFail("Expected intercepted error")
         } catch {
@@ -261,7 +261,7 @@ final class TrainerLabContractTests: XCTestCase {
         }
         XCTAssertEqual(
             api.capturedEndpoints.last?.path,
-            "/api/v1/trainerlab/simulations/7/adjust/",
+            "/api/v1/trainerlab/simulations/7/adjust/"
         )
 
         do {
@@ -272,7 +272,7 @@ final class TrainerLabContractTests: XCTestCase {
         }
         XCTAssertEqual(
             api.capturedEndpoints.last?.path,
-            "/api/v1/trainerlab/simulations/7/events/",
+            "/api/v1/trainerlab/simulations/7/events/"
         )
 
         do {
@@ -280,7 +280,7 @@ final class TrainerLabContractTests: XCTestCase {
                 simulationID: 7,
                 problemID: 3,
                 request: ProblemStatusUpdateRequest(isTreated: true, isResolved: false),
-                idempotencyKey: "k3",
+                idempotencyKey: "k3"
             )
             XCTFail("Expected intercepted error")
         } catch {
@@ -288,7 +288,7 @@ final class TrainerLabContractTests: XCTestCase {
         }
         XCTAssertEqual(
             api.capturedEndpoints.last?.path,
-            "/api/v1/trainerlab/simulations/7/problems/3/",
+            "/api/v1/trainerlab/simulations/7/problems/3/"
         )
 
         do {
@@ -319,7 +319,7 @@ final class TrainerLabContractTests: XCTestCase {
             _ = try await service.createNoteEvent(
                 simulationID: 7,
                 request: SimulationNoteCreateRequest(content: "Observe airway"),
-                idempotencyKey: "k6",
+                idempotencyKey: "k6"
             )
             XCTFail("Expected intercepted error")
         } catch {
@@ -328,7 +328,7 @@ final class TrainerLabContractTests: XCTestCase {
         XCTAssertEqual(api.capturedEndpoints.last?.path, "/api/v1/trainerlab/simulations/7/events/notes/")
         XCTAssertEqual(
             try decodeJSONBody(api.capturedEndpoints.last?.body)?["content"] as? String,
-            "Observe airway",
+            "Observe airway"
         )
     }
 
@@ -368,7 +368,7 @@ final class TrainerLabContractTests: XCTestCase {
               "created_at": "2026-03-12T12:00:00Z",
               "modified_at": "2026-03-12T12:00:00Z"
             }
-            """.utf8,
+            """.utf8
         )
         let service = TrainerLabService(apiClient: api)
 
@@ -474,7 +474,7 @@ final class TrainerLabContractTests: XCTestCase {
                 "triage",
                 "intervention",
                 "other",
-            ],
+            ]
         )
         XCTAssertEqual(
             AnnotationOutcome.allCases.map(\.rawValue),
@@ -484,7 +484,7 @@ final class TrainerLabContractTests: XCTestCase {
                 "missed",
                 "improvised",
                 "pending",
-            ],
+            ]
         )
     }
 
@@ -494,7 +494,7 @@ final class TrainerLabContractTests: XCTestCase {
             learningObjective: .hemorrhageControl,
             outcome: .correct,
             linkedEventID: 99,
-            elapsedSecondsAt: 120,
+            elapsedSecondsAt: 120
         )
         let data = try JSONEncoder().encode(request)
         let object = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
@@ -548,7 +548,7 @@ final class TrainerLabContractTests: XCTestCase {
               ack_state TEXT NOT NULL
             );
             INSERT INTO grdb_migrations(identifier) VALUES ('create_pending_commands');
-            """,
+            """
         )
 
         try execSQL(
@@ -560,7 +560,7 @@ final class TrainerLabContractTests: XCTestCase {
               ('old-adjust', '/api/v1/simulations/77/adjust/', 'POST', NULL, 'h1', '2026-03-12T00:00:00Z', 0, NULL, '2026-03-12T00:00:00Z', 'pending'),
               ('old-session-run', '/api/v1/trainerlab/sessions/55/run/start/', 'POST', NULL, 'h2', '2026-03-12T00:00:00Z', 0, NULL, '2026-03-12T00:00:00Z', 'pending'),
               ('old-sessions-root', '/api/v1/trainerlab/sessions/', 'POST', NULL, 'h3', '2026-03-12T00:00:00Z', 0, NULL, '2026-03-12T00:00:00Z', 'pending');
-            """,
+            """
         )
     }
 
@@ -573,7 +573,7 @@ final class TrainerLabContractTests: XCTestCase {
             throw NSError(
                 domain: "TrainerLabContractTests",
                 code: Int(result),
-                userInfo: [NSLocalizedDescriptionKey: message],
+                userInfo: [NSLocalizedDescriptionKey: message]
             )
         }
     }

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -227,7 +227,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: realtime,
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(status: .seeded))
         store.startConsole()
@@ -238,7 +238,7 @@ final class RunSessionStoreTests: XCTestCase {
             eventType: "trainerlab.adjustment.applied",
             createdAt: Date(),
             correlationID: "corr-1",
-            payload: ["target": .string("avpu")],
+            payload: ["target": .string("avpu")]
         )
 
         realtime.emit(event: event)
@@ -258,7 +258,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: realtime,
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(status: .running))
         store.startConsole()
@@ -273,7 +273,7 @@ final class RunSessionStoreTests: XCTestCase {
                 "vital_type": .string("heart_rate"),
                 "min_value": .number(80),
                 "max_value": .number(140),
-            ],
+            ]
         ))
 
         await waitUntil(timeout: 1.5) {
@@ -288,7 +288,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: realtime,
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(status: .seeded))
         store.startConsole()
@@ -299,7 +299,7 @@ final class RunSessionStoreTests: XCTestCase {
             eventType: "run.started",
             createdAt: Date(),
             correlationID: nil,
-            payload: [:],
+            payload: [:]
         ))
 
         await waitUntil(timeout: 1.5) {
@@ -317,7 +317,7 @@ final class RunSessionStoreTests: XCTestCase {
             eventType: "run.paused",
             createdAt: Date(),
             correlationID: nil,
-            payload: [:],
+            payload: [:]
         ))
 
         await waitUntil(timeout: 1.5) {
@@ -333,7 +333,7 @@ final class RunSessionStoreTests: XCTestCase {
             eventType: "trainerlab.run.resumed",
             createdAt: Date(),
             correlationID: nil,
-            payload: [:],
+            payload: [:]
         ))
 
         await waitUntil(timeout: 1.5) {
@@ -352,7 +352,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: realtime,
-            commandQueue: queue,
+            commandQueue: queue
         )
         store.bind(session: makeSession(status: .running))
         store.startConsole()
@@ -376,7 +376,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: MockRealtimeClient(),
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
 
         store.addTrainerNote("Patient became more agitated after intervention.")
@@ -386,7 +386,7 @@ final class RunSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.state.clinicalTimelineEntries.first?.kind, .note)
         XCTAssertEqual(
             store.state.clinicalTimelineEntries.first?.message,
-            "Patient became more agitated after intervention.",
+            "Patient became more agitated after intervention."
         )
     }
 
@@ -395,7 +395,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: realtime,
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(status: .running, runStartedAt: Date().addingTimeInterval(-12)))
         store.startConsole()
@@ -412,8 +412,8 @@ final class RunSessionStoreTests: XCTestCase {
                 terminalAt: Date(),
                 simulationID: 420,
                 terminalReasonCode: "trainerlab_initial_generation_enqueue_failed",
-                terminalReasonText: "We could not start this simulation. Please try again.",
-            ),
+                terminalReasonText: "We could not start this simulation. Please try again."
+            )
         ))
 
         await waitUntil(timeout: 1.5) {
@@ -432,7 +432,7 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: MockTrainerLabService(),
             realtimeClient: realtime,
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(status: .running, runStartedAt: Date().addingTimeInterval(-6)))
         store.startConsole()
@@ -445,8 +445,8 @@ final class RunSessionStoreTests: XCTestCase {
                 terminalAt: Date(),
                 simulationID: 999,
                 terminalReasonCode: "trainerlab_initial_generation_enqueue_failed",
-                terminalReasonText: "Should be ignored.",
-            ),
+                terminalReasonText: "Should be ignored."
+            )
         ))
 
         try? await Task.sleep(nanoseconds: 150_000_000)
@@ -460,14 +460,14 @@ final class RunSessionStoreTests: XCTestCase {
         let store = RunSessionStore(
             service: service,
             realtimeClient: MockRealtimeClient(),
-            commandQueue: InMemoryCommandQueueStore(),
+            commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(
             status: .failed,
             runCompletedAt: Date(),
             terminalReasonCode: "trainerlab_initial_generation_enqueue_failed",
             terminalReasonText: "We could not start this simulation. Please try again.",
-            retryable: true,
+            retryable: true
         ))
 
         XCTAssertEqual(store.state.terminalCard?.status, .failed)
@@ -488,7 +488,7 @@ final class RunSessionStoreTests: XCTestCase {
         runCompletedAt: Date? = nil,
         terminalReasonCode: String? = nil,
         terminalReasonText: String? = nil,
-        retryable: Bool? = nil,
+        retryable: Bool? = nil
     ) -> TrainerSessionDTO {
         TrainerSessionDTO(
             simulationID: 420,
@@ -505,12 +505,12 @@ final class RunSessionStoreTests: XCTestCase {
             modifiedAt: Date(),
             terminalReasonCode: terminalReasonCode,
             terminalReasonText: terminalReasonText,
-            retryable: retryable,
+            retryable: retryable
         )
     }
 
     private func makeSimulationStateChangedEvent(
-        payload: SimulationStateChangedPayload,
+        payload: SimulationStateChangedPayload
     ) -> EventEnvelope {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -538,13 +538,13 @@ final class RunSessionStoreTests: XCTestCase {
             eventType: "simulation.state_changed",
             createdAt: terminalAt,
             correlationID: nil,
-            payload: eventPayload,
+            payload: eventPayload
         )
     }
 
     private func waitUntil(
         timeout: TimeInterval,
-        condition: @escaping @MainActor () -> Bool,
+        condition: @escaping @MainActor () -> Bool
     ) async {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {


### PR DESCRIPTION
## Summary
- handle `simulation.state_changed` payloads in TrainerLab by decoding the nested payload and transitioning the bound session to `.failed`
- surface terminal failure details in the run console, including fallback messaging, failed timestamps, and a retry action for retryable startup failures
- add a retry service call, refresh Session Hub after leaving Run Console, and log SSE decode failures plus ignored/malformed lifecycle events
- add regression tests for event decoding, failed-state propagation, mismatched simulation IDs, and retry flow rebind behavior

## Testing
- `swift test --package-path apps/trainerlab-ios --filter RunSessionStoreTests`
- `swift test --package-path apps/trainerlab-ios --filter TrainerLabContractTests`
- `swiftformat` on touched MedSim iOS Swift files
- `swiftlint lint` on touched MedSim iOS Swift files