### PR TITLE
feat(app-shell): add auth screen version info

### DIFF
--- a/apps/medsim-shell-ios/Sources/AppShell/AppBuildInfo.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppBuildInfo.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct AppBuildInfo: Equatable, Sendable {
+    let version: String
+    let build: String
+
+    init(
+        version: String,
+        build: String,
+    ) {
+        self.version = AppBuildInfo.resolveValue(version)
+        self.build = AppBuildInfo.resolveValue(build)
+    }
+
+    init(infoDictionary: [String: Any]?) {
+        version = AppBuildInfo.resolveValue(infoDictionary?["CFBundleShortVersionString"] as? String)
+        build = AppBuildInfo.resolveValue(infoDictionary?["CFBundleVersion"] as? String)
+    }
+
+    static func current(bundle: Bundle = .main) -> AppBuildInfo {
+        AppBuildInfo(infoDictionary: bundle.infoDictionary)
+    }
+
+    private static func resolveValue(_ value: String?) -> String {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "—" : trimmed
+    }
+}

--- a/apps/medsim-shell-ios/Sources/AppShell/AppBuildInfo.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppBuildInfo.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct AppBuildInfo: Equatable, Sendable {
+struct AppBuildInfo: Equatable {
     let version: String
     let build: String
 

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
@@ -38,6 +38,7 @@ public final class AppShellModel: ObservableObject {
     public let authViewModel: AuthViewModel
     public let accountSessionStore: AccountSessionStore
     public let billingService: AppleBillingService
+    public let buildInfoStore: BuildInfoStore
     public let sessionHubViewModel: SessionHubViewModel
     public let presetsViewModel: PresetsViewModel
 
@@ -45,6 +46,7 @@ public final class AppShellModel: ObservableObject {
     private let mutableBaseURLProvider: MutableBaseURLProvider
     private let selectedAccountContext: SelectedAccountContext
     private let apiClient: APIClient
+    private let buildInfoService: BuildInfoService
     private let trainerService: TrainerLabService
     private let chatService: ChatLabService
     private let chatMediaLoader: AuthenticatedChatMediaLoader
@@ -92,6 +94,13 @@ public final class AppShellModel: ObservableObject {
         billingService = AppleBillingService(
             apiClient: apiClient,
             accountSessionStore: accountSessionStore,
+        )
+
+        let buildInfoService = BuildInfoService(apiClient: apiClient)
+        self.buildInfoService = buildInfoService
+        buildInfoStore = BuildInfoStore(
+            buildInfoService: buildInfoService,
+            baseURLProvider: { mutableBaseURLProvider.currentURL() },
         )
 
         let commandQueue: CommandQueueStoreProtocol

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
@@ -83,7 +83,12 @@ public struct AppShellRootView: View {
                     onOpenEnvironmentSwitcher: {
                         showEnvironment = true
                     },
-                )
+                ) {
+                    AuthVersionInfoSection(store: model.buildInfoStore)
+                }
+                .task(id: model.environmentStore.baseURL.absoluteString) {
+                    await model.buildInfoStore.loadIfNeeded()
+                }
             }
         }
         .sheet(isPresented: $showEnvironment) {
@@ -109,6 +114,54 @@ public struct AppShellRootView: View {
                 showAccountBilling = false
             }
         }
+    }
+}
+
+private struct AuthVersionInfoSection: View {
+    @ObservedObject var store: BuildInfoStore
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $store.isExpanded) {
+            VStack(spacing: 8) {
+                ForEach(Array(store.displayRows.enumerated()), id: \.offset) { _, row in
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text(row.title)
+                            .foregroundStyle(.secondary)
+
+                        Spacer(minLength: 12)
+
+                        Text(row.value)
+                            .font(row.usesMonospacedValue ? .footnote.monospaced() : .footnote)
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.trailing)
+                            .textSelection(.enabled)
+                    }
+                    .font(.footnote)
+                }
+            }
+            .padding(.top, 6)
+        } label: {
+            HStack(spacing: 8) {
+                Text("Version Info")
+                    .font(.footnote.weight(.semibold))
+
+                Spacer()
+
+                if store.isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(TrainerLabTheme.setupSurface.opacity(0.72))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1),
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
 

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
@@ -80,12 +80,11 @@ public struct AppShellRootView: View {
                     appTitle: "MedSim",
                     appSubtitle: "TrainerLab + ChatLab",
                     environmentLabel: "Env: \(model.environmentStore.selection.rawValue) | \(model.environmentStore.baseURL.host() ?? "unknown")",
-                    onOpenEnvironmentSwitcher: {
-                        showEnvironment = true
+                    onOpenEnvironmentSwitcher: openEnvironmentSwitcher,
+                    footer: {
+                        AuthVersionInfoSection(store: model.buildInfoStore)
                     },
-                ) {
-                    AuthVersionInfoSection(store: model.buildInfoStore)
-                }
+                )
                 .task(id: model.environmentStore.baseURL.absoluteString) {
                     await model.buildInfoStore.loadIfNeeded()
                 }
@@ -114,6 +113,10 @@ public struct AppShellRootView: View {
                 showAccountBilling = false
             }
         }
+    }
+
+    private func openEnvironmentSwitcher() {
+        showEnvironment = true
     }
 }
 

--- a/apps/medsim-shell-ios/Sources/AppShell/BuildInfoStore.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/BuildInfoStore.swift
@@ -1,0 +1,115 @@
+import Combine
+import Foundation
+import Networking
+
+@MainActor
+public final class BuildInfoStore: ObservableObject {
+    public struct DisplayRow: Equatable, Sendable {
+        public let title: String
+        public let value: String
+        public let usesMonospacedValue: Bool
+
+        public init(
+            title: String,
+            value: String,
+            usesMonospacedValue: Bool = false,
+        ) {
+            self.title = title
+            self.value = value
+            self.usesMonospacedValue = usesMonospacedValue
+        }
+    }
+
+    @Published public var isExpanded = false
+    @Published public private(set) var isLoading = false
+    @Published public private(set) var remoteBuildInfo: BuildInfoResponse?
+    @Published public private(set) var loadFailed = false
+
+    private let buildInfoService: BuildInfoServiceProtocol
+    private let baseURLProvider: @Sendable () -> URL
+    private let appBuildInfo: AppBuildInfo
+    private var loadedBaseURL: String?
+    private var loadingBaseURL: String?
+
+    public init(
+        buildInfoService: BuildInfoServiceProtocol,
+        baseURLProvider: @escaping @Sendable () -> URL,
+    ) {
+        self.buildInfoService = buildInfoService
+        self.baseURLProvider = baseURLProvider
+        appBuildInfo = .current()
+    }
+
+    init(
+        buildInfoService: BuildInfoServiceProtocol,
+        baseURLProvider: @escaping @Sendable () -> URL,
+        appBuildInfo: AppBuildInfo = .current(),
+    ) {
+        self.buildInfoService = buildInfoService
+        self.baseURLProvider = baseURLProvider
+        self.appBuildInfo = appBuildInfo
+    }
+
+    public var displayRows: [DisplayRow] {
+        [
+            DisplayRow(title: "App Version", value: appBuildInfo.version),
+            DisplayRow(title: "App Build", value: appBuildInfo.build, usesMonospacedValue: true),
+            DisplayRow(title: "Backend Version", value: valueOrPlaceholder(remoteBuildInfo?.backend?.version)),
+            DisplayRow(
+                title: "Backend Commit",
+                value: shortenedCommit(remoteBuildInfo?.backend?.commit),
+                usesMonospacedValue: true,
+            ),
+            DisplayRow(
+                title: "Backend Build",
+                value: valueOrPlaceholder(remoteBuildInfo?.backend?.buildTime),
+                usesMonospacedValue: true,
+            ),
+            DisplayRow(title: "OrchestrAI", value: valueOrPlaceholder(remoteBuildInfo?.orchestrai?.version)),
+        ]
+    }
+
+    public func loadIfNeeded() async {
+        let baseURL = baseURLProvider().absoluteString
+        if loadedBaseURL == baseURL || loadingBaseURL == baseURL {
+            return
+        }
+
+        if loadedBaseURL != baseURL {
+            remoteBuildInfo = nil
+            loadFailed = false
+        }
+
+        loadingBaseURL = baseURL
+        isLoading = true
+
+        do {
+            let buildInfo = try await buildInfoService.fetchBuildInfo()
+            guard loadingBaseURL == baseURL else { return }
+            remoteBuildInfo = buildInfo
+            loadedBaseURL = baseURL
+            loadFailed = false
+        } catch {
+            guard loadingBaseURL == baseURL else { return }
+            remoteBuildInfo = nil
+            loadedBaseURL = nil
+            loadFailed = true
+        }
+
+        if loadingBaseURL == baseURL {
+            loadingBaseURL = nil
+            isLoading = false
+        }
+    }
+
+    private func valueOrPlaceholder(_ value: String?) -> String {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "—" : trimmed
+    }
+
+    private func shortenedCommit(_ commit: String?) -> String {
+        let trimmed = valueOrPlaceholder(commit)
+        guard trimmed != "—" else { return trimmed }
+        return trimmed.count > 7 ? String(trimmed.prefix(7)) : trimmed
+    }
+}

--- a/apps/medsim-shell-ios/Tests/AppShellTests/BuildInfoStoreTests.swift
+++ b/apps/medsim-shell-ios/Tests/AppShellTests/BuildInfoStoreTests.swift
@@ -43,6 +43,10 @@ private final class URLBox: @unchecked Sendable {
     }
 }
 
+private func makeURL(_ value: String, file: StaticString = #filePath, line: UInt = #line) throws -> URL {
+    try XCTUnwrap(URL(string: value), file: file, line: line)
+}
+
 final class AppBuildInfoTests: XCTestCase {
     func testInitFromInfoDictionaryResolvesValues() {
         let buildInfo = AppBuildInfo(
@@ -71,7 +75,8 @@ final class AppBuildInfoTests: XCTestCase {
 
 @MainActor
 final class BuildInfoStoreTests: XCTestCase {
-    func testLoadIfNeededPopulatesRemoteBuildInfoOnSuccess() async {
+    func testLoadIfNeededPopulatesRemoteBuildInfoOnSuccess() async throws {
+        let exampleURL = try makeURL("https://example.com")
         let service = MockBuildInfoService()
         service.results = [
             .success(
@@ -87,7 +92,7 @@ final class BuildInfoStoreTests: XCTestCase {
         ]
         let store = BuildInfoStore(
             buildInfoService: service,
-            baseURLProvider: { URL(string: "https://example.com")! },
+            baseURLProvider: { exampleURL },
             appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
         )
 
@@ -109,12 +114,13 @@ final class BuildInfoStoreTests: XCTestCase {
         XCTAssertEqual(service.fetchCount, 1)
     }
 
-    func testLoadIfNeededMarksFailureWithoutBlockingLocalRows() async {
+    func testLoadIfNeededMarksFailureWithoutBlockingLocalRows() async throws {
+        let exampleURL = try makeURL("https://example.com")
         let service = MockBuildInfoService()
         service.results = [.failure(MockBuildInfoError.failed)]
         let store = BuildInfoStore(
             buildInfoService: service,
-            baseURLProvider: { URL(string: "https://example.com")! },
+            baseURLProvider: { exampleURL },
             appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
         )
 
@@ -133,10 +139,11 @@ final class BuildInfoStoreTests: XCTestCase {
         ])
     }
 
-    func testDisclosureStateCanToggle() {
+    func testDisclosureStateCanToggle() throws {
+        let exampleURL = try makeURL("https://example.com")
         let store = BuildInfoStore(
             buildInfoService: MockBuildInfoService(),
-            baseURLProvider: { URL(string: "https://example.com")! },
+            baseURLProvider: { exampleURL },
             appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
         )
 
@@ -145,10 +152,11 @@ final class BuildInfoStoreTests: XCTestCase {
         XCTAssertTrue(store.isExpanded)
     }
 
-    func testDisplayRowsStayStableWhenBackendValuesAreMissing() {
+    func testDisplayRowsStayStableWhenBackendValuesAreMissing() throws {
+        let exampleURL = try makeURL("https://example.com")
         let store = BuildInfoStore(
             buildInfoService: MockBuildInfoService(),
-            baseURLProvider: { URL(string: "https://example.com")! },
+            baseURLProvider: { exampleURL },
             appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
         )
 
@@ -170,7 +178,7 @@ final class BuildInfoStoreTests: XCTestCase {
         ])
     }
 
-    func testChangingBaseURLClearsStaleRowsAndFetchesAgain() async {
+    func testChangingBaseURLClearsStaleRowsAndFetchesAgain() async throws {
         let service = MockBuildInfoService()
         service.results = [
             .success(
@@ -194,7 +202,8 @@ final class BuildInfoStoreTests: XCTestCase {
                 ),
             ),
         ]
-        let urlBox = URLBox(url: URL(string: "https://one.example.com")!)
+        let initialURL = try makeURL("https://one.example.com")
+        let urlBox = URLBox(url: initialURL)
         let store = BuildInfoStore(
             buildInfoService: service,
             baseURLProvider: { urlBox.url },
@@ -205,7 +214,8 @@ final class BuildInfoStoreTests: XCTestCase {
         XCTAssertEqual(store.displayRows[2].value, "0.14.2")
 
         service.suspendNextFetch = true
-        urlBox.url = URL(string: "https://two.example.com")!
+        let updatedURL = try makeURL("https://two.example.com")
+        urlBox.url = updatedURL
 
         let loadTask = Task {
             await store.loadIfNeeded()

--- a/apps/medsim-shell-ios/Tests/AppShellTests/BuildInfoStoreTests.swift
+++ b/apps/medsim-shell-ios/Tests/AppShellTests/BuildInfoStoreTests.swift
@@ -1,0 +1,234 @@
+@testable import AppShell
+import Foundation
+import Networking
+import XCTest
+
+private enum MockBuildInfoError: Error {
+    case failed
+}
+
+private final class MockBuildInfoService: BuildInfoServiceProtocol, @unchecked Sendable {
+    var results: [Result<BuildInfoResponse, Error>] = []
+    var fetchCount = 0
+    var suspendNextFetch = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func fetchBuildInfo() async throws -> BuildInfoResponse {
+        fetchCount += 1
+
+        if suspendNextFetch {
+            suspendNextFetch = false
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        guard !results.isEmpty else {
+            throw MockBuildInfoError.failed
+        }
+        return try results.removeFirst().get()
+    }
+
+    func resumeFetch() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private final class URLBox: @unchecked Sendable {
+    var url: URL
+
+    init(url: URL) {
+        self.url = url
+    }
+}
+
+final class AppBuildInfoTests: XCTestCase {
+    func testInitFromInfoDictionaryResolvesValues() {
+        let buildInfo = AppBuildInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "1.2.3",
+                "CFBundleVersion": "45",
+            ],
+        )
+
+        XCTAssertEqual(buildInfo.version, "1.2.3")
+        XCTAssertEqual(buildInfo.build, "45")
+    }
+
+    func testInitFromInfoDictionaryFallsBackSafely() {
+        let buildInfo = AppBuildInfo(
+            infoDictionary: [
+                "CFBundleShortVersionString": "   ",
+                "CFBundleVersion": "",
+            ],
+        )
+
+        XCTAssertEqual(buildInfo.version, "—")
+        XCTAssertEqual(buildInfo.build, "—")
+    }
+}
+
+@MainActor
+final class BuildInfoStoreTests: XCTestCase {
+    func testLoadIfNeededPopulatesRemoteBuildInfoOnSuccess() async {
+        let service = MockBuildInfoService()
+        service.results = [
+            .success(
+                BuildInfoResponse(
+                    backend: BackendBuildInfo(
+                        version: "0.14.2",
+                        commit: "abc1234def5678",
+                        buildTime: "2026-04-09T17:12:44Z",
+                    ),
+                    orchestrai: OrchestraiBuildInfo(version: "1.9.0"),
+                ),
+            ),
+        ]
+        let store = BuildInfoStore(
+            buildInfoService: service,
+            baseURLProvider: { URL(string: "https://example.com")! },
+            appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
+        )
+
+        await store.loadIfNeeded()
+
+        XCTAssertFalse(store.isLoading)
+        XCTAssertFalse(store.loadFailed)
+        XCTAssertEqual(store.remoteBuildInfo?.backend?.version, "0.14.2")
+        XCTAssertEqual(store.remoteBuildInfo?.backend?.commit, "abc1234def5678")
+        XCTAssertEqual(store.remoteBuildInfo?.orchestrai?.version, "1.9.0")
+        XCTAssertEqual(store.displayRows.map(\.value), [
+            "2.0.0",
+            "88",
+            "0.14.2",
+            "abc1234",
+            "2026-04-09T17:12:44Z",
+            "1.9.0",
+        ])
+        XCTAssertEqual(service.fetchCount, 1)
+    }
+
+    func testLoadIfNeededMarksFailureWithoutBlockingLocalRows() async {
+        let service = MockBuildInfoService()
+        service.results = [.failure(MockBuildInfoError.failed)]
+        let store = BuildInfoStore(
+            buildInfoService: service,
+            baseURLProvider: { URL(string: "https://example.com")! },
+            appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
+        )
+
+        await store.loadIfNeeded()
+
+        XCTAssertFalse(store.isLoading)
+        XCTAssertTrue(store.loadFailed)
+        XCTAssertNil(store.remoteBuildInfo)
+        XCTAssertEqual(store.displayRows.map(\.value), [
+            "2.0.0",
+            "88",
+            "—",
+            "—",
+            "—",
+            "—",
+        ])
+    }
+
+    func testDisclosureStateCanToggle() {
+        let store = BuildInfoStore(
+            buildInfoService: MockBuildInfoService(),
+            baseURLProvider: { URL(string: "https://example.com")! },
+            appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
+        )
+
+        XCTAssertFalse(store.isExpanded)
+        store.isExpanded.toggle()
+        XCTAssertTrue(store.isExpanded)
+    }
+
+    func testDisplayRowsStayStableWhenBackendValuesAreMissing() {
+        let store = BuildInfoStore(
+            buildInfoService: MockBuildInfoService(),
+            baseURLProvider: { URL(string: "https://example.com")! },
+            appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
+        )
+
+        XCTAssertEqual(store.displayRows.map(\.title), [
+            "App Version",
+            "App Build",
+            "Backend Version",
+            "Backend Commit",
+            "Backend Build",
+            "OrchestrAI",
+        ])
+        XCTAssertEqual(store.displayRows.map(\.value), [
+            "2.0.0",
+            "88",
+            "—",
+            "—",
+            "—",
+            "—",
+        ])
+    }
+
+    func testChangingBaseURLClearsStaleRowsAndFetchesAgain() async {
+        let service = MockBuildInfoService()
+        service.results = [
+            .success(
+                BuildInfoResponse(
+                    backend: BackendBuildInfo(
+                        version: "0.14.2",
+                        commit: "abc1234def5678",
+                        buildTime: "2026-04-09T17:12:44Z",
+                    ),
+                    orchestrai: OrchestraiBuildInfo(version: "1.9.0"),
+                ),
+            ),
+            .success(
+                BuildInfoResponse(
+                    backend: BackendBuildInfo(
+                        version: "0.15.0",
+                        commit: "def5678abc1234",
+                        buildTime: "2026-04-10T07:30:00Z",
+                    ),
+                    orchestrai: OrchestraiBuildInfo(version: "1.10.0"),
+                ),
+            ),
+        ]
+        let urlBox = URLBox(url: URL(string: "https://one.example.com")!)
+        let store = BuildInfoStore(
+            buildInfoService: service,
+            baseURLProvider: { urlBox.url },
+            appBuildInfo: AppBuildInfo(version: "2.0.0", build: "88"),
+        )
+
+        await store.loadIfNeeded()
+        XCTAssertEqual(store.displayRows[2].value, "0.14.2")
+
+        service.suspendNextFetch = true
+        urlBox.url = URL(string: "https://two.example.com")!
+
+        let loadTask = Task {
+            await store.loadIfNeeded()
+        }
+        await Task.yield()
+
+        XCTAssertTrue(store.isLoading)
+        XCTAssertNil(store.remoteBuildInfo)
+        XCTAssertEqual(store.displayRows[2].value, "—")
+
+        service.resumeFetch()
+        await loadTask.value
+
+        XCTAssertFalse(store.isLoading)
+        XCTAssertFalse(store.loadFailed)
+        XCTAssertEqual(store.displayRows.map(\.value), [
+            "2.0.0",
+            "88",
+            "0.15.0",
+            "def5678",
+            "2026-04-10T07:30:00Z",
+            "1.10.0",
+        ])
+        XCTAssertEqual(service.fetchCount, 2)
+    }
+}

--- a/apps/trainerlab-ios/Package.swift
+++ b/apps/trainerlab-ios/Package.swift
@@ -52,6 +52,8 @@ let package = Package(
                 "AccountSessionStore.swift",
                 "AppleBillingService.swift",
                 "AuthService.swift",
+                "BuildInfoModels.swift",
+                "BuildInfoService.swift",
                 "DecodingDiagnostics.swift",
                 "EnvironmentStore.swift",
                 "MutableBaseURLProvider.swift",

--- a/apps/trainerlab-ios/Sources/Auth/AuthGateView.swift
+++ b/apps/trainerlab-ios/Sources/Auth/AuthGateView.swift
@@ -1,7 +1,7 @@
 import DesignSystem
 import SwiftUI
 
-public struct AuthGateView: View {
+public struct AuthGateView<Footer: View>: View {
     private enum Field: Hashable {
         case email
         case password
@@ -12,6 +12,7 @@ public struct AuthGateView: View {
     private let appSubtitle: String
     private let environmentLabel: String
     private let onOpenEnvironmentSwitcher: () -> Void
+    private let footer: Footer
     @FocusState private var focusedField: Field?
 
     public init(
@@ -20,12 +21,14 @@ public struct AuthGateView: View {
         appSubtitle: String = "Instructor Console",
         environmentLabel: String,
         onOpenEnvironmentSwitcher: @escaping () -> Void,
+        @ViewBuilder footer: () -> Footer,
     ) {
         self.viewModel = viewModel
         self.appTitle = appTitle
         self.appSubtitle = appSubtitle
         self.environmentLabel = environmentLabel
         self.onOpenEnvironmentSwitcher = onOpenEnvironmentSwitcher
+        self.footer = footer()
     }
 
     public var body: some View {
@@ -92,6 +95,9 @@ public struct AuthGateView: View {
                 .trainerCardStyle(background: TrainerLabTheme.setupSurface)
                 .frame(maxWidth: 460)
 
+                footer
+                    .frame(maxWidth: 460)
+
                 Text(environmentLabel)
                     .font(.footnote.monospaced())
                     .foregroundStyle(.secondary)
@@ -150,6 +156,26 @@ public struct AuthGateView: View {
             focusedField = .email
         default:
             focusedField = .email
+        }
+    }
+}
+
+public extension AuthGateView where Footer == EmptyView {
+    init(
+        viewModel: AuthViewModel,
+        appTitle: String = "TrainerLab",
+        appSubtitle: String = "Instructor Console",
+        environmentLabel: String,
+        onOpenEnvironmentSwitcher: @escaping () -> Void,
+    ) {
+        self.init(
+            viewModel: viewModel,
+            appTitle: appTitle,
+            appSubtitle: appSubtitle,
+            environmentLabel: environmentLabel,
+            onOpenEnvironmentSwitcher: onOpenEnvironmentSwitcher,
+        ) {
+            EmptyView()
         }
     }
 }

--- a/apps/trainerlab-ios/Sources/Networking/APIClient.swift
+++ b/apps/trainerlab-ios/Sources/Networking/APIClient.swift
@@ -220,6 +220,16 @@ public enum BillingAPI {
     }
 }
 
+public enum SystemAPI {
+    public static func buildInfo() -> Endpoint {
+        Endpoint(
+            path: "/api/v1/build-info/",
+            requiresAuth: false,
+            requiresAccountContext: false,
+        )
+    }
+}
+
 public enum TrainerLabAPI {
     public static func accessMe() -> Endpoint {
         Endpoint(path: "/api/v1/trainerlab/access/me/")

--- a/apps/trainerlab-ios/Sources/Networking/BuildInfoModels.swift
+++ b/apps/trainerlab-ios/Sources/Networking/BuildInfoModels.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+public struct BuildInfoResponse: Decodable, Sendable {
+    public let backend: BackendBuildInfo?
+    public let orchestrai: OrchestraiBuildInfo?
+
+    public init(
+        backend: BackendBuildInfo?,
+        orchestrai: OrchestraiBuildInfo?,
+    ) {
+        self.backend = backend
+        self.orchestrai = orchestrai
+    }
+}
+
+public struct BackendBuildInfo: Decodable, Sendable {
+    public let version: String?
+    public let commit: String?
+    public let buildTime: String?
+
+    public init(
+        version: String?,
+        commit: String?,
+        buildTime: String?,
+    ) {
+        self.version = version
+        self.commit = commit
+        self.buildTime = buildTime
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case commit
+        case buildTime = "build_time"
+    }
+}
+
+public struct OrchestraiBuildInfo: Decodable, Sendable {
+    public let version: String?
+
+    public init(version: String?) {
+        self.version = version
+    }
+}

--- a/apps/trainerlab-ios/Sources/Networking/BuildInfoService.swift
+++ b/apps/trainerlab-ios/Sources/Networking/BuildInfoService.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public protocol BuildInfoServiceProtocol: Sendable {
+    func fetchBuildInfo() async throws -> BuildInfoResponse
+}
+
+public struct BuildInfoService: BuildInfoServiceProtocol {
+    private let apiClient: APIClientProtocol
+
+    public init(apiClient: APIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    public func fetchBuildInfo() async throws -> BuildInfoResponse {
+        try await apiClient.request(SystemAPI.buildInfo(), as: BuildInfoResponse.self)
+    }
+}

--- a/apps/trainerlab-ios/Tests/NetworkingTests/BuildInfoTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/BuildInfoTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+@testable import Networking
+import XCTest
+
+final class BuildInfoResponseTests: XCTestCase {
+    func testDecodesBuildInfoResponse() throws {
+        let json = Data(
+            #"""
+            {
+              "backend": {
+                "version": "0.14.2",
+                "commit": "abc1234def5678",
+                "build_time": "2026-04-09T17:12:44Z"
+              },
+              "orchestrai": {
+                "version": "1.9.0"
+              }
+            }
+            """#.utf8,
+        )
+
+        let response = try JSONDecoder().decode(BuildInfoResponse.self, from: json)
+
+        XCTAssertEqual(response.backend?.version, "0.14.2")
+        XCTAssertEqual(response.backend?.commit, "abc1234def5678")
+        XCTAssertEqual(response.backend?.buildTime, "2026-04-09T17:12:44Z")
+        XCTAssertEqual(response.orchestrai?.version, "1.9.0")
+    }
+
+    func testDecodesNullBuildInfoSections() throws {
+        let json = Data(#"{"backend":null,"orchestrai":null}"#.utf8)
+
+        let response = try JSONDecoder().decode(BuildInfoResponse.self, from: json)
+
+        XCTAssertNil(response.backend)
+        XCTAssertNil(response.orchestrai)
+    }
+
+    func testDecodesNullBuildInfoFields() throws {
+        let json = Data(
+            #"""
+            {
+              "backend": {
+                "version": null,
+                "commit": null,
+                "build_time": null
+              },
+              "orchestrai": {
+                "version": null
+              }
+            }
+            """#.utf8,
+        )
+
+        let response = try JSONDecoder().decode(BuildInfoResponse.self, from: json)
+
+        XCTAssertNil(response.backend?.version)
+        XCTAssertNil(response.backend?.commit)
+        XCTAssertNil(response.backend?.buildTime)
+        XCTAssertNil(response.orchestrai?.version)
+    }
+
+    func testSystemAPIBuildInfoRouteUsesExpectedContract() {
+        let endpoint = SystemAPI.buildInfo()
+
+        XCTAssertEqual(endpoint.path, "/api/v1/build-info/")
+        XCTAssertEqual(endpoint.method, .get)
+        XCTAssertFalse(endpoint.requiresAuth)
+        XCTAssertFalse(endpoint.requiresAccountContext)
+    }
+}


### PR DESCRIPTION
## Summary
- add typed networking support for `/api/v1/build-info/` with a dedicated service and route helper
- add an app-shell build info store that combines local app metadata with backend build metadata
- render a collapsible Version Info section on the unauthenticated auth screen via an injected Auth footer slot
- keep build info loading non-blocking and refresh it when the selected environment base URL changes

## Testing
- `swift test --package-path apps/trainerlab-ios --filter BuildInfo`
- `swift test --package-path apps/medsim-shell-ios --filter BuildInfo`