### PR TITLE
Align ChatLab realtime with backend checkpoint/cursor contract

### DIFF
--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
@@ -477,11 +477,39 @@ public enum ChatRealtimeConnectionState: Sendable, Equatable {
     case connecting
     case connected
     case reconnecting(attempt: Int)
-    case catchingUp
+    case staleCursor
 }
 
 public struct ChatConversationListResponse: Codable, Sendable {
     public let items: [ChatConversation]
+    public let latestEventCursor: String?
+
+    enum CodingKeys: String, CodingKey {
+        case items
+        case latestEventCursor = "latest_event_id"
+    }
+
+    enum CompatibilityCodingKeys: String, CodingKey {
+        case latestEventCursorFallback = "latest_event_cursor"
+        case latestEventCheckpoint = "latest_event_checkpoint"
+    }
+
+    public init(items: [ChatConversation], latestEventCursor: String? = nil) {
+        self.items = items
+        self.latestEventCursor = latestEventCursor
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        items = try container.decode([ChatConversation].self, forKey: .items)
+        if let latest = try container.decodeIfPresent(String.self, forKey: .latestEventCursor) {
+            latestEventCursor = latest
+            return
+        }
+        let compatibilityContainer = try decoder.container(keyedBy: CompatibilityCodingKeys.self)
+        latestEventCursor = try compatibilityContainer.decodeIfPresent(String.self, forKey: .latestEventCursorFallback)
+            ?? compatibilityContainer.decodeIfPresent(String.self, forKey: .latestEventCheckpoint)
+    }
 }
 
 public struct ChatCreateConversationRequest: Codable, Sendable {

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRealtimeClient.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRealtimeClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Networking
+import OSLog
 import SharedModels
 
 public protocol ChatRealtimeClientProtocol: Sendable {
@@ -8,6 +9,12 @@ public protocol ChatRealtimeClientProtocol: Sendable {
     func connect(simulationID: Int, cursor: String?) async
     func disconnect()
     func send(eventType: String, payload: [String: JSONValue]) async
+}
+
+private let realtimeLogger = Logger(subsystem: "com.jackfruit.medsim", category: "ChatRealtime")
+
+enum ChatRealtimeError: Error {
+    case staleCursor
 }
 
 private enum ChatSSEStreamItem {
@@ -138,15 +145,26 @@ public final class ChatRealtimeClient: ChatRealtimeClientProtocol, @unchecked Se
         while !Task.isCancelled {
             do {
                 stateContinuation.yield(.connecting)
+                realtimeLogger.debug(
+                    "Connecting chat SSE for simulation \(simulationID, privacy: .public) with cursor \(currentCursor ?? "nil", privacy: .public)",
+                )
                 try await consumeSSE(simulationID: simulationID, currentCursor: &currentCursor)
                 reconnectAttempt = 0
+            } catch ChatRealtimeError.staleCursor {
+                stateContinuation.yield(.staleCursor)
+                realtimeLogger.warning(
+                    "Detected stale cursor for simulation \(simulationID, privacy: .public). Waiting for re-bootstrap.",
+                )
+                break
             } catch {
                 if Task.isCancelled {
                     break
                 }
                 reconnectAttempt += 1
                 stateContinuation.yield(.reconnecting(attempt: reconnectAttempt))
-                await performCatchup(simulationID: simulationID, currentCursor: &currentCursor)
+                realtimeLogger.warning(
+                    "Chat SSE reconnect attempt \(self.reconnectAttempt, privacy: .public) for simulation \(simulationID, privacy: .public) using cursor \(currentCursor ?? "nil", privacy: .public)",
+                )
 
                 let delaySeconds = min(pow(2.0, Double(max(reconnectAttempt - 1, 0))), 15.0)
                 let jitter = Double.random(in: 0 ... 0.35)
@@ -166,6 +184,7 @@ public final class ChatRealtimeClient: ChatRealtimeClientProtocol, @unchecked Se
                 stateContinuation.yield(.connected)
                 currentCursor = event.eventID
                 cursor = event.eventID
+                realtimeLogger.debug("Chat SSE cursor advanced to \(event.eventID, privacy: .public)")
                 emitIfNew(event)
             case .keepAlive:
                 stateContinuation.yield(.connected)
@@ -276,12 +295,18 @@ public final class ChatRealtimeClient: ChatRealtimeClientProtocol, @unchecked Se
         if initial.1.statusCode == 401 {
             try await authLoader.refreshAccessToken()
             let refreshed = try await open()
+            if [409, 410, 422].contains(refreshed.1.statusCode) {
+                throw ChatRealtimeError.staleCursor
+            }
             guard (200 ..< 300).contains(refreshed.1.statusCode) else {
                 throw URLError(.userAuthenticationRequired)
             }
             return refreshed
         }
 
+        if [409, 410, 422].contains(initial.1.statusCode) {
+            throw ChatRealtimeError.staleCursor
+        }
         guard (200 ..< 300).contains(initial.1.statusCode) else {
             throw URLError(.badServerResponse)
         }
@@ -299,34 +324,6 @@ public final class ChatRealtimeClient: ChatRealtimeClientProtocol, @unchecked Se
             seenEventIDs.remove(oldest)
         }
         eventContinuation.yield(event)
-    }
-
-    private func performCatchup(simulationID: Int, currentCursor: inout String?) async {
-        stateContinuation.yield(.catchingUp)
-        do {
-            while !Task.isCancelled {
-                let page = try await service.listEvents(
-                    simulationID: simulationID,
-                    cursor: currentCursor,
-                    limit: 50,
-                )
-                if page.items.isEmpty, !page.hasMore {
-                    break
-                }
-
-                for event in page.items {
-                    currentCursor = event.eventID
-                    emitIfNew(event)
-                }
-                if !page.hasMore {
-                    break
-                }
-                currentCursor = page.nextCursor
-            }
-            cursor = currentCursor
-        } catch {
-            // Keep reconnect loop alive and try SSE again.
-        }
     }
 
     private nonisolated static func parseISO8601(_ value: String) -> Date? {

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Networking
+import OSLog
 import SharedModels
 
 private enum AwaitingReplyReason: Equatable {
@@ -18,6 +19,14 @@ private enum RefreshTrigger {
     case manualStatusRefresh
     case manualReconnect
     case automaticReconnect
+}
+
+private let runStoreLogger = Logger(subsystem: "com.jackfruit.medsim", category: "ChatRunStore")
+
+private enum EventHandlingOutcome {
+    case ignored
+    case duplicate
+    case applied(needsToolRefresh: Bool)
 }
 
 public struct ChatMessageItem: Identifiable, Sendable, Equatable {
@@ -93,6 +102,9 @@ public final class ChatRunStore: ObservableObject {
     private var markReadInFlight = Set<Int>()
     private let foregroundRecoveryGraceSeconds: TimeInterval = 12
     private var pendingTransportRecovery = false
+    private var bootstrapCheckpointCursor: String?
+    private var toolRefreshTask: Task<Void, Never>?
+    private var isRebootstrapping = false
 
     public init(
         service: ChatLabServiceProtocol,
@@ -174,6 +186,7 @@ public final class ChatRunStore: ObservableObject {
                 await MainActor.run {
                     self.lastRealtimeSignalAt = Date()
                     self.lastEventCursor = event.eventID
+                    runStoreLogger.debug("Committed cursor advanced to \(event.eventID, privacy: .public)")
                     self.handleEvent(event)
                 }
             }
@@ -209,30 +222,19 @@ public final class ChatRunStore: ObservableObject {
         stateTask?.cancel()
         heartbeatTask?.cancel()
         typingStopTask?.cancel()
+        toolRefreshTask?.cancel()
         eventTask = nil
         stateTask = nil
         heartbeatTask = nil
         typingStopTask = nil
+        toolRefreshTask = nil
         stopAwaitingReply()
         realtimeClient.disconnect()
     }
 
     private func bootstrap() async {
         do {
-            let list = try await service.listConversations(simulationID: simulation.id)
-            conversations = list.items
-            if activeConversationID == nil {
-                activeConversationID = conversations.first?.id
-            }
-
-            if let activeConversationID {
-                await loadInitialMessages(conversationID: activeConversationID)
-                markConversationRead(conversationID: activeConversationID)
-            }
-
-            startInitialAwaitingReplyIfNeeded()
-            await realtimeClient.connect(simulationID: simulation.id, cursor: nil)
-            await refreshGuardState()
+            try await bootstrapStateAndConnect(reason: "initial_bootstrap")
         } catch {
             presentableError = AppErrorPresenter.present(error)
         }
@@ -458,39 +460,53 @@ public final class ChatRunStore: ObservableObject {
     private func handleEvent(_ event: ChatEventEnvelope) {
         let event = event.canonicalized()
         captureActivity(from: event)
+        switch applyEvent(event) {
+        case .ignored:
+            break
+        case .duplicate:
+            runStoreLogger.debug("Fast-skipped duplicate event \(event.eventID, privacy: .public) type \(event.eventType, privacy: .public)")
+        case let .applied(needsToolRefresh):
+            if needsToolRefresh {
+                scheduleToolRefresh(reason: event.eventType)
+            }
+        }
+    }
+
+    private func applyEvent(_ event: ChatEventEnvelope) -> EventHandlingOutcome {
         switch event.eventType {
         case SimulationEventType.messageItemCreated:
-            handleMessageCreated(event.payload)
-            toolRefreshToken = UUID()
+            return handleMessageCreated(event.payload) ? .applied(needsToolRefresh: false) : .duplicate
 
         case SimulationEventType.messageDeliveryUpdated:
-            handleMessageStatusUpdate(event.payload)
+            return handleMessageStatusUpdate(event.payload) ? .applied(needsToolRefresh: false) : .ignored
 
         case SimulationEventType.typing:
             setTyping(event.payload, started: true)
+            return .applied(needsToolRefresh: false)
 
         case SimulationEventType.stoppedTyping:
             setTyping(event.payload, started: false)
+            return .applied(needsToolRefresh: false)
 
         case SimulationEventType.simulationStatusUpdated:
             handleSimulationStatusUpdated(event.payload)
+            return .applied(needsToolRefresh: false)
 
         case SimulationEventType.feedbackGenerationFailed:
             feedbackFailureText = string(event.payload, keys: ["error_text"]) ?? "Feedback generation failed."
             feedbackRetryable = bool(event.payload, key: "retryable") ?? true
+            return .applied(needsToolRefresh: false)
 
-        case SimulationEventType.feedbackGenerationUpdated:
-            feedbackFailureText = nil
-            toolRefreshToken = UUID()
-
-        case SimulationEventType.feedbackItemCreated,
+        case SimulationEventType.feedbackGenerationUpdated,
+             SimulationEventType.feedbackItemCreated,
              SimulationEventType.patientMetadataCreated,
              SimulationEventType.patientResultsUpdated:
             feedbackFailureText = nil
-            toolRefreshToken = UUID()
+            return .applied(needsToolRefresh: true)
 
         case SimulationEventType.guardStateUpdated, SimulationEventType.guardWarningUpdated:
             Task { await refreshGuardState() }
+            return .applied(needsToolRefresh: false)
 
         case SimulationEventType.connected,
              SimulationEventType.disconnected,
@@ -498,10 +514,10 @@ public final class ChatRunStore: ObservableObject {
              SimulationEventType.error,
              SimulationEventType.simulationFeedbackContinueConversation,
              SimulationEventType.simulationHotwashContinueConversation:
-            break
+            return .ignored
 
         default:
-            break
+            return .ignored
         }
     }
 
@@ -557,10 +573,10 @@ public final class ChatRunStore: ObservableObject {
         }
     }
 
-    private func handleMessageCreated(_ payload: [String: JSONValue]) {
+    private func handleMessageCreated(_ payload: [String: JSONValue]) -> Bool {
         let serverID = int(payload, keys: ["message_id", "id"])
-        guard let serverID else { return }
-        guard !seenMessageIDs.contains(serverID) else { return }
+        guard let serverID else { return false }
+        guard !seenMessageIDs.contains(serverID) else { return false }
         seenMessageIDs.insert(serverID)
 
         let conversationID = int(payload, keys: ["conversation_id"]) ?? activeConversationID ?? 0
@@ -586,7 +602,7 @@ public final class ChatRunStore: ObservableObject {
                 status: status,
             ) {
                 if conversationID == activeConversationID {
-                    return
+                    return true
                 }
             }
         }
@@ -614,10 +630,11 @@ public final class ChatRunStore: ObservableObject {
         if conversationID == activeConversationID, !item.isFromSelf {
             markConversationRead(conversationID: conversationID)
         }
+        return true
     }
 
-    private func handleMessageStatusUpdate(_ payload: [String: JSONValue]) {
-        guard let serverID = int(payload, keys: ["id", "message_id"]) else { return }
+    private func handleMessageStatusUpdate(_ payload: [String: JSONValue]) -> Bool {
+        guard let serverID = int(payload, keys: ["id", "message_id"]) else { return false }
         let status = DeliveryStatus(rawValue: string(payload, keys: ["status"]) ?? "sent") ?? .sent
         let retryable = bool(payload, key: "retryable") ?? true
         let errorText = string(payload, keys: ["error_text"])
@@ -631,8 +648,9 @@ public final class ChatRunStore: ObservableObject {
             if status == .failed {
                 stopAwaitingReply(for: conversationID)
             }
-            break
+            return true
         }
+        return false
     }
 
     private func setTyping(_ payload: [String: JSONValue], started: Bool) {
@@ -828,13 +846,6 @@ public final class ChatRunStore: ObservableObject {
                     message: "Live updates are healthy again.",
                 )
                 pendingTransportRecovery = false
-                if previousState == .catchingUp {
-                    addLocalActivity(
-                        eventType: "chat.realtime.catchup.complete",
-                        title: "Catch-up Complete",
-                        message: "Missed updates were reconciled after reconnecting.",
-                    )
-                }
             } else if previousState != .connected, previousState != .connecting {
                 refreshAfterForegroundOrReconnect()
             }
@@ -850,19 +861,17 @@ public final class ChatRunStore: ObservableObject {
                 )
             }
 
-        case .catchingUp:
-            socketDisconnected = true
-            pendingTransportRecovery = true
-            if previousState != .catchingUp {
-                addLocalActivity(
-                    eventType: "chat.realtime.catching_up",
-                    title: "Syncing Missed Updates",
-                    message: "Replaying missed events before live updates resume.",
-                )
-            }
-
         case .connecting:
             socketDisconnected = true
+
+        case .staleCursor:
+            socketDisconnected = true
+            addLocalActivity(
+                eventType: "chat.realtime.stale_cursor",
+                title: "Realtime Re-Sync Required",
+                message: "Live cursor expired; reloading latest chat state.",
+            )
+            Task { await self.handleStaleCursorDetected() }
 
         case .disconnected:
             socketDisconnected = true
@@ -1056,14 +1065,73 @@ public final class ChatRunStore: ObservableObject {
             }
 
             if reconnectRealtime {
-                realtimeClient.disconnect()
-                await realtimeClient.connect(simulationID: simulation.id, cursor: nil)
+                reconnectRealtimeFromStoredCursor()
                 if trigger == .foregroundHealthCheck {
                     pendingTransportRecovery = true
                 }
             }
         } catch {
             presentableError = AppErrorPresenter.present(error)
+        }
+    }
+
+    private func bootstrapStateAndConnect(reason: String) async throws {
+        let list = try await service.listConversations(simulationID: simulation.id)
+        conversations = list.items
+        bootstrapCheckpointCursor = list.latestEventCursor
+        runStoreLogger.info("Bootstrap checkpoint received: \(list.latestEventCursor ?? "nil", privacy: .public)")
+
+        if activeConversationID == nil {
+            activeConversationID = conversations.first?.id
+        }
+
+        if let activeConversationID {
+            await loadInitialMessages(conversationID: activeConversationID)
+            markConversationRead(conversationID: activeConversationID)
+        }
+
+        startInitialAwaitingReplyIfNeeded()
+        let connectCursor = lastEventCursor ?? bootstrapCheckpointCursor
+        runStoreLogger.info("Connecting realtime (\(reason, privacy: .public)) with cursor \(connectCursor ?? "nil", privacy: .public)")
+        await realtimeClient.connect(simulationID: simulation.id, cursor: connectCursor)
+        await refreshGuardState()
+    }
+
+    private func reconnectRealtimeFromStoredCursor() {
+        let cursor = lastEventCursor ?? bootstrapCheckpointCursor
+        runStoreLogger.info("Reconnecting realtime with cursor \(cursor ?? "nil", privacy: .public)")
+        realtimeClient.disconnect()
+        Task {
+            await realtimeClient.connect(simulationID: simulation.id, cursor: cursor)
+        }
+    }
+
+    private func handleStaleCursorDetected() async {
+        guard !isRebootstrapping else { return }
+        isRebootstrapping = true
+        defer { isRebootstrapping = false }
+
+        runStoreLogger.warning("Stale cursor detected -> controlled re-bootstrap")
+        do {
+            try await bootstrapStateAndConnect(reason: "stale_cursor_rebootstrap")
+        } catch {
+            presentableError = AppErrorPresenter.present(error)
+        }
+    }
+
+    private func scheduleToolRefresh(reason: String) {
+        if toolRefreshTask != nil {
+            runStoreLogger.debug("Tool refresh coalesced for \(reason, privacy: .public)")
+            return
+        }
+        runStoreLogger.debug("Tool refresh requested for \(reason, privacy: .public)")
+        toolRefreshTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            await MainActor.run {
+                self?.toolRefreshToken = UUID()
+                self?.toolRefreshTask = nil
+                runStoreLogger.debug("Tool refresh token advanced")
+            }
         }
     }
 

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -379,10 +379,10 @@ public struct ChatRunView: View {
                 return "Checking"
             }
             return "Live"
-        case .catchingUp:
-            return "Catching Up"
         case .reconnecting:
             return "Recovering"
+        case .staleCursor:
+            return "Resyncing"
         case .connecting:
             return "Connecting"
         case .disconnected:
@@ -394,10 +394,10 @@ public struct ChatRunView: View {
         switch store.transportState {
         case .connected:
             "dot.radiowaves.left.and.right"
-        case .catchingUp:
-            "arrow.triangle.2.circlepath"
         case .reconnecting:
             "bolt.horizontal.circle"
+        case .staleCursor:
+            "arrow.clockwise.icloud"
         case .connecting:
             "hourglass"
         case .disconnected:
@@ -414,9 +414,9 @@ public struct ChatRunView: View {
                 return .orange
             }
             return .green
-        case .catchingUp:
-            return .blue
         case .reconnecting, .connecting:
+            return .orange
+        case .staleCursor:
             return .orange
         case .disconnected:
             return .secondary

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabContractTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabContractTests.swift
@@ -126,6 +126,17 @@ final class ChatLabContractTests: XCTestCase {
         XCTAssertEqual(simulation.retryable, true)
     }
 
+    func testConversationBootstrapDecodesLatestEventCheckpoint() throws {
+        let json = """
+        {
+          "items": [],
+          "latest_event_id": "evt-447"
+        }
+        """
+        let response = try JSONDecoder().decode(ChatConversationListResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(response.latestEventCursor, "evt-447")
+    }
+
     func testChatLabServiceUsesExpectedEndpoints() async throws {
         let api = ChatRecordingAPIClient()
         let service = ChatLabService(apiClient: api)

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -196,6 +196,7 @@ private final class TestRealtimeClient: ChatRealtimeClientProtocol, @unchecked S
     private let stateContinuation: AsyncStream<ChatRealtimeConnectionState>.Continuation
     private(set) var connectCalls = 0
     private(set) var disconnectCalls = 0
+    private(set) var connectCursors: [String?] = []
 
     init() {
         var eventCont: AsyncStream<ChatEventEnvelope>.Continuation!
@@ -212,8 +213,9 @@ private final class TestRealtimeClient: ChatRealtimeClientProtocol, @unchecked S
         stateContinuation = stateCont
     }
 
-    func connect(simulationID _: Int, cursor _: String?) async {
+    func connect(simulationID _: Int, cursor: String?) async {
         connectCalls += 1
+        connectCursors.append(cursor)
         stateContinuation.yield(.connected)
     }
 
@@ -910,6 +912,107 @@ final class ChatRunStoreTests: XCTestCase {
         try await waitUntil {
             store.lastEventCursor != nil && store.lastRealtimeSignalAt != nil
         }
+    }
+
+    func testBootstrapCheckpointCursorIsUsedForInitialConnect() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil)
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(
+            items: [patientConversation],
+            latestEventCursor: "evt-bootstrap-9",
+        )
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+
+        try await waitUntil {
+            realtime.connectCursors.first == "evt-bootstrap-9"
+        }
+    }
+
+    func testReconnectUsesLatestCommittedCursor() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil)
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation], latestEventCursor: "evt-bootstrap-1")
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+        realtime.pushEvent(makeEvent(type: SimulationEventType.feedbackGenerationFailed, payload: [
+            "error_text": .string("x"),
+            "retryable": .bool(true),
+        ]))
+        let committedCursor = store.lastEventCursor
+        store.reconnectRealtimeAndRefresh()
+
+        try await waitUntil { realtime.connectCursors.count >= 2 }
+        XCTAssertEqual(realtime.connectCursors.last!, committedCursor)
+    }
+
+    func testDuplicateMessageEventFastSkipsWithoutToolRefreshSpam() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil)
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        let initialToken = store.toolRefreshToken
+        let duplicatePayload: [String: JSONValue] = [
+            "id": .number(801),
+            "message_id": .number(801),
+            "conversation_id": .number(Double(patientConversation.id)),
+            "content": .string("same"),
+            "is_from_ai": .bool(true),
+            "display_name": .string(patientConversation.displayName),
+            "timestamp": .string(isoTimestamp()),
+            "delivery_status": .string("sent"),
+        ]
+        realtime.pushEvent(makeEvent(type: SimulationEventType.messageItemCreated, payload: duplicatePayload))
+        realtime.pushEvent(makeEvent(type: SimulationEventType.messageItemCreated, payload: duplicatePayload))
+
+        try await waitUntil {
+            (store.messagesByConversation[patientConversation.id] ?? []).count == 1
+        }
+        XCTAssertEqual(store.toolRefreshToken, initialToken)
+    }
+
+    func testStaleCursorStateTriggersRebootstrapAndReconnectFromFreshCheckpoint() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil)
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation], latestEventCursor: "evt-bootstrap-a")
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { realtime.connectCursors.first == "evt-bootstrap-a" }
+
+        service.conversations = ChatConversationListResponse(items: [patientConversation], latestEventCursor: "evt-bootstrap-b")
+        realtime.pushState(.staleCursor)
+
+        try await waitUntil { realtime.connectCursors.count >= 2 }
+        XCTAssertEqual(realtime.connectCursors.last!, "evt-bootstrap-b")
     }
 
     private func waitUntil(


### PR DESCRIPTION
### Motivation
- Bring ChatLab frontend realtime behavior into alignment with the SimWorks PR #447 contract (REST bootstrap first, backend-provided checkpoint, tail-only SSE, explicit replay, at-least-once delivery). 
- Simplify client logic by removing fallback/replay heuristics that compensated for ambiguous backend semantics. 
- Make reconnect and stale/pruned-cursor handling deterministic and cheap while reducing unnecessary tool refresh churn. 

### Description
- Decode and surface the backend bootstrap checkpoint by adding `latestEventCursor` to `ChatConversationListResponse` (decoded from `latest_event_id`, with compatibility aliases) and store it on bootstrap as `bootstrapCheckpointCursor` in `ChatRunStore`. 
- Change bootstrap/connect flow so REST bootstrap completes first, then SSE is opened using `lastEventCursor ?? bootstrapCheckpointCursor` (only nil when truly absent), and make that the single cursor authority used for initial connect and reconnect. 
- Simplify the SSE client by removing the REST catch-up replay path, retaining tail-following SSE with at-least-once delivery and cheap dedupe, and surface stale/pruned cursor HTTP statuses (409/410/422) as a `staleCursor` error/state. 
- Refactor event application in `ChatRunStore` into `applyEvent` with explicit outcomes, implement fast-skip duplicate handling, coalesced/debounced tool refresh scheduling, concise logs for cursor/duplicate/stale events, and a controlled re-bootstrap flow that runs when a stale cursor is detected. 

### Testing
- Ran `swift package dump-package` in `apps/chatlab-ios` which succeeded as a package sanity check. 
- Attempted `swift test` for `apps/chatlab-ios` but it failed in this environment due to a missing Apple `Security` module in the wider package graph (so unit tests could not be executed here). 
- `xcodebuild`-based iOS tests were not run because `xcodebuild` is not available in this environment. 
- Added/updated unit tests to cover the new contract expectations (bootstrap checkpoint decode and usage, reconnect-from-latest-committed-cursor, duplicate fast-skip behavior, stale-cursor re-bootstrap): `ChatLabContractTests.testConversationBootstrapDecodesLatestEventCheckpoint` and `ChatRunStoreTests` cases `testBootstrapCheckpointCursorIsUsedForInitialConnect`, `testReconnectUsesLatestCommittedCursor`, `testDuplicateMessageEventFastSkipsWithoutToolRefreshSpam`, and `testStaleCursorStateTriggersRebootstrapAndReconnectFromFreshCheckpoint`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d01034ed3c8333971100da570fb1f2)