### PR TITLE
fix(chatlab-ios): format patient history for display

### DIFF
--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLayoutSupport.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLayoutSupport.swift
@@ -202,27 +202,19 @@ struct ChatPatientHistoryItem: Equatable {
     var titleText: String? {
         switch (displayLabel, displayQualifier) {
         case let (label?, qualifier?) where !qualifier.isEmpty:
-            return "\(label) — \(qualifier)"
+            "\(label) — \(qualifier)"
         case let (label?, _):
-            return label
+            label
         default:
-            return nil
+            nil
         }
     }
 }
 
 enum ChatPatientHistoryPresentation {
-    private static let labelOverrides: [String: String] = [
-        "symptom_onset": "Symptom onset",
-        "urinary_frequency_now": "Urinary frequency",
-        "pain_location": "Pain location",
-        "pain_severity": "Pain severity",
-        "associated_symptoms": "Associated symptoms",
-    ]
-
-    private static let noisyKeySuffixes = [
-        "_now",
-        "_current",
+    private static let noisyTrailingLabelTokens: Set<String> = [
+        "now",
+        "current",
     ]
 
     static func item(from row: [String: JSONValue]) -> ChatPatientHistoryItem? {
@@ -244,13 +236,12 @@ enum ChatPatientHistoryPresentation {
         )
 
         let displayQualifier = shouldDisplayQualifier(qualifierInfo, alongside: narrative) ? qualifierInfo.text : nil
-        let displayText: String
-        if let narrative, !narrative.isEmpty {
-            displayText = narrative
+        let displayText = if let narrative, !narrative.isEmpty {
+            narrative
         } else if let qualifier = qualifierInfo.text, !qualifier.isEmpty {
-            displayText = qualifier
+            qualifier
         } else {
-            displayText = ""
+            ""
         }
 
         guard label != nil || !displayText.isEmpty else {
@@ -272,15 +263,7 @@ enum ChatPatientHistoryPresentation {
             return nil
         }
 
-        if let override = labelOverrides[cleanedKey] {
-            return override
-        }
-
         let normalizedKey = stripNoisySuffixes(from: cleanedKey)
-        if let override = labelOverrides[normalizedKey] {
-            return override
-        }
-
         let tokens = normalizedKey
             .split(separator: "_")
             .map(String.init)
@@ -525,12 +508,16 @@ enum ChatPatientHistoryPresentation {
     }
 
     private static func stripNoisySuffixes(from key: String) -> String {
-        var normalizedKey = key
-        for suffix in noisyKeySuffixes where normalizedKey.hasSuffix(suffix) {
-            normalizedKey.removeLast(suffix.count)
-            break
+        var tokens = key
+            .split(separator: "_")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+
+        while let lastToken = tokens.last, noisyTrailingLabelTokens.contains(lastToken) {
+            tokens.removeLast()
         }
-        return normalizedKey.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+
+        return tokens.joined(separator: "_")
     }
 
     private static func formattedHistoryLabelToken(_ token: String, isFirst: Bool) -> String {

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLayoutSupport.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLayoutSupport.swift
@@ -194,6 +194,393 @@ enum ChatToolValueFormatter {
     }
 }
 
+struct ChatPatientHistoryItem: Equatable {
+    let displayLabel: String?
+    let displayQualifier: String?
+    let displayText: String
+
+    var titleText: String? {
+        switch (displayLabel, displayQualifier) {
+        case let (label?, qualifier?) where !qualifier.isEmpty:
+            return "\(label) — \(qualifier)"
+        case let (label?, _):
+            return label
+        default:
+            return nil
+        }
+    }
+}
+
+enum ChatPatientHistoryPresentation {
+    private static let labelOverrides: [String: String] = [
+        "symptom_onset": "Symptom onset",
+        "urinary_frequency_now": "Urinary frequency",
+        "pain_location": "Pain location",
+        "pain_severity": "Pain severity",
+        "associated_symptoms": "Associated symptoms",
+    ]
+
+    private static let noisyKeySuffixes = [
+        "_now",
+        "_current",
+    ]
+
+    static func item(from row: [String: JSONValue]) -> ChatPatientHistoryItem? {
+        let summary = firstRenderedString(in: row, keys: ["summary"])
+        let parsedSummary = parseSummary(summary)
+
+        let explicitLabel = normalizedLabelCandidate(firstRenderedString(in: row, keys: ["label", "display_label", "title"]))
+        let rawKey = firstRenderedString(in: row, keys: ["key", "field", "attribute"]) ?? parsedSummary.key
+        let label = explicitLabel ?? rawKey.flatMap(displayLabel(for:)) ?? normalizedLabelCandidate(parsedSummary.label)
+
+        let qualifierInfo = normalizeQualifier(
+            firstRenderedString(in: row, keys: ["qualifier", "status", "timing", "timeframe", "duration", "when"])
+                ?? parsedSummary.qualifier,
+        )
+
+        let narrative = sanitizeNarrative(
+            firstRenderedString(in: row, keys: ["value", "text", "narrative", "details", "description", "answer"])
+                ?? parsedSummary.narrative,
+        )
+
+        let displayQualifier = shouldDisplayQualifier(qualifierInfo, alongside: narrative) ? qualifierInfo.text : nil
+        let displayText: String
+        if let narrative, !narrative.isEmpty {
+            displayText = narrative
+        } else if let qualifier = qualifierInfo.text, !qualifier.isEmpty {
+            displayText = qualifier
+        } else {
+            displayText = ""
+        }
+
+        guard label != nil || !displayText.isEmpty else {
+            return nil
+        }
+
+        return ChatPatientHistoryItem(
+            displayLabel: label,
+            displayQualifier: displayQualifier,
+            displayText: displayText,
+        )
+    }
+
+    static func displayLabel(for rawKey: String) -> String? {
+        let cleanedKey = rawKey
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard !cleanedKey.isEmpty else {
+            return nil
+        }
+
+        if let override = labelOverrides[cleanedKey] {
+            return override
+        }
+
+        let normalizedKey = stripNoisySuffixes(from: cleanedKey)
+        if let override = labelOverrides[normalizedKey] {
+            return override
+        }
+
+        let tokens = normalizedKey
+            .split(separator: "_")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        guard !tokens.isEmpty else {
+            return nil
+        }
+
+        return tokens.enumerated()
+            .map { index, token in
+                formattedHistoryLabelToken(token, isFirst: index == 0)
+            }
+            .joined(separator: " ")
+    }
+
+    private struct ParsedSummary {
+        var key: String?
+        var label: String?
+        var qualifier: String?
+        var narrative: String?
+    }
+
+    private struct NormalizedQualifier {
+        let text: String?
+        let isPureTimingOrStatus: Bool
+        let fullyRecognized: Bool
+    }
+
+    private static func firstRenderedString(in row: [String: JSONValue], keys: [String]) -> String? {
+        for key in keys {
+            guard let value = row[key] else {
+                continue
+            }
+
+            let rendered = renderedString(from: value)
+            if let rendered, !rendered.isEmpty {
+                return rendered
+            }
+        }
+
+        return nil
+    }
+
+    private static func renderedString(from value: JSONValue) -> String? {
+        switch value {
+        case .null:
+            return nil
+        default:
+            let rendered = cleanInlineText(ChatToolValueFormatter.render(value))
+            return rendered.isEmpty ? nil : rendered
+        }
+    }
+
+    private static func parseSummary(_ summary: String?) -> ParsedSummary {
+        guard let summary, !summary.isEmpty else {
+            return ParsedSummary()
+        }
+
+        let nsSummary = summary as NSString
+        let pattern = #"(?i)^history\s+of\s+([a-z0-9_]+)(?:\s*\(([^)]*)\))?\s*$"#
+        if let regex = try? NSRegularExpression(pattern: pattern),
+           let match = regex.firstMatch(in: summary, range: NSRange(location: 0, length: nsSummary.length))
+        {
+            let key = match.range(at: 1).location != NSNotFound ? nsSummary.substring(with: match.range(at: 1)) : nil
+            let qualifier = match.range(at: 2).location != NSNotFound ? nsSummary.substring(with: match.range(at: 2)) : nil
+            return ParsedSummary(
+                key: key,
+                label: nil,
+                qualifier: qualifier,
+                narrative: nil,
+            )
+        }
+
+        if summary.contains("_"), summary.contains(" ") == false {
+            return ParsedSummary(key: summary, label: nil, qualifier: nil, narrative: nil)
+        }
+
+        if let range = summary.range(of: ":", options: .backwards) {
+            let left = cleanInlineText(String(summary[..<range.lowerBound]))
+            let right = cleanInlineText(String(summary[range.upperBound...]))
+            if !left.isEmpty, !right.isEmpty, left.split(separator: " ").count <= 4 {
+                return ParsedSummary(key: nil, label: left, qualifier: nil, narrative: right)
+            }
+        }
+
+        if let range = summary.range(of: " — ") {
+            let left = cleanInlineText(String(summary[..<range.lowerBound]))
+            let right = cleanInlineText(String(summary[range.upperBound...]))
+            if !left.isEmpty, !right.isEmpty, left.split(separator: " ").count <= 5 {
+                return ParsedSummary(key: nil, label: left, qualifier: nil, narrative: right)
+            }
+        }
+
+        if summary.split(separator: " ").count <= 4 {
+            return ParsedSummary(key: nil, label: summary, qualifier: nil, narrative: nil)
+        }
+
+        return ParsedSummary(key: nil, label: nil, qualifier: nil, narrative: summary)
+    }
+
+    private static func sanitizeNarrative(_ text: String?) -> String? {
+        guard var cleaned = text.map(cleanInlineText), !cleaned.isEmpty else {
+            return nil
+        }
+
+        let pattern = #"\(([^()]*)\)\s*$"#
+        let nsCleaned = cleaned as NSString
+        if let regex = try? NSRegularExpression(pattern: pattern),
+           let match = regex.firstMatch(in: cleaned, range: NSRange(location: 0, length: nsCleaned.length)),
+           match.range(at: 1).location != NSNotFound
+        {
+            let metadata = nsCleaned.substring(with: match.range(at: 1))
+            let qualifier = normalizeQualifier(metadata)
+            if qualifier.fullyRecognized {
+                let baseRange = NSRange(location: 0, length: match.range.location)
+                cleaned = cleanInlineText(nsCleaned.substring(with: baseRange))
+            }
+        }
+
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    private static func normalizeQualifier(_ raw: String?) -> NormalizedQualifier {
+        guard let raw, !raw.isEmpty else {
+            return NormalizedQualifier(text: nil, isPureTimingOrStatus: true, fullyRecognized: true)
+        }
+
+        let normalized = cleanInlineText(raw)
+            .lowercased()
+            .replacingOccurrences(of: "on-going", with: "ongoing")
+            .replacingOccurrences(of: "on going", with: "ongoing")
+        let fragments = normalized
+            .split(separator: ",")
+            .map { cleanInlineText(String($0)) }
+            .filter { !$0.isEmpty }
+
+        var ongoing = false
+        var timePhrase: String?
+        var otherFragments: [String] = []
+        var fullyRecognized = true
+        var isPureTimingOrStatus = true
+
+        for fragment in fragments {
+            switch fragment {
+            case "ongoing":
+                ongoing = true
+            case "same day", "same-day", "current", "now":
+                continue
+            default:
+                if let normalizedTime = normalizeTimeFragment(fragment) {
+                    timePhrase = normalizedTime
+                    continue
+                }
+
+                fullyRecognized = false
+                isPureTimingOrStatus = false
+                if otherFragments.contains(fragment) == false {
+                    otherFragments.append(fragment)
+                }
+            }
+        }
+
+        var components: [String] = []
+        if ongoing {
+            if let timePhrase {
+                components.append("ongoing \(timePhrase)")
+            } else {
+                components.append("ongoing")
+            }
+        } else if let timePhrase {
+            components.append(timePhrase)
+        }
+        for fragment in otherFragments where components.contains(fragment) == false {
+            components.append(fragment)
+        }
+
+        let text = components.joined(separator: ", ")
+        return NormalizedQualifier(
+            text: text.isEmpty ? nil : text,
+            isPureTimingOrStatus: isPureTimingOrStatus,
+            fullyRecognized: fullyRecognized,
+        )
+    }
+
+    private static func normalizeTimeFragment(_ fragment: String) -> String? {
+        var cleaned = fragment
+        if cleaned.hasPrefix("for since ") {
+            cleaned = "since " + String(cleaned.dropFirst("for since ".count))
+        }
+
+        if cleaned.hasPrefix("ongoing since ") {
+            let remainder = cleanInlineText(String(cleaned.dropFirst("ongoing since ".count)))
+            return remainder.isEmpty ? "ongoing" : "ongoing since \(remainder)"
+        }
+
+        if cleaned.hasPrefix("since ") {
+            let remainder = cleanInlineText(String(cleaned.dropFirst("since ".count)))
+            switch remainder {
+            case "morning":
+                return "since this morning"
+            case "afternoon":
+                return "since this afternoon"
+            case "evening":
+                return "since this evening"
+            case "night":
+                return "since tonight"
+            case "today":
+                return "since today"
+            default:
+                return remainder.isEmpty ? nil : "since \(remainder)"
+            }
+        }
+
+        if cleaned.hasPrefix("for ") {
+            let remainder = cleanInlineText(String(cleaned.dropFirst("for ".count)))
+            return remainder.isEmpty ? nil : "for \(remainder)"
+        }
+
+        return nil
+    }
+
+    private static func shouldDisplayQualifier(_ qualifier: NormalizedQualifier, alongside narrative: String?) -> Bool {
+        guard let text = qualifier.text, !text.isEmpty else {
+            return false
+        }
+
+        guard let narrative, !narrative.isEmpty else {
+            return false
+        }
+
+        if qualifier.isPureTimingOrStatus {
+            return false
+        }
+
+        return comparableText(narrative).contains(comparableText(text)) == false
+    }
+
+    private static func comparableText(_ text: String) -> String {
+        cleanInlineText(text)
+            .lowercased()
+            .replacingOccurrences(of: #"[^a-z0-9 ]+"#, with: "", options: .regularExpression)
+    }
+
+    private static func stripNoisySuffixes(from key: String) -> String {
+        var normalizedKey = key
+        for suffix in noisyKeySuffixes where normalizedKey.hasSuffix(suffix) {
+            normalizedKey.removeLast(suffix.count)
+            break
+        }
+        return normalizedKey.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+    }
+
+    private static func formattedHistoryLabelToken(_ token: String, isFirst: Bool) -> String {
+        switch token.lowercased() {
+        case "ai":
+            return "AI"
+        case "id":
+            return "ID"
+        case "hr":
+            return "HR"
+        case "bp":
+            return "BP"
+        case "rr":
+            return "RR"
+        case "spo2":
+            return "SpO2"
+        default:
+            let lowercased = token.lowercased()
+            guard isFirst else {
+                return lowercased
+            }
+            return lowercased.prefix(1).uppercased() + lowercased.dropFirst()
+        }
+    }
+
+    private static func normalizedLabelCandidate(_ rawLabel: String?) -> String? {
+        guard let rawLabel else {
+            return nil
+        }
+
+        let cleaned = cleanInlineText(rawLabel)
+        guard !cleaned.isEmpty else {
+            return nil
+        }
+
+        if cleaned.contains("_"), cleaned.contains(" ") == false {
+            return displayLabel(for: cleaned)
+        }
+
+        return cleaned
+    }
+
+    private static func cleanInlineText(_ text: String) -> String {
+        text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .replacingOccurrences(of: #"\s+([,.;:])"#, with: "$1", options: .regularExpression)
+    }
+}
+
 enum ChatFeedbackKind: Equatable {
     case boolTrue // green checkmark.square.fill
     case boolFalse // red x.square.fill

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -1385,20 +1385,23 @@ private struct PatientHistoryRows: View {
         } else {
             VStack(alignment: .leading, spacing: 8) {
                 ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                    VStack(alignment: .leading, spacing: 4) {
-                        if let summary = row["summary"] {
-                            Text(ChatToolValueFormatter.render(summary))
-                                .font(.subheadline.weight(.semibold))
+                    if let item = ChatPatientHistoryPresentation.item(from: row) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            if let title = item.titleText {
+                                Text(title)
+                                    .font(.subheadline.weight(.semibold))
+                            }
+                            if !item.displayText.isEmpty {
+                                Text(item.displayText)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
                         }
-                        if let value = row["value"] {
-                            Text(ChatToolValueFormatter.render(value))
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .background(Color.secondary.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     }
-                    .padding(10)
-                    .background(Color.secondary.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }
             }
         }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLayoutSupportTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLayoutSupportTests.swift
@@ -1,4 +1,5 @@
 @testable import ChatLabiOS
+import SharedModels
 import SwiftUI
 import XCTest
 
@@ -93,5 +94,54 @@ final class ChatLayoutSupportTests: XCTestCase {
         } else {
             XCTFail("Expected .text kind for areas for improvement")
         }
+    }
+
+    func testPatientHistoryLabelPrettificationUsesOverridesAndDropsNoisySuffixes() {
+        XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "symptom_onset"), "Symptom onset")
+        XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "urinary_frequency_now"), "Urinary frequency")
+        XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "pain_location"), "Pain location")
+    }
+
+    func testPatientHistoryItemRemovesHistoryPrefixAndAvoidsDuplicatedTiming() {
+        let item = ChatPatientHistoryPresentation.item(from: [
+            "summary": .string("History of symptom_onset (ongoing, since morning)"),
+            "value": .string(" since around breakfast (same day) "),
+        ])
+
+        XCTAssertEqual(item?.displayLabel, "Symptom onset")
+        XCTAssertNil(item?.displayQualifier)
+        XCTAssertEqual(item?.displayText, "since around breakfast")
+        XCTAssertFalse(item?.titleText?.contains("History of") ?? false)
+    }
+
+    func testPatientHistoryMetadataNormalizationAvoidsMachineishTimingText() {
+        let item = ChatPatientHistoryPresentation.item(from: [
+            "summary": .string("History of urinary_frequency_now (on going, for since morning)"),
+        ])
+
+        XCTAssertEqual(item?.displayLabel, "Urinary frequency")
+        XCTAssertNil(item?.displayQualifier)
+        XCTAssertEqual(item?.displayText, "ongoing since this morning")
+        XCTAssertFalse(item?.displayText.contains("for since") ?? false)
+        XCTAssertFalse(item?.displayText.contains("on going") ?? false)
+    }
+
+    func testPatientHistoryRendersLabelAndNarrativeWhenOnlyStructuredFieldsExist() {
+        let item = ChatPatientHistoryPresentation.item(from: [
+            "key": .string("pain_location"),
+            "value": .string("lower abdomen"),
+        ])
+
+        XCTAssertEqual(item?.displayLabel, "Pain location")
+        XCTAssertEqual(item?.displayText, "lower abdomen")
+    }
+
+    func testPatientHistoryFallsBackGracefullyWhenLabelIsMissing() {
+        let item = ChatPatientHistoryPresentation.item(from: [
+            "value": .string("needing to pee more often with lower belly discomfort"),
+        ])
+
+        XCTAssertNil(item?.displayLabel)
+        XCTAssertEqual(item?.displayText, "needing to pee more often with lower belly discomfort")
     }
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLayoutSupportTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLayoutSupportTests.swift
@@ -96,10 +96,11 @@ final class ChatLayoutSupportTests: XCTestCase {
         }
     }
 
-    func testPatientHistoryLabelPrettificationUsesOverridesAndDropsNoisySuffixes() {
+    func testPatientHistoryLabelPrettificationUsesGenericNormalization() {
         XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "symptom_onset"), "Symptom onset")
         XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "urinary_frequency_now"), "Urinary frequency")
         XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "pain_location"), "Pain location")
+        XCTAssertEqual(ChatPatientHistoryPresentation.displayLabel(for: "chief_complaint_current"), "Chief complaint")
     }
 
     func testPatientHistoryItemRemovesHistoryPrefixAndAvoidsDuplicatedTiming() {


### PR DESCRIPTION
## Summary
- add a dedicated patient history presentation formatter for label normalization and narrative cleanup
- replace raw `summary` and `value` rendering with formatted history rows in the chat run view
- cover key prettification, metadata normalization, duplicate suppression, and fallback behavior with tests

## Testing
- `swift test`
- `swift test --filter ChatLayoutSupportTests`