### PR TITLE
fix(chatlab-ios): keep patient lab results flat in tool state

### DIFF
--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatPatientResults.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatPatientResults.swift
@@ -1,0 +1,97 @@
+import Foundation
+import SharedModels
+
+struct ChatPatientResult: Codable, Equatable, Sendable {
+    let rawRow: [String: JSONValue]
+
+    init(rawRow: [String: JSONValue]) {
+        self.rawRow = rawRow
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        rawRow = try container.decode([String: JSONValue].self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawRow)
+    }
+
+    var id: JSONValue? { rawRow["id"] }
+    var resultName: String? { rawRow.stringValue(forKey: "result_name") }
+    var panelName: String? { rawRow.nonEmptyString(forKey: "panel_name") }
+    var value: JSONValue? { rawRow["value"] }
+    var unit: String? { rawRow.nonEmptyString(forKey: "unit") }
+    var referenceRangeLow: JSONValue? { rawRow["reference_range_low"] }
+    var referenceRangeHigh: JSONValue? { rawRow["reference_range_high"] }
+    var flag: String? { rawRow.nonEmptyString(forKey: "flag") }
+    var attribute: String? { rawRow.nonEmptyString(forKey: "attribute") }
+    var type: String? { rawRow.nonEmptyString(forKey: "type") }
+
+    var displayName: String {
+        let trimmed = resultName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "Result" : trimmed
+    }
+
+    var stableIdentifier: String {
+        if let id {
+            return ChatToolValueFormatter.render(id)
+        }
+
+        let panel = panelName ?? "standalone"
+        return "\(panel)|\(displayName)|\(rawRow.count)"
+    }
+}
+
+struct ChatPatientResultSection: Equatable, Sendable {
+    let panelName: String?
+    var rows: [ChatPatientResult]
+}
+
+enum ChatPatientResultsPresentation {
+    static func sections(from results: [ChatPatientResult]) -> [ChatPatientResultSection] {
+        var sections: [ChatPatientResultSection] = []
+        var panelIndexByName: [String: Int] = [:]
+
+        for result in results {
+            if let panelName = result.panelName {
+                if let index = panelIndexByName[panelName] {
+                    sections[index].rows.append(result)
+                } else {
+                    panelIndexByName[panelName] = sections.count
+                    sections.append(ChatPatientResultSection(panelName: panelName, rows: [result]))
+                }
+            } else {
+                sections.append(ChatPatientResultSection(panelName: nil, rows: [result]))
+            }
+        }
+
+        return sections
+    }
+}
+
+extension ChatToolState {
+    var patientResults: [ChatPatientResult] {
+        data.map(ChatPatientResult.init(rawRow:))
+    }
+}
+
+private extension Dictionary where Key == String, Value == JSONValue {
+    func stringValue(forKey key: String) -> String? {
+        guard case let .string(text) = self[key] else {
+            return nil
+        }
+        return text
+    }
+
+    func nonEmptyString(forKey key: String) -> String? {
+        guard let text = stringValue(forKey: key)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !text.isEmpty
+        else {
+            return nil
+        }
+        return text
+    }
+}

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatPatientResults.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatPatientResults.swift
@@ -1,33 +1,33 @@
 import Foundation
 import SharedModels
 
-struct ChatPatientResult: Codable, Equatable, Sendable {
-    let rawRow: [String: JSONValue]
+public struct ChatPatientResult: Codable, Equatable, Sendable {
+    public let rawRow: [String: JSONValue]
 
     init(rawRow: [String: JSONValue]) {
         self.rawRow = rawRow
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         rawRow = try container.decode([String: JSONValue].self)
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(rawRow)
     }
 
-    var id: JSONValue? { rawRow["id"] }
-    var resultName: String? { rawRow.stringValue(forKey: "result_name") }
-    var panelName: String? { rawRow.nonEmptyString(forKey: "panel_name") }
-    var value: JSONValue? { rawRow["value"] }
-    var unit: String? { rawRow.nonEmptyString(forKey: "unit") }
-    var referenceRangeLow: JSONValue? { rawRow["reference_range_low"] }
-    var referenceRangeHigh: JSONValue? { rawRow["reference_range_high"] }
-    var flag: String? { rawRow.nonEmptyString(forKey: "flag") }
-    var attribute: String? { rawRow.nonEmptyString(forKey: "attribute") }
-    var type: String? { rawRow.nonEmptyString(forKey: "type") }
+    public var id: JSONValue? { rawRow["id"] }
+    public var resultName: String? { rawRow.stringValue(forKey: "result_name") }
+    public var panelName: String? { rawRow.nonEmptyString(forKey: "panel_name") }
+    public var value: JSONValue? { rawRow["value"] }
+    public var unit: String? { rawRow.nonEmptyString(forKey: "unit") }
+    public var referenceRangeLow: JSONValue? { rawRow["reference_range_low"] }
+    public var referenceRangeHigh: JSONValue? { rawRow["reference_range_high"] }
+    public var flag: String? { rawRow.nonEmptyString(forKey: "flag") }
+    public var attribute: String? { rawRow.nonEmptyString(forKey: "attribute") }
+    public var type: String? { rawRow.nonEmptyString(forKey: "type") }
 
     var displayName: String {
         let trimmed = resultName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatPatientResults.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatPatientResults.swift
@@ -18,16 +18,45 @@ public struct ChatPatientResult: Codable, Equatable, Sendable {
         try container.encode(rawRow)
     }
 
-    public var id: JSONValue? { rawRow["id"] }
-    public var resultName: String? { rawRow.stringValue(forKey: "result_name") }
-    public var panelName: String? { rawRow.nonEmptyString(forKey: "panel_name") }
-    public var value: JSONValue? { rawRow["value"] }
-    public var unit: String? { rawRow.nonEmptyString(forKey: "unit") }
-    public var referenceRangeLow: JSONValue? { rawRow["reference_range_low"] }
-    public var referenceRangeHigh: JSONValue? { rawRow["reference_range_high"] }
-    public var flag: String? { rawRow.nonEmptyString(forKey: "flag") }
-    public var attribute: String? { rawRow.nonEmptyString(forKey: "attribute") }
-    public var type: String? { rawRow.nonEmptyString(forKey: "type") }
+    public var id: JSONValue? {
+        rawRow["id"]
+    }
+
+    public var resultName: String? {
+        rawRow.stringValue(forKey: "result_name")
+    }
+
+    public var panelName: String? {
+        rawRow.nonEmptyString(forKey: "panel_name")
+    }
+
+    public var value: JSONValue? {
+        rawRow["value"]
+    }
+
+    public var unit: String? {
+        rawRow.nonEmptyString(forKey: "unit")
+    }
+
+    public var referenceRangeLow: JSONValue? {
+        rawRow["reference_range_low"]
+    }
+
+    public var referenceRangeHigh: JSONValue? {
+        rawRow["reference_range_high"]
+    }
+
+    public var flag: String? {
+        rawRow.nonEmptyString(forKey: "flag")
+    }
+
+    public var attribute: String? {
+        rawRow.nonEmptyString(forKey: "attribute")
+    }
+
+    public var type: String? {
+        rawRow.nonEmptyString(forKey: "type")
+    }
 
     var displayName: String {
         let trimmed = resultName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -44,7 +73,7 @@ public struct ChatPatientResult: Codable, Equatable, Sendable {
     }
 }
 
-struct ChatPatientResultSection: Equatable, Sendable {
+struct ChatPatientResultSection: Equatable {
     let panelName: String?
     var rows: [ChatPatientResult]
 }
@@ -77,7 +106,7 @@ extension ChatToolState {
     }
 }
 
-private extension Dictionary where Key == String, Value == JSONValue {
+private extension [String: JSONValue] {
     func stringValue(forKey key: String) -> String? {
         guard case let .string(text) = self[key] else {
             return nil

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -717,7 +717,7 @@ public struct ChatRunView: View {
                     PatientHistoryRows(rows: toolsStore.toolData("patient_history"))
                 }
                 toolSection(.patientResults, layoutMode: layoutMode) {
-                    ToolDataRows(rows: toolsStore.toolData("patient_results"))
+                    PatientResultsRows(results: toolsStore.patientResults)
                 }
                 if simulationHasEnded {
                     toolSection(.simulationFeedback, layoutMode: layoutMode) {
@@ -1370,6 +1370,106 @@ private struct ToolDataRows: View {
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }
             }
+        }
+    }
+}
+
+private struct PatientResultsRows: View {
+    let results: [ChatPatientResult]
+
+    private var sections: [ChatPatientResultSection] {
+        ChatPatientResultsPresentation.sections(from: results)
+    }
+
+    var body: some View {
+        if results.isEmpty {
+            Text("No data yet")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
+                    VStack(alignment: .leading, spacing: 8) {
+                        if let panelName = section.panelName {
+                            Text(panelName)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                        }
+
+                        ForEach(Array(section.rows.enumerated()), id: \.offset) { _, result in
+                            PatientResultRow(result: result)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct PatientResultRow: View {
+    let result: ChatPatientResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(result.displayName)
+                    .font(.subheadline.weight(.semibold))
+                Spacer(minLength: 12)
+                Text(valueText)
+                    .font(.headline.monospacedDigit())
+                    .multilineTextAlignment(.trailing)
+            }
+
+            if !metadataLine.isEmpty {
+                Text(metadataLine)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let referenceRangeText {
+                Text("Reference: \(referenceRangeText)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(Color.secondary.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private var valueText: String {
+        let renderedValue = result.value.map(ChatToolValueFormatter.render) ?? "-"
+        if let unit = result.unit, renderedValue != "-" {
+            return "\(renderedValue) \(unit)"
+        }
+        return renderedValue
+    }
+
+    private var metadataLine: String {
+        [result.attribute, result.flag, result.type]
+            .compactMap { value in
+                guard let value, !value.isEmpty else {
+                    return nil
+                }
+                return value
+            }
+            .joined(separator: " • ")
+    }
+
+    private var referenceRangeText: String? {
+        let low = result.referenceRangeLow.map(ChatToolValueFormatter.render)
+        let high = result.referenceRangeHigh.map(ChatToolValueFormatter.render)
+
+        switch (low, high) {
+        case let (.some(low), .some(high)):
+            return "\(low) - \(high)"
+        case let (.some(low), nil):
+            return ">= \(low)"
+        case let (nil, .some(high)):
+            return "<= \(high)"
+        case (nil, nil):
+            return nil
         }
     }
 }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatToolsStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatToolsStore.swift
@@ -5,6 +5,7 @@ import SharedModels
 @MainActor
 public final class ChatToolsStore: ObservableObject {
     @Published public private(set) var toolsByName: [String: ChatToolState] = [:]
+    @Published public private(set) var patientResults: [ChatPatientResult] = []
     @Published public private(set) var isLoading = false
     @Published public private(set) var isSubmittingOrders = false
     @Published public private(set) var presentableError: PresentableAppError?
@@ -28,7 +29,7 @@ public final class ChatToolsStore: ObservableObject {
         defer { isLoading = false }
         do {
             let response = try await service.listTools(simulationID: simulationID, names: nil)
-            toolsByName = Dictionary(uniqueKeysWithValues: response.items.map { ($0.name, $0) })
+            apply(response.items)
         } catch {
             presentableError = AppErrorPresenter.present(error)
         }
@@ -37,7 +38,7 @@ public final class ChatToolsStore: ObservableObject {
     public func refreshTools() async {
         do {
             let response = try await service.listTools(simulationID: simulationID, names: nil)
-            toolsByName = Dictionary(uniqueKeysWithValues: response.items.map { ($0.name, $0) })
+            apply(response.items)
         } catch {
             presentableError = AppErrorPresenter.present(error)
         }
@@ -76,5 +77,11 @@ public final class ChatToolsStore: ObservableObject {
 
     public func toolData(_ name: String) -> [[String: JSONValue]] {
         toolsByName[name]?.data ?? []
+    }
+
+    private func apply(_ tools: [ChatToolState]) {
+        let normalized = Dictionary(uniqueKeysWithValues: tools.map { ($0.name, $0) })
+        toolsByName = normalized
+        patientResults = normalized["patient_results"]?.patientResults ?? []
     }
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatPatientResultsTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatPatientResultsTests.swift
@@ -1,0 +1,289 @@
+@testable import ChatLabiOS
+import Foundation
+import Networking
+import SharedModels
+import XCTest
+
+private final class PatientResultsService: ChatLabServiceProtocol, @unchecked Sendable {
+    var toolItems: [ChatToolState] = []
+
+    func listSimulations(
+        limit _: Int,
+        cursor _: String?,
+        status _: String?,
+        query _: String?,
+        searchMessages _: Bool,
+    ) async throws -> PaginatedResponse<ChatSimulation> {
+        fatalError("unused")
+    }
+
+    func quickCreateSimulation(request _: ChatQuickCreateRequest) async throws -> ChatSimulation {
+        fatalError("unused")
+    }
+
+    func getSimulation(simulationID _: Int) async throws -> ChatSimulation {
+        fatalError("unused")
+    }
+
+    func endSimulation(simulationID _: Int) async throws -> ChatSimulation {
+        fatalError("unused")
+    }
+
+    func retryInitial(simulationID _: Int) async throws -> ChatSimulation {
+        fatalError("unused")
+    }
+
+    func retryFeedback(simulationID _: Int) async throws -> ChatSimulation {
+        fatalError("unused")
+    }
+
+    func listConversations(simulationID _: Int) async throws -> ChatConversationListResponse {
+        fatalError("unused")
+    }
+
+    func createConversation(simulationID _: Int, request _: ChatCreateConversationRequest) async throws -> ChatConversation {
+        fatalError("unused")
+    }
+
+    func getConversation(simulationID _: Int, conversationUUID _: String) async throws -> ChatConversation {
+        fatalError("unused")
+    }
+
+    func listMessages(
+        simulationID _: Int,
+        conversationID _: Int?,
+        cursor _: String?,
+        order _: String,
+        limit _: Int,
+    ) async throws -> PaginatedResponse<ChatMessage> {
+        fatalError("unused")
+    }
+
+    func createMessage(simulationID _: Int, request _: ChatCreateMessageRequest) async throws -> ChatMessage {
+        fatalError("unused")
+    }
+
+    func retryMessage(simulationID _: Int, messageID _: Int) async throws -> ChatMessage {
+        fatalError("unused")
+    }
+
+    func getMessage(simulationID _: Int, messageID _: Int) async throws -> ChatMessage {
+        fatalError("unused")
+    }
+
+    func markMessageRead(simulationID _: Int, messageID _: Int) async throws -> ChatMessage {
+        fatalError("unused")
+    }
+
+    func listEvents(simulationID _: Int, lastEventID _: String?, limit _: Int) async throws -> ChatEventReplayResponse {
+        fatalError("unused")
+    }
+
+    func listTools(simulationID _: Int, names _: [String]?) async throws -> ChatToolListResponse {
+        ChatToolListResponse(items: toolItems)
+    }
+
+    func getTool(simulationID _: Int, toolName _: String) async throws -> ChatToolState {
+        fatalError("unused")
+    }
+
+    func signOrders(simulationID _: Int, request _: ChatSignOrdersRequest) async throws -> ChatSignOrdersResponse {
+        fatalError("unused")
+    }
+
+    func submitLabOrders(simulationID _: Int, request _: ChatSubmitLabOrdersRequest) async throws -> ChatLabOrdersResponse {
+        fatalError("unused")
+    }
+
+    func getGuardState(simulationID _: Int) async throws -> GuardStateDTO {
+        fatalError("unused")
+    }
+
+    func sendHeartbeat(simulationID _: Int) async throws -> GuardStateDTO {
+        fatalError("unused")
+    }
+
+    func listModifierGroups(groups _: [String]?) async throws -> [ModifierGroup] {
+        fatalError("unused")
+    }
+}
+
+final class ChatPatientResultsTests: XCTestCase {
+    func testToolStateDecodesFlatPatientResultsWithoutCreatingPanelContainer() throws {
+        let json = """
+        {
+          "name": "patient_results",
+          "display_name": "Patient Results",
+          "data": [
+            {
+              "id": 101,
+              "result_name": "WBC",
+              "panel_name": "CBC",
+              "value": 4.7,
+              "unit": "K/uL",
+              "reference_range_low": 4.0,
+              "reference_range_high": 10.5,
+              "flag": "normal",
+              "attribute": "hematology",
+              "type": "lab"
+            },
+            {
+              "id": 102,
+              "result_name": "Hemoglobin",
+              "panel_name": "CBC",
+              "value": 13.2,
+              "unit": "g/dL",
+              "reference_range_low": 12.0,
+              "reference_range_high": 16.0,
+              "flag": "normal",
+              "attribute": "hematology",
+              "type": "lab"
+            }
+          ],
+          "is_generic": false,
+          "checksum": "cbc-1"
+        }
+        """
+
+        let tool = try JSONDecoder().decode(ChatToolState.self, from: Data(json.utf8))
+        let results = tool.patientResults
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.map(\.displayName), ["WBC", "Hemoglobin"])
+        XCTAssertEqual(results.map(\.panelName), ["CBC", "CBC"])
+        XCTAssertEqual(results[0].value, .number(4.7))
+        XCTAssertEqual(results[1].value, .number(13.2))
+        XCTAssertFalse(results.contains(where: hasNestedValue))
+    }
+
+    func testPresentationGroupsRowsByPanelNameForDisplayOnly() {
+        let results = [
+            makeResult(id: 101, resultName: "WBC", panelName: "CBC", value: .number(4.7)),
+            makeResult(id: 102, resultName: "Hemoglobin", panelName: "CBC", value: .number(13.2)),
+        ]
+
+        let sections = ChatPatientResultsPresentation.sections(from: results)
+
+        XCTAssertEqual(sections.count, 1)
+        XCTAssertEqual(sections.first?.panelName, "CBC")
+        XCTAssertEqual(sections.first?.rows.map(\.displayName), ["WBC", "Hemoglobin"])
+    }
+
+    func testGroupingDoesNotRewriteScalarValueIntoNestedDictionary() {
+        let results = [
+            makeResult(id: 101, resultName: "WBC", panelName: "CBC", value: .number(4.7)),
+            makeResult(id: 102, resultName: "Hemoglobin", panelName: "CBC", value: .number(13.2)),
+        ]
+
+        let sections = ChatPatientResultsPresentation.sections(from: results)
+
+        XCTAssertEqual(sections.first?.rows.first?.value, .number(4.7))
+        XCTAssertEqual(sections.first?.rows.last?.value, .number(13.2))
+        XCTAssertFalse(sections.flatMap(\.rows).contains(where: hasNestedValue))
+    }
+
+    func testMixedPanelAndStandaloneResultsKeepStandaloneRowsIndependent() {
+        let results = [
+            makeResult(id: 201, resultName: "Troponin", panelName: nil, value: .number(0.02)),
+            makeResult(id: 101, resultName: "WBC", panelName: "CBC", value: .number(4.7)),
+            makeResult(id: 102, resultName: "Hemoglobin", panelName: "CBC", value: .number(13.2)),
+            makeResult(id: 202, resultName: "Lactate", panelName: nil, value: .number(1.6)),
+        ]
+
+        let sections = ChatPatientResultsPresentation.sections(from: results)
+
+        XCTAssertEqual(sections.map(\.panelName), [nil, "CBC", nil])
+        XCTAssertEqual(sections[0].rows.map(\.displayName), ["Troponin"])
+        XCTAssertEqual(sections[1].rows.map(\.displayName), ["WBC", "Hemoglobin"])
+        XCTAssertEqual(sections[2].rows.map(\.displayName), ["Lactate"])
+    }
+
+    @MainActor
+    func testToolsStoreKeepsBootstrapAndRefreshResultsInSameFlatShape() async {
+        let service = PatientResultsService()
+        let store = ChatToolsStore(service: service, simulationID: 42)
+
+        let bootstrapResults = [
+            makeResult(id: 101, resultName: "WBC", panelName: "CBC", value: .number(4.7)),
+            makeResult(id: 102, resultName: "Hemoglobin", panelName: "CBC", value: .number(13.2)),
+        ]
+        service.toolItems = [makeTool(results: bootstrapResults, checksum: "bootstrap")]
+
+        await store.loadTools()
+
+        XCTAssertEqual(store.patientResults.map(\.rawRow), bootstrapResults.map(\.rawRow))
+        XCTAssertFalse(store.patientResults.contains(where: hasNestedValue))
+
+        let refreshedResults = [
+            makeResult(id: 301, resultName: "Sodium", panelName: "CMP", value: .number(140)),
+            makeResult(id: 302, resultName: "Potassium", panelName: "CMP", value: .number(4.1)),
+            makeResult(id: 401, resultName: "Troponin", panelName: nil, value: .number(0.02)),
+        ]
+        service.toolItems = [makeTool(results: refreshedResults, checksum: "refresh")]
+
+        await store.refreshTools()
+
+        XCTAssertEqual(store.patientResults.map(\.rawRow), refreshedResults.map(\.rawRow))
+        XCTAssertFalse(store.patientResults.contains(where: hasNestedValue))
+    }
+
+    private func makeResult(
+        id: Int,
+        resultName: String,
+        panelName: String?,
+        value: JSONValue,
+        unit: String? = nil,
+        referenceRangeLow: JSONValue? = nil,
+        referenceRangeHigh: JSONValue? = nil,
+        flag: String? = nil,
+        attribute: String? = nil,
+        type: String? = "lab",
+    ) -> ChatPatientResult {
+        var row: [String: JSONValue] = [
+            "id": .number(Double(id)),
+            "result_name": .string(resultName),
+            "value": value,
+        ]
+        if let panelName {
+            row["panel_name"] = .string(panelName)
+        }
+        if let unit {
+            row["unit"] = .string(unit)
+        }
+        if let referenceRangeLow {
+            row["reference_range_low"] = referenceRangeLow
+        }
+        if let referenceRangeHigh {
+            row["reference_range_high"] = referenceRangeHigh
+        }
+        if let flag {
+            row["flag"] = .string(flag)
+        }
+        if let attribute {
+            row["attribute"] = .string(attribute)
+        }
+        if let type {
+            row["type"] = .string(type)
+        }
+        return ChatPatientResult(rawRow: row)
+    }
+
+    private func makeTool(results: [ChatPatientResult], checksum: String) -> ChatToolState {
+        ChatToolState(
+            name: "patient_results",
+            displayName: "Patient Results",
+            data: results.map(\.rawRow),
+            isGeneric: false,
+            checksum: checksum,
+        )
+    }
+
+    private func hasNestedValue(_ result: ChatPatientResult) -> Bool {
+        switch result.value {
+        case .object, .array:
+            return true
+        case .string, .number, .bool, .null, nil:
+            return false
+        }
+    }
+}

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatPatientResultsTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatPatientResultsTests.swift
@@ -281,9 +281,9 @@ final class ChatPatientResultsTests: XCTestCase {
     private func hasNestedValue(_ result: ChatPatientResult) -> Bool {
         switch result.value {
         case .object, .array:
-            return true
+            true
         case .string, .number, .bool, .null, nil:
-            return false
+            false
         }
     }
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -635,6 +635,31 @@ final class ChatRunStoreTests: XCTestCase {
         try await waitUntil { !store.activeTypingUsers.contains("consultant@example.com") }
     }
 
+    func testPatientResultsUpdatedEventAdvancesToolRefreshToken() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+        let initialToken = store.toolRefreshToken
+
+        realtime.pushEvent(makeEvent(
+            id: "evt-results-1",
+            type: SimulationEventType.patientResultsUpdated,
+            payload: ["result_count": .number(2)],
+        ))
+
+        try await waitUntil { store.toolRefreshToken != initialToken }
+    }
+
     func testTransportStateTracksConnectingReplayingConnectedResyncingAndFailure() async throws {
         let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
         let patientConversation = makeConversation()


### PR DESCRIPTION
## Summary
- add a dedicated `ChatPatientResult` model that preserves raw flat lab-result rows from `patient_results`
- normalize `patient_results` into a flat store shape in `ChatToolsStore` and group rows by `panel_name` only in presentation
- replace the generic patient-results renderer with sectioned lab rows and add tests for flat decode, grouping, mixed standalone rows, and realtime refresh signaling

## Testing
- `swift test --package-path apps/chatlab-ios` (started, interrupted before completion)