### PR TITLE
Fix TrainerLab runtime state hydration and timeline updates

### DIFF
--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -60,7 +60,7 @@ enum RunConsoleTimelinePresentation {
         case .lifecycle:
             entry.title
         case .note:
-            "Trainer Note"
+            entry.title
         case .vitals:
             entry.title
         }
@@ -194,7 +194,7 @@ enum RunConsoleTimelineFilter: Hashable, CaseIterable, Identifiable {
     case kind(ClinicalTimelineKind)
 
     static var allCases: [RunConsoleTimelineFilter] {
-        [.all, .kind(.lifecycle), .kind(.cause), .kind(.problem), .kind(.recommendation), .kind(.intervention), .kind(.loc), .kind(.vitals)]
+        [.all, .kind(.lifecycle), .kind(.cause), .kind(.problem), .kind(.recommendation), .kind(.intervention), .kind(.loc), .kind(.vitals), .kind(.note)]
     }
 
     var id: String {
@@ -237,12 +237,11 @@ enum RunConsoleTimelineFilter: Hashable, CaseIterable, Identifiable {
         from entries: [ClinicalTimelineEntry],
         matching filter: RunConsoleTimelineFilter
     ) -> [ClinicalTimelineEntry] {
-        let visibleEntries = entries.filter { $0.kind != .note }
         return switch filter {
         case .all:
-            visibleEntries
+            entries
         case let .kind(kind):
-            visibleEntries.filter { $0.kind == kind }
+            entries.filter { $0.kind == kind }
         }
     }
 }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -133,7 +133,6 @@ public struct RunConsoleView: View {
         }
         .task {
             store.startConsole()
-            await store.loadRuntimeState()
             await store.loadControlPlaneDebug()
         }
         .onDisappear {
@@ -518,22 +517,25 @@ public struct RunConsoleView: View {
         }
     }
 
-    // MARK: - Combined Info Panel (Scenario Brief + AI Instructor)
+    // MARK: - Combined Info Panel (Scenario Brief + Patient Status + AI Instructor)
 
-    private enum ActiveInfoPanel: Equatable { case scenarioBrief, aiInstructor, annotations }
+    private enum ActiveInfoPanel: Equatable { case scenarioBrief, patientStatus, aiInstructor, annotations }
 
     private var combinedInfoPanel: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Segmented pill + collapse button
             HStack(spacing: 8) {
-                HStack(spacing: 0) {
-                    infoPanelSegment(.scenarioBrief, label: "Scenario Brief")
-                    infoPanelSegment(.aiInstructor, label: "AI Instructor")
-                    infoPanelSegment(.annotations, label: "Annotations")
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 0) {
+                        infoPanelSegment(.scenarioBrief, label: "Scenario Brief")
+                        infoPanelSegment(.patientStatus, label: "Patient Status")
+                        infoPanelSegment(.aiInstructor, label: "AI Instructor")
+                        infoPanelSegment(.annotations, label: "Annotations")
+                    }
+                    .background(Color.white.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.white.opacity(0.1), lineWidth: 1))
                 }
-                .background(Color.white.opacity(0.06))
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(RoundedRectangle(cornerRadius: 10).strokeBorder(Color.white.opacity(0.1), lineWidth: 1))
 
                 if activeInfoPanel != nil {
                     Button {
@@ -557,6 +559,8 @@ public struct RunConsoleView: View {
 
                 if activeInfoPanel == .scenarioBrief {
                     scenarioBriefContent
+                } else if activeInfoPanel == .patientStatus {
+                    patientStatusContent
                 } else if activeInfoPanel == .aiInstructor {
                     aiInstructorContent
                 } else if activeInfoPanel == .annotations {
@@ -591,7 +595,7 @@ public struct RunConsoleView: View {
                 Text(label)
                     .font(.subheadline.weight(isActive ? .semibold : .regular))
                     .frame(maxWidth: .infinity)
-                if isLoadingRuntimeState, panel == .aiInstructor {
+                if isLoadingRuntimeState, panel != .annotations {
                     ProgressView().controlSize(.mini)
                 }
             }
@@ -658,6 +662,87 @@ public struct RunConsoleView: View {
             Text("No scenario brief available.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder private var patientStatusContent: some View {
+        if isSeedingSession {
+            sessionLoadingMessage(
+                title: "Seeding scenario...",
+                message: "Patient status and clinical findings will populate when the initial runtime snapshot is ready."
+            )
+        } else if isLoadingRuntimeState, store.runtimeState == nil {
+            ProgressView()
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+        } else {
+            let status = store.patientStatus
+            let hasStatusContent = !(status.narrative.isEmpty
+                && status.teachingFlags.isEmpty
+                && status.avpu == nil
+                && !status.respiratoryDistress
+                && !status.hemodynamicInstability
+                && !status.impendingPneumothorax
+                && !status.tensionPneumothorax
+                && store.assessmentFindings.isEmpty
+                && store.diagnosticResults.isEmpty
+                && store.resources.isEmpty
+                && store.disposition == nil)
+
+            if hasStatusContent {
+                VStack(alignment: .leading, spacing: 10) {
+                    if let avpu = status.avpu, !avpu.isEmpty {
+                        briefRow(label: "AVPU", value: avpu.uppercased())
+                    }
+                    if !status.narrative.isEmpty {
+                        Text(status.narrative)
+                            .font(.subheadline)
+                    }
+
+                    let alertRows = patientAlertRows(status)
+                    if !alertRows.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Flags")
+                                .font(.caption.bold())
+                                .foregroundStyle(.secondary)
+                            ForEach(alertRows, id: \.label) { row in
+                                patientStatusBadge(label: row.label, color: row.color)
+                            }
+                        }
+                    }
+
+                    if !status.teachingFlags.isEmpty {
+                        statusListSection(title: "Teaching Flags", values: status.teachingFlags)
+                    }
+                    if !store.assessmentFindings.isEmpty {
+                        statusListSection(
+                            title: "Assessment Findings",
+                            values: store.assessmentFindings.compactMap(runtimeDisplayText)
+                        )
+                    }
+                    if !store.diagnosticResults.isEmpty {
+                        statusListSection(
+                            title: "Diagnostic Results",
+                            values: store.diagnosticResults.compactMap(runtimeDisplayText)
+                        )
+                    }
+                    if !store.resources.isEmpty {
+                        statusListSection(
+                            title: "Resources",
+                            values: store.resources.compactMap(runtimeDisplayText)
+                        )
+                    }
+                    if let disposition = store.disposition,
+                       let dispositionSummary = runtimeDisplayText(disposition)
+                    {
+                        statusListSection(title: "Disposition", values: [dispositionSummary])
+                    }
+                }
+            } else {
+                Text("No patient status available.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -949,6 +1034,109 @@ public struct RunConsoleView: View {
         }
     }
 
+    private func patientStatusBadge(label: String, color: Color) -> some View {
+        Text(label)
+            .font(.caption2.bold())
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(color.opacity(0.14))
+            .clipShape(Capsule())
+    }
+
+    private func statusListSection(title: String, values: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+            ForEach(Array(values.enumerated()), id: \.offset) { item in
+                Text("• \(item.element)")
+                    .font(.caption)
+                    .foregroundStyle(Color(white: 0.70))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func patientAlertRows(_ status: RuntimePatientStatus) -> [(label: String, color: Color)] {
+        var rows: [(label: String, color: Color)] = []
+        if status.respiratoryDistress {
+            rows.append(("Respiratory Distress", TrainerLabTheme.warning))
+        }
+        if status.hemodynamicInstability {
+            rows.append(("Hemodynamic Instability", TrainerLabTheme.danger))
+        }
+        if status.impendingPneumothorax {
+            rows.append(("Impending Pneumothorax", TrainerLabTheme.warning))
+        }
+        if status.tensionPneumothorax {
+            rows.append(("Tension Pneumothorax", TrainerLabTheme.danger))
+        }
+        return rows
+    }
+
+    private func runtimeDisplayText(_ finding: RuntimeAssessmentFindingState) -> String? {
+        runtimeDisplayText(
+            title: finding.title,
+            code: finding.code ?? finding.kind,
+            description: finding.description,
+            status: finding.status
+        )
+    }
+
+    private func runtimeDisplayText(_ result: RuntimeDiagnosticResultState) -> String? {
+        runtimeDisplayText(
+            title: result.title,
+            code: result.code ?? result.kind,
+            description: result.description,
+            status: result.status
+        )
+    }
+
+    private func runtimeDisplayText(_ resource: RuntimeResourceState) -> String? {
+        runtimeDisplayText(
+            title: resource.title,
+            code: resource.code ?? resource.kind,
+            description: resource.description,
+            status: resource.status
+        )
+    }
+
+    private func runtimeDisplayText(_ disposition: RuntimeDispositionState) -> String? {
+        runtimeDisplayText(
+            title: disposition.title,
+            code: disposition.code,
+            description: nil,
+            status: disposition.status
+        )
+    }
+
+    private func runtimeDisplayText(
+        title: String?,
+        code: String?,
+        description: String?,
+        status: String?
+    ) -> String? {
+        let candidates: [String?] = [
+            title,
+            code?.replacingOccurrences(of: "_", with: " ").capitalized,
+            description,
+        ]
+        let primary = candidates
+            .compactMap { (value: String?) -> String? in
+                guard let value else { return nil }
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            .first
+
+        guard let primary else { return nil }
+        if let status, !status.isEmpty {
+            return "\(primary) (\(status.replacingOccurrences(of: "_", with: " ").capitalized))"
+        }
+        return primary
+    }
+
     private func fetchRuntimeState() async {
         isLoadingRuntimeState = true
         await store.loadRuntimeState()
@@ -958,7 +1146,7 @@ public struct RunConsoleView: View {
 
     private func fetchInfoPanelData(for panel: ActiveInfoPanel) async {
         switch panel {
-        case .scenarioBrief, .aiInstructor:
+        case .scenarioBrief, .patientStatus, .aiInstructor:
             await fetchRuntimeState()
         case .annotations:
             await store.loadAnnotations()

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionReducer.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionReducer.swift
@@ -24,8 +24,8 @@ public enum RunSessionReducer {
         case let .eventReceived(event):
             next.timeline.append(event)
             next.eventCursor = event.eventID
-            if next.timeline.count > 300 {
-                next.timeline.removeFirst(next.timeline.count - 300)
+            if next.timeline.count > 400 {
+                next.timeline.removeFirst(next.timeline.count - 400)
             }
             let eventType = canonicalEventType(event.eventType)
             if eventType.hasPrefix("run."), let session = next.session {

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -25,12 +25,19 @@ public final class RunSessionStore: ObservableObject {
     @Published public private(set) var diagnosticResults: [RuntimeDiagnosticResultState] = []
     @Published public private(set) var resources: [RuntimeResourceState] = []
     @Published public private(set) var disposition: RuntimeDispositionState?
+    @Published public private(set) var patientStatus: RuntimePatientStatus = .init()
 
     private var eventTask: Task<Void, Never>?
     private var transportTask: Task<Void, Never>?
     private var vitalsTask: Task<Void, Never>?
     private var stopwatchTask: Task<Void, Never>?
+    private var bootstrapTask: Task<Void, Never>?
+    private var runtimeRefreshTask: Task<Void, Never>?
     private var lastAppliedLifecycleRevision: Int?
+    private var pendingRuntimeRefresh = false
+
+    private let runtimeRefreshDebounceNanoseconds: UInt64 = 150_000_000
+    private let maxTimelineEvents = 400
 
     private struct SessionLifecycleSnapshot {
         let status: TrainerSessionStatus
@@ -42,6 +49,12 @@ public final class RunSessionStore: ObservableObject {
         let terminalReasonCode: String?
         let terminalReasonText: String?
         let retryable: Bool?
+    }
+
+    private struct EventHandlingOutcome {
+        let shouldRehydrateSeededSession: Bool
+        let shouldRefreshRuntimeState: Bool
+        let canonicalEventType: String
     }
 
     public init(
@@ -69,34 +82,20 @@ public final class RunSessionStore: ObservableObject {
         transportTask?.cancel()
         vitalsTask?.cancel()
         stopwatchTask?.cancel()
+        bootstrapTask?.cancel()
+        runtimeRefreshTask?.cancel()
+        pendingRuntimeRefresh = false
 
         eventTask = Task { [weak self] in
             guard let self else { return }
             for await event in realtimeClient.events {
-                let shouldRehydrateSeededSession = await MainActor.run {
-                    let previousStatus = self.state.session?.status
-                    self.state = RunSessionReducer.reduce(state: self.state, action: .eventReceived(event))
-                    self.handleSimulationStateChanged(event)
-                    self.captureVitalRange(from: event)
-                    self.captureInjuryAnnotation(from: event)
-                    self.captureInterventionAnnotation(from: event)
-                    self.captureProblemAnnotation(from: event)
-                    self.captureRecommendedIntervention(from: event)
-                    self.capturePulseAnnotation(from: event)
-                    self.captureClinicalTimelineEntry(from: event)
-                    let shouldRehydrate = self.handleSessionLifecycleEvent(event)
-                    self.syncStopwatchState(previousStatus: previousStatus)
-                    return shouldRehydrate
+                let outcome = await self.handleIncomingEvent(event)
+                if outcome.shouldRehydrateSeededSession {
+                    await self.refreshSession()
+                    await self.loadAnnotations()
                 }
-                if shouldRefreshRuntimeProjection(for: event) {
-                    await loadRuntimeState()
-                    await reconcileAnnotationsFromSnapshot()
-                }
-                if shouldRehydrateSeededSession {
-                    await refreshSession()
-                    await loadRuntimeState()
-                    await reconcileAnnotationsFromSnapshot()
-                    await loadAnnotations()
+                if outcome.shouldRefreshRuntimeState {
+                    await self.scheduleRuntimeRefresh(reason: "event \(outcome.canonicalEventType)")
                 }
             }
         }
@@ -105,6 +104,9 @@ public final class RunSessionStore: ObservableObject {
             guard let self else { return }
             for await transport in realtimeClient.transportStates {
                 await MainActor.run {
+                    logger.info(
+                        "Realtime transport for simulation \(self.state.session?.simulationID ?? -1, privacy: .public) -> \(self.transportDescription(transport), privacy: .public)"
+                    )
                     self.state = RunSessionReducer.reduce(state: self.state, action: .transportChanged(transport))
                     self.syncTransportPresentation(for: transport)
                 }
@@ -132,13 +134,9 @@ public final class RunSessionStore: ObservableObject {
             }
         }
 
-        Task {
-            await realtimeClient.connect(simulationID: session.simulationID, cursor: state.eventCursor)
-            await loadRuntimeState()
-            await loadAnnotations()
-            await reconcileAnnotationsFromSnapshot()
-            await replayPendingCommands()
-            await refreshPendingCount()
+        bootstrapTask = Task { [weak self] in
+            guard let self else { return }
+            await self.bootstrapConsole(for: session)
         }
 
         loadInterventionDictionary()
@@ -149,6 +147,9 @@ public final class RunSessionStore: ObservableObject {
         transportTask?.cancel()
         vitalsTask?.cancel()
         stopwatchTask?.cancel()
+        bootstrapTask?.cancel()
+        runtimeRefreshTask?.cancel()
+        pendingRuntimeRefresh = false
         realtimeClient.disconnect()
     }
 
@@ -177,18 +178,22 @@ public final class RunSessionStore: ObservableObject {
     }
 
     /// Loads the runtime state (scenario brief, AI plan, rationale notes) on demand.
-    public func loadRuntimeState() async {
-        guard let simulationID = state.session?.simulationID else { return }
+    @discardableResult
+    public func loadRuntimeState(reason: String = "manual") async -> TrainerRuntimeStateOut? {
+        guard let simulationID = state.session?.simulationID else { return nil }
+        logger.info("Fetching runtime state for simulation \(simulationID, privacy: .public) (\(reason, privacy: .public))")
         do {
             let rs = try await service.getRuntimeState(simulationID: simulationID)
-            runtimeState = rs
-            noteLifecycleRevision(rs.stateRevision)
-            hydrateHiddenClinicalState(from: rs.currentSnapshot)
-            if let brief = rs.scenarioBrief {
-                scenarioBrief = brief
-            }
+            logger.info(
+                "Fetched runtime state for simulation \(simulationID, privacy: .public): revision=\(rs.stateRevision, privacy: .public) status=\(rs.status, privacy: .public)"
+            )
+            applyRuntimeState(rs, source: reason)
+            return rs
         } catch {
-            // Non-critical; caller handles nil runtimeState
+            logger.error(
+                "Runtime state fetch failed for simulation \(simulationID, privacy: .public) (\(reason, privacy: .public)): \(error.localizedDescription, privacy: .public)"
+            )
+            return nil
         }
     }
 
@@ -209,6 +214,136 @@ public final class RunSessionStore: ObservableObject {
         } catch {
             // Optional UI; keep current list if fetch fails.
         }
+    }
+
+    private func bootstrapConsole(for session: TrainerSessionDTO) async {
+        logger.info("Bootstrapping TrainerLab console for simulation \(session.simulationID, privacy: .public)")
+
+        _ = await loadRuntimeState(reason: "bootstrap")
+
+        let historicalEvents = await loadHistoricalEvents(simulationID: session.simulationID)
+        applyHistoricalEvents(historicalEvents)
+
+        logger.info(
+            "Connecting realtime stream for simulation \(session.simulationID, privacy: .public) from cursor \(self.state.eventCursor ?? "nil", privacy: .public)"
+        )
+        await realtimeClient.connect(simulationID: session.simulationID, cursor: self.state.eventCursor)
+        await loadAnnotations()
+        await replayPendingCommands()
+        await refreshPendingCount()
+    }
+
+    private func loadHistoricalEvents(simulationID: Int) async -> [EventEnvelope] {
+        var events: [EventEnvelope] = []
+        var cursor: String?
+        var seenCursors = Set<String>()
+
+        while !Task.isCancelled {
+            do {
+                let page = try await service.listEvents(simulationID: simulationID, cursor: cursor, limit: maxTimelineEvents)
+                logger.info(
+                    "Fetched \(page.items.count, privacy: .public) historical events for simulation \(simulationID, privacy: .public) cursor \(cursor ?? "nil", privacy: .public)"
+                )
+                events.append(contentsOf: page.items)
+
+                guard page.hasMore else { break }
+                guard let nextCursor = page.nextCursor else {
+                    logger.warning(
+                        "Historical events for simulation \(simulationID, privacy: .public) reported more pages without a next cursor"
+                    )
+                    break
+                }
+                guard seenCursors.insert(nextCursor).inserted else {
+                    logger.warning(
+                        "Stopping historical events pagination for simulation \(simulationID, privacy: .public) because cursor \(nextCursor, privacy: .public) repeated"
+                    )
+                    break
+                }
+                cursor = nextCursor
+            } catch {
+                logger.error(
+                    "Historical events fetch failed for simulation \(simulationID, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+                break
+            }
+        }
+
+        return normalizedEvents(events)
+    }
+
+    private func applyHistoricalEvents(_ events: [EventEnvelope]) {
+        guard !events.isEmpty else {
+            logger.info("No historical events found for simulation \(self.state.session?.simulationID ?? -1, privacy: .public)")
+            normalizeStoredTimelineEvents()
+            return
+        }
+
+        state.timeline = normalizedEvents(state.timeline + events)
+        state.eventCursor = state.timeline.last?.eventID
+        rebuildClinicalTimelineEntries(from: state.timeline)
+        logger.info(
+            "Applied \(self.state.timeline.count, privacy: .public) historical events for simulation \(self.state.session?.simulationID ?? -1, privacy: .public)"
+        )
+    }
+
+    private func normalizeStoredTimelineEvents() {
+        state.timeline = normalizedEvents(state.timeline)
+        state.eventCursor = state.timeline.last?.eventID
+    }
+
+    private func normalizedEvents(_ events: [EventEnvelope]) -> [EventEnvelope] {
+        let sorted = events.sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt < rhs.createdAt
+            }
+            return lhs.eventID < rhs.eventID
+        }
+
+        var seenEventIDs = Set<String>()
+        var deduped: [EventEnvelope] = []
+        deduped.reserveCapacity(sorted.count)
+        for event in sorted where seenEventIDs.insert(event.eventID).inserted {
+            deduped.append(event)
+        }
+
+        if deduped.count > maxTimelineEvents {
+            deduped.removeFirst(deduped.count - maxTimelineEvents)
+        }
+        return deduped
+    }
+
+    private func rebuildClinicalTimelineEntries(from events: [EventEnvelope]) {
+        state.clinicalTimelineEntries = []
+        for event in events {
+            captureClinicalTimelineEntry(from: event)
+        }
+        state.clinicalTimelineEntries.sort { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt > rhs.createdAt
+            }
+            return lhs.dedupeKey > rhs.dedupeKey
+        }
+    }
+
+    private func handleIncomingEvent(_ event: EventEnvelope) async -> EventHandlingOutcome {
+        let eventType = canonicalEventType(event.eventType)
+        logger.info(
+            "Received runtime event \(eventType, privacy: .public) id=\(event.eventID, privacy: .public)"
+        )
+
+        state = RunSessionReducer.reduce(state: state, action: .eventReceived(event))
+        normalizeStoredTimelineEvents()
+
+        handleSimulationStateChanged(event)
+        let shouldRehydrateSeededSession = handleSessionLifecycleEvent(event)
+        captureClinicalTimelineEntry(from: event)
+        syncStopwatchState()
+
+        return EventHandlingOutcome(
+            shouldRehydrateSeededSession: shouldRehydrateSeededSession,
+            shouldRefreshRuntimeState: shouldRefreshRuntimeProjection(for: event),
+            canonicalEventType: eventType
+        )
     }
 
     public func refreshSession() async {
@@ -237,8 +372,7 @@ public final class RunSessionStore: ObservableObject {
                 state = RunSessionReducer.reduce(state: state, action: .sessionLoaded(updated))
                 state = RunSessionReducer.reduce(state: state, action: .clearConflict)
                 syncStopwatchState(previousStatus: previousStatus)
-                await loadRuntimeState()
-                await reconcileAnnotationsFromSnapshot()
+                _ = await loadRuntimeState(reason: "retry initial simulation")
             } catch {
                 state.conflictBanner = error.localizedDescription
             }
@@ -705,6 +839,42 @@ public final class RunSessionStore: ObservableObject {
         }
     }
 
+    private func scheduleRuntimeRefresh(reason: String) async {
+        pendingRuntimeRefresh = true
+        logger.debug("Queued authoritative runtime refresh (\(reason, privacy: .public))")
+        guard runtimeRefreshTask == nil else { return }
+        runtimeRefreshTask = Task { [weak self] in
+            guard let self else { return }
+            await self.flushScheduledRuntimeRefreshes()
+        }
+    }
+
+    private func flushScheduledRuntimeRefreshes() async {
+        defer { runtimeRefreshTask = nil }
+
+        while pendingRuntimeRefresh, !Task.isCancelled {
+            try? await Task.sleep(nanoseconds: runtimeRefreshDebounceNanoseconds)
+            guard !Task.isCancelled else { return }
+            pendingRuntimeRefresh = false
+            _ = await loadRuntimeState(reason: "coalesced live refresh")
+        }
+    }
+
+    private func transportDescription(_ transport: RealtimeTransportState) -> String {
+        switch transport {
+        case .connectedSSE:
+            return "connected_sse"
+        case .polling:
+            return "polling"
+        case let .reconnecting(attempt):
+            return "reconnecting_\(attempt)"
+        case .connecting:
+            return "connecting"
+        case .disconnected:
+            return "disconnected"
+        }
+    }
+
     private func syncTransportPresentation(for transport: RealtimeTransportState) {
         switch transport {
         case .connectedSSE:
@@ -1026,6 +1196,32 @@ public final class RunSessionStore: ObservableObject {
             return
         }
 
+        if isStateUpdateEvent(eventType: eventType) {
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "Runtime State Updated",
+                message: eventPrimaryLabel(from: event.payload) ?? "Authoritative runtime state refreshed.",
+                createdAt: event.createdAt
+            )
+            return
+        }
+
+        if isAIIntentEvent(eventType: eventType) {
+            let summary = jsonString(event.payload["summary"])
+                ?? jsonString(event.payload["title"])
+                ?? jsonString(event.payload["trigger"])
+                ?? "Instructor intent updated."
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "AI Instructor",
+                message: summary,
+                createdAt: event.createdAt
+            )
+            return
+        }
+
         if isCauseEvent(eventType: eventType) {
             let kindTitle = eventType.hasPrefix("injury.") ? "Injury" : "Illness"
             let summary = eventPrimaryLabel(from: event.payload) ?? kindTitle
@@ -1075,6 +1271,44 @@ public final class RunSessionStore: ObservableObject {
             return
         }
 
+        if isVitalEvent(eventType: eventType) {
+            let vitalType = jsonString(event.payload["vital_type"])
+                ?? inferVitalType(from: jsonString(event.payload["domain_event_type"]))
+                ?? "vitals"
+            let minValue = jsonInt(event.payload["min_value"])
+            let maxValue = jsonInt(event.payload["max_value"])
+            let message: String
+            if let minValue, let maxValue {
+                message = "\(humanizedLabel(vitalType)) range \(minValue)-\(maxValue)"
+            } else {
+                message = eventPrimaryLabel(from: event.payload) ?? "\(humanizedLabel(vitalType)) updated"
+            }
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .vitals,
+                title: "Vital Update",
+                message: message,
+                createdAt: event.createdAt
+            )
+            return
+        }
+
+        if isPulseEvent(eventType: eventType, payload: event.payload) {
+            let location = jsonString(event.payload["location"]).map(humanizedLabel) ?? "Pulse"
+            let present = jsonBool(event.payload["present"])
+            let quality = jsonString(event.payload["quality"]) ?? jsonString(event.payload["description"])
+            let presenceText = present.map { $0 ? "present" : "absent" } ?? "updated"
+            let message = quality.map { "\(location) \(presenceText) (\($0))" } ?? "\(location) \(presenceText)"
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .vitals,
+                title: "Pulse Update",
+                message: message,
+                createdAt: event.createdAt
+            )
+            return
+        }
+
         if isNoteEvent(eventType: eventType, payload: event.payload) {
             let content = jsonString(event.payload["content"])
                 ?? jsonString(event.payload["note"])
@@ -1111,7 +1345,7 @@ public final class RunSessionStore: ObservableObject {
                 "intervention_type": interventionType,
                 "site_code": siteCode,
                 "effectiveness": effectiveness,
-                "status": status,
+                "intervention_status": status,
             ]
             if let supersedesID { meta["superseded_by"] = supersedesID }
 
@@ -1131,6 +1365,21 @@ public final class RunSessionStore: ObservableObject {
             return
         }
 
+        if isScenarioBriefEvent(eventType: eventType, payload: event.payload) {
+            let content = jsonString(event.payload["read_aloud_brief"])
+                ?? jsonString(event.payload["title"])
+                ?? jsonString(event.payload["location_overview"])
+                ?? "Scenario brief updated."
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "Scenario Brief",
+                message: content,
+                createdAt: event.createdAt
+            )
+            return
+        }
+
         if eventType.hasPrefix("adjustment.") || eventType.hasPrefix("trainerlab.adjustment."),
            jsonString(event.payload["target"]) == "avpu"
         {
@@ -1145,21 +1394,57 @@ public final class RunSessionStore: ObservableObject {
             return
         }
 
-        // Scenario brief delivered via SSE — update the published brief directly
-        if eventType.contains("scenario_brief") || event.payload["read_aloud_brief"] != nil {
-            if let readAloud = jsonString(event.payload["read_aloud_brief"]) {
-                let brief = ScenarioBriefOut(
-                    readAloudBrief: readAloud,
-                    environment: jsonString(event.payload["environment"]) ?? "",
-                    locationOverview: jsonString(event.payload["location_overview"]),
-                    threatContext: jsonString(event.payload["threat_context"]),
-                    evacuationOptions: jsonStringArray(event.payload["evacuation_options"]),
-                    evacuationTime: jsonString(event.payload["evacuation_time"]),
-                    specialConsiderations: jsonStringArray(event.payload["special_considerations"])
-                )
-                scenarioBrief = brief
-            }
+        if isAssessmentFindingEvent(eventType: eventType) {
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "Assessment Finding",
+                message: eventPrimaryLabel(from: event.payload) ?? "Assessment finding updated.",
+                createdAt: event.createdAt
+            )
+            return
         }
+
+        if isDiagnosticResultEvent(eventType: eventType) {
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "Diagnostic Result",
+                message: eventPrimaryLabel(from: event.payload) ?? "Diagnostic result updated.",
+                createdAt: event.createdAt
+            )
+            return
+        }
+
+        if isResourceEvent(eventType: eventType) {
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "Resource Update",
+                message: eventPrimaryLabel(from: event.payload) ?? "Resource state updated.",
+                createdAt: event.createdAt
+            )
+            return
+        }
+
+        if isDispositionEvent(eventType: eventType) {
+            addClinicalTimelineEntry(
+                dedupeKey: "event:\(event.eventID)",
+                kind: .note,
+                title: "Disposition",
+                message: eventPrimaryLabel(from: event.payload) ?? "Disposition updated.",
+                createdAt: event.createdAt
+            )
+            return
+        }
+
+        addClinicalTimelineEntry(
+            dedupeKey: "event:\(event.eventID)",
+            kind: .note,
+            title: humanizedEventTitle(eventType),
+            message: eventPrimaryLabel(from: event.payload) ?? "Runtime event received.",
+            createdAt: event.createdAt
+        )
     }
 
     private func addClinicalTimelineEntry(
@@ -1174,7 +1459,7 @@ public final class RunSessionStore: ObservableObject {
             return
         }
 
-        state.clinicalTimelineEntries.insert(
+        state.clinicalTimelineEntries.append(
             ClinicalTimelineEntry(
                 dedupeKey: dedupeKey,
                 kind: kind,
@@ -1182,12 +1467,18 @@ public final class RunSessionStore: ObservableObject {
                 message: message,
                 createdAt: createdAt,
                 metadata: metadata
-            ),
-            at: 0
+            )
         )
 
-        if state.clinicalTimelineEntries.count > 400 {
-            state.clinicalTimelineEntries.removeLast(state.clinicalTimelineEntries.count - 400)
+        state.clinicalTimelineEntries.sort { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt {
+                return lhs.createdAt > rhs.createdAt
+            }
+            return lhs.dedupeKey > rhs.dedupeKey
+        }
+
+        if state.clinicalTimelineEntries.count > maxTimelineEvents {
+            state.clinicalTimelineEntries.removeLast(state.clinicalTimelineEntries.count - maxTimelineEvents)
         }
     }
 
@@ -1208,6 +1499,17 @@ public final class RunSessionStore: ObservableObject {
             createdAt: entry.createdAt,
             metadata: meta
         )
+    }
+
+    private func humanizedEventTitle(_ eventType: String) -> String {
+        humanizedLabel(eventType.replacingOccurrences(of: ".", with: " "))
+    }
+
+    private func humanizedLabel(_ rawValue: String) -> String {
+        rawValue
+            .replacingOccurrences(of: "_", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .capitalized
     }
 
     private func captureVitalRange(from event: EventEnvelope) {
@@ -1346,6 +1648,9 @@ public final class RunSessionStore: ObservableObject {
         let maxStep = max(2, Int(Double(high - low) * 0.08))
         let stepLow = max(low, current - maxStep)
         let stepHigh = min(high, current + maxStep)
+        if stepLow > stepHigh {
+            return Int.random(in: low ... high)
+        }
         return Int.random(in: stepLow ... stepHigh)
     }
 
@@ -1792,54 +2097,8 @@ public final class RunSessionStore: ObservableObject {
     // MARK: - Reconcile annotations from runtime state on reconnect
 
     private func reconcileAnnotationsFromSnapshot() async {
-        guard let snapshot = runtimeState?.currentSnapshot else { return }
-        hydrateHiddenClinicalState(from: snapshot)
-
-        let causesByID = Dictionary(uniqueKeysWithValues: snapshot.causes.compactMap { cause in
-            cause.causeID.map { ($0, cause) }
-        })
-        let problemsByID = Dictionary(uniqueKeysWithValues: snapshot.problems.compactMap { problem in
-            problem.problemID.map { ($0, problem) }
-        })
-
-        state.causeAnnotations = snapshot.causes.compactMap { cause in
-            makeCauseAnnotation(from: cause, fallbackProblem: cause.causeID.flatMap { causeID in
-                snapshot.problems.first(where: { $0.causeID == causeID })
-            })
-        }
-
-        state.problemAnnotations = snapshot.problems.map { problem in
-            makeProblemAnnotation(from: problem, causesByID: causesByID)
-        }
-
-        state.recommendedInterventions = snapshot.recommendedInterventions.map { recommendation in
-            makeRecommendedInterventionItem(from: recommendation, problemsByID: problemsByID)
-        }
-
-        // Reconcile vitals from snapshot so ranges are visible before the sim starts
-        for vitalState in snapshot.vitals {
-            guard state.vitals.first(where: { $0.key == vitalState.vitalType }) == nil else { continue }
-            let sampled = randomVitalNumbers(
-                key: vitalState.vitalType,
-                minValue: vitalState.minValue,
-                maxValue: vitalState.maxValue,
-                minDiastolic: vitalState.minValueDiastolic,
-                maxDiastolic: vitalState.maxValueDiastolic
-            )
-            upsertVital(VitalStatusSnapshot(
-                key: vitalState.vitalType,
-                minValue: vitalState.minValue,
-                maxValue: vitalState.maxValue,
-                minValueDiastolic: vitalState.minValueDiastolic,
-                maxValueDiastolic: vitalState.maxValueDiastolic,
-                lockValue: vitalState.lockValue,
-                currentValue: sampled.primary,
-                currentDiastolicValue: sampled.secondary
-            ))
-        }
-
-        state.interventionAnnotations = snapshot.interventions.compactMap(makeInterventionAnnotation)
-        state.pulseAnnotations = snapshot.pulses.compactMap(makePulseAnnotation)
+        guard let runtimeState else { return }
+        applyRuntimeState(runtimeState, source: "reconcile")
     }
 
     private func hydrateHiddenClinicalState(from snapshot: TrainerRuntimeSnapshot) {
@@ -1847,6 +2106,90 @@ public final class RunSessionStore: ObservableObject {
         diagnosticResults = snapshot.diagnosticResults
         resources = snapshot.resources
         disposition = snapshot.disposition
+        patientStatus = snapshot.patientStatus
+    }
+
+    private func makeVitalSnapshot(
+        from vitalState: RuntimeVitalState,
+        existing: VitalStatusSnapshot?
+    ) -> VitalStatusSnapshot? {
+        guard
+            let vitalType = vitalState.vitalType?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !vitalType.isEmpty,
+            let minValue = vitalState.minValue,
+            let maxValue = vitalState.maxValue
+        else {
+            logger.debug("Skipping invalid runtime vital payload during authoritative apply")
+            return nil
+        }
+
+        let sampled = randomVitalNumbers(
+            key: vitalType,
+            minValue: minValue,
+            maxValue: maxValue,
+            minDiastolic: vitalState.minValueDiastolic,
+            maxDiastolic: vitalState.maxValueDiastolic,
+            currentPrimary: existing?.currentValue,
+            currentSecondary: existing?.currentDiastolicValue
+        )
+
+        let trend = vitalState.trend.flatMap(VitalTrendDirection.init(rawValue:))
+            ?? existing?.trend
+            ?? .flat
+
+        return VitalStatusSnapshot(
+            key: vitalType,
+            minValue: minValue,
+            maxValue: maxValue,
+            minValueDiastolic: vitalState.minValueDiastolic,
+            maxValueDiastolic: vitalState.maxValueDiastolic,
+            lockValue: vitalState.lockValue ?? false,
+            previousValue: existing?.currentValue,
+            previousDiastolicValue: existing?.currentDiastolicValue,
+            currentValue: sampled.primary,
+            currentDiastolicValue: sampled.secondary,
+            trend: trend,
+            changeToken: existing?.changeToken ?? 0,
+            lastUpdatedAt: parseISODate(vitalState.timestamp) ?? Date()
+        )
+    }
+
+    private func applyRuntimeState(_ runtimeState: TrainerRuntimeStateOut, source: String) {
+        let snapshot = runtimeState.currentSnapshot
+        logger.info(
+            "Applying runtime state for simulation \(runtimeState.simulationID, privacy: .public) from \(source, privacy: .public): revision=\(runtimeState.stateRevision, privacy: .public)"
+        )
+
+        self.runtimeState = runtimeState
+        scenarioBrief = runtimeState.scenarioBrief
+        hydrateHiddenClinicalState(from: snapshot)
+        noteLifecycleRevision(runtimeState.stateRevision)
+
+        let causesByID = Dictionary(uniqueKeysWithValues: snapshot.causes.compactMap { cause in
+            cause.causeID.map { ($0, cause) }
+        })
+        let problemsByID = Dictionary(uniqueKeysWithValues: snapshot.problems.compactMap { problem in
+            problem.problemID.map { ($0, problem) }
+        })
+        let existingVitalsByKey = Dictionary(uniqueKeysWithValues: state.vitals.map { ($0.key, $0) })
+
+        state.causeAnnotations = snapshot.causes.compactMap { cause in
+            makeCauseAnnotation(from: cause, fallbackProblem: cause.causeID.flatMap { causeID in
+                snapshot.problems.first(where: { $0.causeID == causeID })
+            })
+        }
+        state.problemAnnotations = snapshot.problems.map { problem in
+            makeProblemAnnotation(from: problem, causesByID: causesByID)
+        }
+        state.recommendedInterventions = snapshot.recommendedInterventions.map { recommendation in
+            makeRecommendedInterventionItem(from: recommendation, problemsByID: problemsByID)
+        }
+        state.interventionAnnotations = snapshot.interventions.compactMap(makeInterventionAnnotation)
+        state.pulseAnnotations = snapshot.pulses.compactMap(makePulseAnnotation)
+        state.vitals = snapshot.vitals.compactMap { vitalState in
+            let existing = vitalState.vitalType.flatMap { existingVitalsByKey[$0] }
+            return makeVitalSnapshot(from: vitalState, existing: existing)
+        }
     }
 
     private func makeCauseAnnotation(
@@ -2109,10 +2452,20 @@ public final class RunSessionStore: ObservableObject {
     private func shouldRefreshRuntimeProjection(for event: EventEnvelope) -> Bool {
         let eventType = canonicalEventType(event.eventType)
         return isStateUpdateEvent(eventType: eventType)
+            || isAIIntentEvent(eventType: eventType)
+            || isRunLifecycleEvent(eventType: eventType)
+            || eventType == "session.seeded"
             || isCauseEvent(eventType: eventType)
             || isProblemEvent(eventType: eventType)
             || isRecommendedInterventionEvent(eventType: eventType)
             || isInterventionEvent(eventType: eventType, payload: event.payload)
+            || isVitalEvent(eventType: eventType)
+            || isPulseEvent(eventType: eventType, payload: event.payload)
+            || isScenarioBriefEvent(eventType: eventType, payload: event.payload)
+            || isAssessmentFindingEvent(eventType: eventType)
+            || isDiagnosticResultEvent(eventType: eventType)
+            || isResourceEvent(eventType: eventType)
+            || isDispositionEvent(eventType: eventType)
     }
 
     private func canonicalEventType(_ eventType: String) -> String {
@@ -2125,6 +2478,18 @@ public final class RunSessionStore: ObservableObject {
 
     private func isStateUpdateEvent(eventType: String) -> Bool {
         eventType == "state.updated"
+    }
+
+    private func isAIIntentEvent(eventType: String) -> Bool {
+        eventType == "ai.intent.updated"
+    }
+
+    private func isRunLifecycleEvent(eventType: String) -> Bool {
+        eventType == "run.started"
+            || eventType == "run.paused"
+            || eventType == "run.resumed"
+            || eventType == "run.stopped"
+            || eventType == "run.completed"
     }
 
     private func isCauseEvent(eventType: String) -> Bool {
@@ -2145,6 +2510,46 @@ public final class RunSessionStore: ObservableObject {
         eventType == "recommended_intervention.created"
             || eventType == "recommended_intervention.updated"
             || eventType == "recommended_intervention.cleared"
+            || eventType == "recommended_intervention.removed"
+    }
+
+    private func isVitalEvent(eventType: String) -> Bool {
+        eventType == "vital.created"
+            || eventType == "vital.updated"
+    }
+
+    private func isPulseEvent(eventType: String, payload: [String: JSONValue]) -> Bool {
+        let domainEventType = jsonString(payload["domain_event_type"])?.lowercased()
+        let eventKind = jsonString(payload["event_kind"])?.lowercased()
+        return eventType == "pulse.created"
+            || eventType == "pulse.updated"
+            || domainEventType == "pulseassessment"
+            || eventKind == "pulse_assessment"
+    }
+
+    private func isScenarioBriefEvent(eventType: String, payload: [String: JSONValue]) -> Bool {
+        eventType == "scenario_brief.created"
+            || eventType == "scenario_brief.updated"
+            || payload["read_aloud_brief"] != nil
+    }
+
+    private func isAssessmentFindingEvent(eventType: String) -> Bool {
+        eventType == "assessment_finding.created"
+            || eventType == "assessment_finding.updated"
+            || eventType == "assessment_finding.removed"
+    }
+
+    private func isDiagnosticResultEvent(eventType: String) -> Bool {
+        eventType == "diagnostic_result.created"
+            || eventType == "diagnostic_result.updated"
+    }
+
+    private func isResourceEvent(eventType: String) -> Bool {
+        eventType == "resource.updated"
+    }
+
+    private func isDispositionEvent(eventType: String) -> Bool {
+        eventType == "disposition.updated"
     }
 
     private func isNoteEvent(eventType: String, payload: [String: JSONValue]) -> Bool {
@@ -2253,7 +2658,7 @@ public final class RunSessionStore: ObservableObject {
     }
 
     private func injuryZone(for code: String) -> (side: InjuryZoneSide, x: Double, y: Double)? {
-        InjuryZoneMap.table[code]
+        InjuryZoneMap.table[code] ?? InterventionSiteMap.table[code]
     }
 
     private func resolvedAnatomicLocationCode(primary: String?, fallback: String?) -> String? {

--- a/apps/trainerlab-ios/Sources/SharedModels/Contracts.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/Contracts.swift
@@ -1239,13 +1239,13 @@ public struct RuntimeDispositionState: Codable, Sendable {
 
 public struct RuntimeVitalState: Codable, Sendable {
     public let domainEventID: Int?
-    public let vitalType: String
-    public let minValue: Int
-    public let maxValue: Int
-    public let lockValue: Bool
+    public let vitalType: String?
+    public let minValue: Int?
+    public let maxValue: Int?
+    public let lockValue: Bool?
     public let minValueDiastolic: Int?
     public let maxValueDiastolic: Int?
-    public let trend: String
+    public let trend: String?
     public let source: String?
     public let timestamp: String?
 
@@ -1260,6 +1260,20 @@ public struct RuntimeVitalState: Codable, Sendable {
         case trend
         case source
         case timestamp
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        domainEventID = try container.decodeIfPresent(Int.self, forKey: .domainEventID)
+        vitalType = try container.decodeIfPresent(String.self, forKey: .vitalType)
+        minValue = try container.decodeIfPresent(Int.self, forKey: .minValue)
+        maxValue = try container.decodeIfPresent(Int.self, forKey: .maxValue)
+        lockValue = try container.decodeIfPresent(Bool.self, forKey: .lockValue)
+        minValueDiastolic = try container.decodeIfPresent(Int.self, forKey: .minValueDiastolic)
+        maxValueDiastolic = try container.decodeIfPresent(Int.self, forKey: .maxValueDiastolic)
+        trend = try container.decodeIfPresent(String.self, forKey: .trend)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        timestamp = try container.decodeIfPresent(String.self, forKey: .timestamp)
     }
 }
 
@@ -1380,6 +1394,17 @@ public struct RuntimeInstructorIntent: Codable, Sendable {
         case upcomingChanges = "upcoming_changes"
         case monitoringFocus = "monitoring_focus"
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
+        rationale = try container.decodeIfPresent(String.self, forKey: .rationale) ?? ""
+        trigger = try container.decodeIfPresent(String.self, forKey: .trigger) ?? ""
+        etaSeconds = try container.decodeIfPresent(Int.self, forKey: .etaSeconds)
+        confidence = try container.decodeIfPresent(Double.self, forKey: .confidence) ?? 0
+        upcomingChanges = try container.decodeIfPresent([String].self, forKey: .upcomingChanges) ?? []
+        monitoringFocus = try container.decodeIfPresent([String].self, forKey: .monitoringFocus) ?? []
+    }
 }
 
 public struct TrainerRuntimeStateOut: Codable, Sendable {
@@ -1422,10 +1447,10 @@ public struct TrainerRuntimeStateOut: Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         simulationID = try container.decode(Int.self, forKey: .simulationID)
-        sessionID = try container.decode(Int.self, forKey: .sessionID)
-        status = try container.decode(String.self, forKey: .status)
-        stateRevision = try container.decode(Int.self, forKey: .stateRevision)
-        activeElapsedSeconds = try container.decode(Int.self, forKey: .activeElapsedSeconds)
+        sessionID = try container.decodeIfPresent(Int.self, forKey: .sessionID) ?? simulationID
+        status = try container.decodeIfPresent(String.self, forKey: .status) ?? "unknown"
+        stateRevision = try container.decodeIfPresent(Int.self, forKey: .stateRevision) ?? 0
+        activeElapsedSeconds = try container.decodeIfPresent(Int.self, forKey: .activeElapsedSeconds) ?? 0
         tickIntervalSeconds = try container.decodeIfPresent(Int.self, forKey: .tickIntervalSeconds)
         nextTickAt = try container.decodeIfPresent(Date.self, forKey: .nextTickAt)
         scenarioBrief = try container.decodeIfPresent(ScenarioBriefOut.self, forKey: .scenarioBrief)

--- a/apps/trainerlab-ios/Tests/NetworkingTests/TrainerLabContractTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/TrainerLabContractTests.swift
@@ -546,6 +546,89 @@ final class TrainerLabContractTests: XCTestCase {
         XCTAssertNotNil(state.lastAITickAt)
     }
 
+    func testTrainerRuntimeStateDecodesVitalWithoutLockValue() throws {
+        let json = """
+        {
+          "simulation_id": 420,
+          "status": "running",
+          "current_snapshot": {
+            "causes": [],
+            "problems": [],
+            "recommended_interventions": [],
+            "interventions": [],
+            "assessment_findings": [],
+            "diagnostic_results": [],
+            "resources": [],
+            "disposition": null,
+            "vitals": [
+              {
+                "vital_type": "heart_rate",
+                "min_value": 80,
+                "max_value": 120
+              }
+            ],
+            "pulses": [],
+            "patient_status": {}
+          }
+        }
+        """
+
+        let state = try makeContractDecoder().decode(TrainerRuntimeStateOut.self, from: Data(json.utf8))
+
+        XCTAssertEqual(state.currentSnapshot.vitals.first?.vitalType, "heart_rate")
+        XCTAssertNil(state.currentSnapshot.vitals.first?.lockValue)
+    }
+
+    func testTrainerRuntimeStateDecodesSparseAIPlan() throws {
+        let json = """
+        {
+          "simulation_id": 420,
+          "status": "running",
+          "current_snapshot": {
+            "causes": [],
+            "problems": [],
+            "recommended_interventions": [],
+            "interventions": [],
+            "assessment_findings": [],
+            "diagnostic_results": [],
+            "resources": [],
+            "disposition": null,
+            "vitals": [],
+            "pulses": [],
+            "patient_status": {}
+          },
+          "ai_plan": {
+            "summary": "Watch SpO2"
+          }
+        }
+        """
+
+        let state = try makeContractDecoder().decode(TrainerRuntimeStateOut.self, from: Data(json.utf8))
+
+        XCTAssertEqual(state.aiPlan?.summary, "Watch SpO2")
+        XCTAssertEqual(state.aiPlan?.rationale, "")
+        XCTAssertEqual(state.aiPlan?.monitoringFocus, [])
+    }
+
+    func testRecommendedInterventionRemovedEnvelopeDecodesWithoutStrictPayloadSchema() throws {
+        let json = """
+        {
+          "event_id": "rec-removed-1",
+          "event_type": "recommended_intervention.removed",
+          "created_at": "2026-03-20T13:56:34.990952+00:00",
+          "payload": {
+            "recommendation_id": 91,
+            "target_problem_id": 12
+          }
+        }
+        """
+
+        let event = try makeContractDecoder().decode(EventEnvelope.self, from: Data(json.utf8))
+
+        XCTAssertEqual(event.eventType, "recommended_intervention.removed")
+        XCTAssertEqual(event.payload["recommendation_id"], .number(91))
+    }
+
     func testControlPlaneDebugDecodesCurrentBackendShape() throws {
         let json = """
         {

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -124,7 +124,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         XCTAssertEqual(RunConsoleTimelinePresentation.chipText(for: .loc), "LOC")
         XCTAssertEqual(RunConsoleTimelinePresentation.title(for: injuryEntry), "Change")
         XCTAssertEqual(RunConsoleTimelinePresentation.title(for: lifecycleEntry), "Run Started")
-        XCTAssertEqual(RunConsoleTimelinePresentation.title(for: noteEntry), "Trainer Note")
+        XCTAssertEqual(RunConsoleTimelinePresentation.title(for: noteEntry), "Anything")
     }
 
     func testControlCatalogSeparatesSessionAndQuickControls() {
@@ -142,7 +142,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         )
     }
 
-    func testTimelineFiltersHideNotesFromRunConsole() {
+    func testTimelineFiltersIncludeNotesInRunConsole() {
         let causeEntry = ClinicalTimelineEntry(
             dedupeKey: "cause-1",
             kind: .cause,
@@ -162,8 +162,12 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
             matching: .all
         )
 
-        XCTAssertFalse(RunConsoleTimelineFilter.allCases.contains(.kind(.note)))
-        XCTAssertEqual(visibleEntries, [causeEntry])
+        XCTAssertTrue(RunConsoleTimelineFilter.allCases.contains(.kind(.note)))
+        XCTAssertEqual(visibleEntries, [causeEntry, noteEntry])
+        XCTAssertEqual(
+            RunConsoleTimelineFilter.visibleEntries(from: [causeEntry, noteEntry], matching: .kind(.note)),
+            [noteEntry]
+        )
     }
 
     func testLifecycleActionsMatchSessionStatus() {

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -23,7 +23,11 @@ private final class MockTrainerLabService: TrainerLabServiceProtocol, @unchecked
     var retryInitialCalls: [Int] = []
     var retryInitialResult: Result<TrainerSessionDTO, Error> = .failure(MockServiceError.unused)
     var getRuntimeStateCalls: [Int] = []
+    var getRuntimeStateResultsQueue: [Result<TrainerRuntimeStateOut, Error>] = []
     var getRuntimeStateResult: Result<TrainerRuntimeStateOut, Error> = .failure(MockServiceError.unused)
+    var listEventsCalls: [(simulationID: Int, cursor: String?, limit: Int)] = []
+    var listEventsResultsQueue: [Result<PaginatedResponse<EventEnvelope>, Error>] = []
+    var listEventsResult: Result<PaginatedResponse<EventEnvelope>, Error> = .failure(MockServiceError.unused)
     var listAnnotationsCalls: [Int] = []
     var listAnnotationsResult: Result<[AnnotationOut], Error> = .failure(MockServiceError.unused)
     var replayPendingCalls: [ReplayPendingCall] = []
@@ -57,6 +61,9 @@ private final class MockTrainerLabService: TrainerLabServiceProtocol, @unchecked
 
     func getRuntimeState(simulationID: Int) async throws -> TrainerRuntimeStateOut {
         getRuntimeStateCalls.append(simulationID)
+        if !getRuntimeStateResultsQueue.isEmpty {
+            return try getRuntimeStateResultsQueue.removeFirst().get()
+        }
         return try getRuntimeStateResult.get()
     }
 
@@ -77,8 +84,12 @@ private final class MockTrainerLabService: TrainerLabServiceProtocol, @unchecked
         throw MockServiceError.unused
     }
 
-    func listEvents(simulationID _: Int, cursor _: String?, limit _: Int) async throws -> PaginatedResponse<EventEnvelope> {
-        throw MockServiceError.unused
+    func listEvents(simulationID: Int, cursor: String?, limit: Int) async throws -> PaginatedResponse<EventEnvelope> {
+        listEventsCalls.append((simulationID: simulationID, cursor: cursor, limit: limit))
+        if !listEventsResultsQueue.isEmpty {
+            return try listEventsResultsQueue.removeFirst().get()
+        }
+        return try listEventsResult.get()
     }
 
     func getRunSummary(simulationID _: Int) async throws -> RunSummary {
@@ -210,6 +221,7 @@ private final class MockTrainerLabService: TrainerLabServiceProtocol, @unchecked
 private final class MockRealtimeClient: RealtimeClientProtocol, @unchecked Sendable {
     let events: AsyncStream<EventEnvelope>
     let transportStates: AsyncStream<RealtimeTransportState>
+    private(set) var connectCalls: [(simulationID: Int, cursor: String?)] = []
 
     private let eventContinuation: AsyncStream<EventEnvelope>.Continuation
     private let stateContinuation: AsyncStream<RealtimeTransportState>.Continuation
@@ -229,7 +241,8 @@ private final class MockRealtimeClient: RealtimeClientProtocol, @unchecked Senda
         stateContinuation = stateCont
     }
 
-    func connect(simulationID _: Int, cursor _: String?) async {
+    func connect(simulationID: Int, cursor: String?) async {
+        connectCalls.append((simulationID: simulationID, cursor: cursor))
         stateContinuation.yield(.connecting)
         stateContinuation.yield(.connectedSSE)
     }
@@ -282,16 +295,32 @@ final class RunSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.state.clinicalTimelineEntries.first?.kind, .loc)
     }
 
-    func testVitalEventsDoNotCreateClinicalTimelineEntries() async {
+    func testVitalEventsTriggerAuthoritativeRefreshAndTimelineEntries() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = [
+            .success(try makeRuntimeState(status: "running")),
+            .success(try makeRuntimeState(
+                status: "running",
+                vitals: [[
+                    "vital_type": "heart_rate",
+                    "min_value": 80,
+                    "max_value": 140,
+                ]]
+            )),
+        ]
         let realtime = MockRealtimeClient()
         let store = RunSessionStore(
-            service: MockTrainerLabService(),
+            service: service,
             realtimeClient: realtime,
             commandQueue: InMemoryCommandQueueStore()
         )
         store.bind(session: makeSession(status: .running))
         store.startConsole()
         defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
 
         realtime.emit(event: EventEnvelope(
             eventID: "vital-1",
@@ -305,11 +334,282 @@ final class RunSessionStoreTests: XCTestCase {
             ]
         ))
 
-        await waitUntil(timeout: 1.5) {
-            store.state.vitals.count == 1
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2
+                && store.state.vitals.count == 1
+                && store.state.clinicalTimelineEntries.first?.kind == .vitals
         }
 
-        XCTAssertTrue(store.state.clinicalTimelineEntries.isEmpty)
+        XCTAssertEqual(store.state.vitals.first?.key, "heart_rate")
+        XCTAssertEqual(store.state.clinicalTimelineEntries.first?.title, "Vital Update")
+    }
+
+    func testBootstrapLoadsAuthoritativeRuntimeStateAndHistoricalTimeline() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResult = .success(try makeRuntimeState(
+            status: "seeded",
+            stateRevision: 4,
+            scenarioBrief: [
+                "read_aloud_brief": "Patrol medic called to blast injury.",
+                "environment": "Night operation",
+            ],
+            causes: [[
+                "cause_id": 11,
+                "kind": "injury",
+                "title": "Blast Injury",
+                "description": "Open wound to the left arm",
+                "injury_location": "LEFT_ARM",
+            ]],
+            problems: [[
+                "problem_id": 21,
+                "title": "Hemorrhagic Shock",
+                "status": "active",
+                "cause_id": 11,
+                "anatomical_location": "LEFT_ARM",
+            ]],
+            vitals: [[
+                "vital_type": "heart_rate",
+                "min_value": 120,
+                "max_value": 140,
+            ]],
+            pulses: [[
+                "location": "radial_left",
+                "present": false,
+                "quality": "weak",
+            ]],
+            assessmentFindings: [[
+                "title": "Absent breath sounds",
+                "status": "present",
+            ]],
+            diagnosticResults: [[
+                "title": "Ultrasound pending",
+                "status": "queued",
+            ]],
+            resources: [[
+                "title": "Whole blood available",
+                "status": "ready",
+            ]],
+            disposition: [
+                "title": "Urgent evacuation",
+                "status": "requested",
+            ],
+            patientStatus: [
+                "avpu": "verbal",
+                "narrative": "Increasing respiratory distress.",
+                "respiratory_distress": true,
+            ],
+            aiPlan: [
+                "summary": "Escalate respiratory distress",
+                "upcoming_changes": ["Decrease SpO2"],
+            ]
+        ))
+        service.listEventsResult = .success(PaginatedResponse(
+            items: [
+                makeLifecycleEvent(eventID: "seed-1", eventType: "session.seeded", createdAt: Date(timeIntervalSince1970: 10)),
+                makeLifecycleEvent(eventID: "run-1", eventType: "run.started", createdAt: Date(timeIntervalSince1970: 20)),
+            ],
+            nextCursor: nil,
+            hasMore: false
+        ))
+        service.listAnnotationsResult = .success([])
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore()
+        )
+        store.bind(session: makeSession(status: .seeded))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 2.0) {
+            store.runtimeState?.stateRevision == 4
+                && store.state.clinicalTimelineEntries.count == 2
+                && realtime.connectCalls.first?.cursor == "run-1"
+        }
+
+        XCTAssertEqual(store.state.vitals.first?.key, "heart_rate")
+        XCTAssertEqual(store.state.pulseAnnotations.first?.location, "radial_left")
+        XCTAssertEqual(store.state.causeAnnotations.first?.causeID, 11)
+        XCTAssertEqual(store.state.problemAnnotations.first?.problemID, 21)
+        XCTAssertEqual(store.scenarioBrief?.readAloudBrief, "Patrol medic called to blast injury.")
+        XCTAssertEqual(store.patientStatus.narrative, "Increasing respiratory distress.")
+        XCTAssertEqual(store.runtimeState?.aiPlan?.summary, "Escalate respiratory distress")
+        XCTAssertEqual(store.state.clinicalTimelineEntries.map(\.title), ["Run Started", "Scenario Ready"])
+    }
+
+    func testStateUpdatedAuthoritativelyReplacesVitals() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = [
+            .success(try makeRuntimeState(
+                status: "running",
+                stateRevision: 1,
+                vitals: [[
+                    "vital_type": "heart_rate",
+                    "min_value": 80,
+                    "max_value": 100,
+                ]]
+            )),
+            .success(try makeRuntimeState(
+                status: "running",
+                stateRevision: 2,
+                vitals: [[
+                    "vital_type": "heart_rate",
+                    "min_value": 120,
+                    "max_value": 150,
+                ]]
+            )),
+        ]
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore()
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            store.state.vitals.first?.minValue == 80
+        }
+
+        realtime.emit(event: EventEnvelope(
+            eventID: "state-2",
+            eventType: "state.updated",
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [:]
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2
+                && store.state.vitals.first?.minValue == 120
+                && store.state.vitals.first?.maxValue == 150
+        }
+
+        XCTAssertEqual(store.state.vitals.count, 1)
+    }
+
+    func testAIIntentUpdatedTriggersAuthoritativeRefresh() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = [
+            .success(try makeRuntimeState(status: "running")),
+            .success(try makeRuntimeState(
+                status: "running",
+                aiPlan: [
+                    "summary": "Reassess airway",
+                    "rationale": "SpO2 is falling",
+                ]
+            )),
+        ]
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore()
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
+
+        realtime.emit(event: EventEnvelope(
+            eventID: "ai-1",
+            eventType: "ai.intent.updated",
+            createdAt: Date(),
+            correlationID: nil,
+            payload: ["summary": .string("Reassess airway")]
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2
+                && store.runtimeState?.aiPlan?.summary == "Reassess airway"
+        }
+
+        XCTAssertEqual(store.state.clinicalTimelineEntries.first?.title, "AI Instructor")
+    }
+
+    func testBurstRuntimeEventsCoalesceToSingleRefresh() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = [
+            .success(try makeRuntimeState(status: "running")),
+            .success(try makeRuntimeState(status: "running", stateRevision: 2)),
+        ]
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore()
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
+
+        realtime.emit(event: EventEnvelope(eventID: "e1", eventType: "state.updated", createdAt: Date(), correlationID: nil, payload: [:]))
+        realtime.emit(event: EventEnvelope(eventID: "e2", eventType: "ai.intent.updated", createdAt: Date(), correlationID: nil, payload: [:]))
+        realtime.emit(event: EventEnvelope(eventID: "e3", eventType: "recommended_intervention.updated", createdAt: Date(), correlationID: nil, payload: [:]))
+
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2
+        }
+
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(service.getRuntimeStateCalls.count, 2)
+    }
+
+    func testHistoryAndLiveTimelineDedupesAndSortsStably() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResult = .success(try makeRuntimeState(status: "running"))
+        service.listEventsResult = .success(PaginatedResponse(
+            items: [
+                makeLifecycleEvent(eventID: "seed-1", eventType: "session.seeded", createdAt: Date(timeIntervalSince1970: 10)),
+                makeLifecycleEvent(eventID: "run-1", eventType: "run.started", createdAt: Date(timeIntervalSince1970: 20)),
+            ],
+            nextCursor: nil,
+            hasMore: false
+        ))
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore()
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 2.0) {
+            store.state.timeline.count == 2
+        }
+
+        realtime.emit(event: makeLifecycleEvent(
+            eventID: "run-1",
+            eventType: "run.started",
+            createdAt: Date(timeIntervalSince1970: 20)
+        ))
+        realtime.emit(event: makeLifecycleEvent(
+            eventID: "run-2",
+            eventType: "run.paused",
+            createdAt: Date(timeIntervalSince1970: 30)
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            store.state.timeline.map(\.eventID) == ["seed-1", "run-1", "run-2"]
+                && store.state.clinicalTimelineEntries.map(\.title) == ["Run Paused", "Run Started", "Scenario Ready"]
+        }
     }
 
     func testStopwatchTracksRunLifecycleTransitions() async throws {
@@ -986,43 +1286,72 @@ final class RunSessionStoreTests: XCTestCase {
         )
     }
 
-    private func makeRuntimeState(status: String, stateRevision: Int = 1) throws -> TrainerRuntimeStateOut {
-        let json = """
-        {
-          "simulation_id": 420,
-          "session_id": 420,
-          "status": "\(status)",
-          "state_revision": \(stateRevision),
-          "active_elapsed_seconds": 0,
-          "tick_interval_seconds": 15,
-          "next_tick_at": null,
-          "scenario_brief": null,
-          "current_snapshot": {
-            "causes": [],
-            "problems": [],
-            "recommended_interventions": [],
-            "interventions": [],
-            "assessment_findings": [],
-            "diagnostic_results": [],
-            "resources": [],
-            "disposition": null,
-            "vitals": [],
-            "pulses": [],
-            "patient_status": {}
-          },
-          "ai_plan": null,
-          "ai_rationale_notes": [],
-          "pending_runtime_reasons": [],
-          "pending_reasons": [],
-          "currently_processing_reasons": [],
-          "last_runtime_error": "",
-          "last_ai_tick_at": null
-        }
-        """
+    private func makeRuntimeState(
+        status: String,
+        stateRevision: Int = 1,
+        scenarioBrief: [String: Any]? = nil,
+        causes: [[String: Any]] = [],
+        problems: [[String: Any]] = [],
+        vitals: [[String: Any]] = [],
+        pulses: [[String: Any]] = [],
+        recommendedInterventions: [[String: Any]] = [],
+        interventions: [[String: Any]] = [],
+        assessmentFindings: [[String: Any]] = [],
+        diagnosticResults: [[String: Any]] = [],
+        resources: [[String: Any]] = [],
+        disposition: [String: Any]? = nil,
+        patientStatus: [String: Any] = [:],
+        aiPlan: [String: Any]? = nil
+    ) throws -> TrainerRuntimeStateOut {
+        let payload: [String: Any] = [
+            "simulation_id": 420,
+            "session_id": 420,
+            "status": status,
+            "state_revision": stateRevision,
+            "active_elapsed_seconds": 0,
+            "tick_interval_seconds": 15,
+            "next_tick_at": NSNull(),
+            "scenario_brief": scenarioBrief ?? NSNull(),
+            "current_snapshot": [
+                "causes": causes,
+                "problems": problems,
+                "recommended_interventions": recommendedInterventions,
+                "interventions": interventions,
+                "assessment_findings": assessmentFindings,
+                "diagnostic_results": diagnosticResults,
+                "resources": resources,
+                "disposition": disposition ?? (NSNull() as Any),
+                "vitals": vitals,
+                "pulses": pulses,
+                "patient_status": patientStatus,
+            ],
+            "ai_plan": aiPlan ?? NSNull(),
+            "ai_rationale_notes": [],
+            "pending_runtime_reasons": [],
+            "pending_reasons": [],
+            "currently_processing_reasons": [],
+            "last_runtime_error": "",
+            "last_ai_tick_at": NSNull(),
+        ]
 
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(TrainerRuntimeStateOut.self, from: Data(json.utf8))
+        return try decoder.decode(TrainerRuntimeStateOut.self, from: data)
+    }
+
+    private func makeLifecycleEvent(
+        eventID: String,
+        eventType: String,
+        createdAt: Date
+    ) -> EventEnvelope {
+        EventEnvelope(
+            eventID: eventID,
+            eventType: eventType,
+            createdAt: createdAt,
+            correlationID: nil,
+            payload: [:]
+        )
     }
 
     private func waitUntil(


### PR DESCRIPTION
**Summary**
- Fix authoritative TrainerLab runtime state bootstrap so the UI populates from `/state/` on load instead of waiting on local mutations or live events
- Load historical `/events/` into the timeline before connecting realtime updates, with stable dedupe and ordering
- Expand live event handling so runtime refreshes cover AI intent, run lifecycle, vitals, pulses, scenario brief, findings, diagnostics, resources, and disposition updates
- Harden runtime DTO decoding for sparse backend payloads and add targeted diagnostics around state, events, and transport flow
- Render patient status, assessment findings, diagnostic results, resources, and disposition in the run console

**Testing**
- `swift test` in `apps/trainerlab-ios`
- `swift test --filter RunSessionStoreTests`
- `xcodebuild -list -project MedSim.xcodeproj`
- `xcodebuild` MedSim simulator build/test could not be completed in this environment because CoreSimulatorService was unavailable and package resolution hit sandbox/cache permission errors