### PR TITLE
fix(trainerlab): make /state/ the single authority for panel state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,11 @@ jobs:
             -scheme "$XCODE_SCHEME" \
             -clonedSourcePackagesDirPath "$CLONED_SOURCE_PACKAGES_DIR"
 
+      - name: Prepare simulator
+        run: |
+          xcrun simctl list devices | grep -q "iPhone 17 Pro" || \
+            xcrun simctl create "iPhone 17 Pro" "iPhone 17 Pro"
+
       - name: Build for testing
         run: |
           set -euo pipefail
@@ -234,6 +239,11 @@ jobs:
             -project "$XCODE_PROJECT" \
             -scheme "$XCODE_SCHEME" \
             -clonedSourcePackagesDirPath "$CLONED_SOURCE_PACKAGES_DIR"
+
+      - name: Prepare simulator
+        run: |
+          xcrun simctl list devices | grep -q "iPhone 17 Pro" || \
+            xcrun simctl create "iPhone 17 Pro" "iPhone 17 Pro"
 
       - name: Run unit tests with coverage
         run: |
@@ -280,6 +290,11 @@ jobs:
             -project "$XCODE_PROJECT" \
             -scheme "$XCODE_SCHEME" \
             -clonedSourcePackagesDirPath "$CLONED_SOURCE_PACKAGES_DIR"
+
+      - name: Prepare simulator
+        run: |
+          xcrun simctl list devices | grep -q "iPhone 17 Pro" || \
+            xcrun simctl create "iPhone 17 Pro" "iPhone 17 Pro"
 
       - name: Run UI smoke test
         run: |

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -2098,7 +2098,7 @@ public struct RunConsoleView: View {
 
     private var groupedRecommendations: [(priority: String, items: [RecommendedInterventionItem])] {
         let grouped = Dictionary(grouping: store.state.recommendedInterventions) { recommendation in
-            recommendation.priority?.capitalized ?? "Unprioritized"
+            recommendation.priority.map(String.init) ?? "Unprioritized"
         }
         return grouped
             .map { (priority: $0.key, items: $0.value.sorted { $0.title < $1.title }) }
@@ -2108,13 +2108,8 @@ public struct RunConsoleView: View {
     }
 
     private func recommendationPriorityRank(_ priority: String) -> Int {
-        switch priority.lowercased() {
-        case "critical": 0
-        case "high": 1
-        case "medium", "moderate": 2
-        case "low": 3
-        default: 4
-        }
+        // Numeric priority: lower value = higher urgency. "Unprioritized" sorts last.
+        Int(priority) ?? .max
     }
 
     private func linkedProblemLabel(for recommendation: RecommendedInterventionItem) -> String? {

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -2075,7 +2075,7 @@ public final class RunSessionStore: ObservableObject {
             normalizedKind: jsonString(event.payload["normalized_kind"]),
             normalizedCode: jsonString(event.payload["normalized_code"]),
             rationale: jsonString(event.payload["rationale"]),
-            priority: jsonString(event.payload["priority"]),
+            priority: jsonInt(event.payload["priority"]),
             siteCode: jsonString(event.payload["site_code"]),
             siteLabel: jsonString(event.payload["site_label"]),
             warnings: jsonStringArray(event.payload["warnings"]),

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -84,6 +84,9 @@ public final class RunSessionStore: ObservableObject {
     }
 
     public func bind(session: TrainerSessionDTO) {
+        if state.session?.simulationID != session.simulationID {
+            resetSnapshotState()
+        }
         state = RunSessionReducer.reduce(state: state, action: .sessionLoaded(session))
         conflictError = nil
         seedHydrationFromSessionRuntimeState(session)
@@ -184,6 +187,37 @@ public final class RunSessionStore: ObservableObject {
         runtimeRefreshTask?.cancel()
         pendingRuntimeRefresh = false
         realtimeClient.disconnect()
+        resetSnapshotState()
+    }
+
+    /// Clears all snapshot-authoritative panel state and resets revision guards.
+    ///
+    /// Call this before binding to a different simulation or after stopping the console
+    /// so that state from one simulation cannot bleed into another, and so that the
+    /// stale-revision guard does not reject valid lower revisions for a new simulation.
+    private func resetSnapshotState() {
+        runtimeState = nil
+        scenarioBrief = nil
+        controlPlaneDebug = nil
+        hydratedCauses = []
+        hydratedProblems = []
+        assessmentFindings = []
+        diagnosticResults = []
+        resources = []
+        disposition = nil
+        patientStatus = .init()
+        aiInstructorIntent = nil
+        aiInstructorNotes = []
+        lastSnapshotRefreshError = nil
+        debriefAnnotations = []
+        state.causeAnnotations = []
+        state.problemAnnotations = []
+        state.recommendedInterventions = []
+        state.interventionAnnotations = []
+        state.pulseAnnotations = []
+        state.vitals = []
+        appliedSnapshotRevision = -1
+        lastAppliedLifecycleRevision = nil
     }
 
     /// Fire-and-forget: loads the intervention and injury dictionaries from the API.

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -1492,15 +1492,15 @@ public final class RunSessionStore: ObservableObject {
     }
 
     // MARK: - Live event projection (guard-only; canonical panel state comes from snapshot)
-    //
-    // Panel state (scenarioBrief, vitals, annotations, assessmentFindings, etc.) is driven
-    // exclusively by applyRuntimeState() / the authoritative /state/ snapshot.
-    // Events that arrive via SSE or polling trigger a debounced snapshot refresh via
-    // scheduleRuntimeRefresh(), and the seeded lifecycle path forces an immediate refresh.
-    //
-    // The capture helpers below (captureVitalRange, captureInjuryAnnotation, …) are
-    // retained as overlay helpers for future optimistic-UI work but are NOT called from
-    // the main event-handling path.
+
+    /// Panel state (scenarioBrief, vitals, annotations, assessmentFindings, etc.) is driven
+    /// exclusively by applyRuntimeState() / the authoritative /state/ snapshot.
+    /// Events that arrive via SSE or polling trigger a debounced snapshot refresh via
+    /// scheduleRuntimeRefresh(), and the seeded lifecycle path forces an immediate refresh.
+    ///
+    /// The capture helpers below (captureVitalRange, captureInjuryAnnotation, …) are
+    /// retained as overlay helpers for future optimistic-UI work but are NOT called from
+    /// the main event-handling path.
     private func applyLiveEventProjection(from event: EventEnvelope) {
         switch event.eventType {
         case SimulationEventType.guardStateUpdated, SimulationEventType.guardWarningUpdated:
@@ -2262,7 +2262,7 @@ public final class RunSessionStore: ObservableObject {
         let newRevision = runtimeState.runtimeSnapshot.stateRevision
         guard newRevision >= appliedSnapshotRevision else {
             logger.info(
-                "Ignoring stale snapshot revision=\(newRevision, privacy: .public) for simulation \(runtimeState.simulationID, privacy: .public) (applied=\(appliedSnapshotRevision, privacy: .public), source=\(source, privacy: .public))",
+                "Ignoring stale snapshot revision=\(newRevision, privacy: .public) for simulation \(runtimeState.simulationID, privacy: .public) (applied=\(self.appliedSnapshotRevision, privacy: .public), source=\(source, privacy: .public))",
             )
             return
         }
@@ -2331,7 +2331,7 @@ public final class RunSessionStore: ObservableObject {
     }
 
     // MARK: - Derived mapping from snapshot
-    //
+
     // These are pure functions that convert authoritative DTO types into UI-facing annotation
     // and state types. They are called exclusively from applyRuntimeState() and are the single
     // place where snapshot data is translated into rendered panel state.

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -2260,9 +2260,10 @@ public final class RunSessionStore: ObservableObject {
 
     private func applyRuntimeState(_ runtimeState: TrainerRestViewModelDTO, source: String) {
         let newRevision = runtimeState.runtimeSnapshot.stateRevision
-        guard newRevision >= appliedSnapshotRevision else {
+        let currentRevision = appliedSnapshotRevision
+        guard newRevision >= currentRevision else {
             logger.info(
-                "Ignoring stale snapshot revision=\(newRevision, privacy: .public) for simulation \(runtimeState.simulationID, privacy: .public) (applied=\(self.appliedSnapshotRevision, privacy: .public), source=\(source, privacy: .public))",
+                "Ignoring stale snapshot revision=\(newRevision, privacy: .public) for simulation \(runtimeState.simulationID, privacy: .public) (applied=\(currentRevision, privacy: .public), source=\(source, privacy: .public))",
             )
             return
         }

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -32,6 +32,9 @@ public final class RunSessionStore: ObservableObject {
     @Published public private(set) var patientStatus: RuntimePatientStatus = .init()
     @Published public private(set) var aiInstructorIntent: RuntimeInstructorIntent?
     @Published public private(set) var aiInstructorNotes: [String] = []
+    /// Set whenever a `/state/` fetch fails; cleared on the next successful fetch.
+    /// Exposed for debug surfaces and diagnostic tooling.
+    @Published public private(set) var lastSnapshotRefreshError: Error?
 
     private var eventTask: Task<Void, Never>?
     private var transportTask: Task<Void, Never>?
@@ -42,6 +45,9 @@ public final class RunSessionStore: ObservableObject {
     private var runtimeRefreshTask: Task<Void, Never>?
     private var lastAppliedLifecycleRevision: Int?
     private var pendingRuntimeRefresh = false
+    /// Highest `stateRevision` successfully applied from a snapshot.
+    /// Used to reject stale snapshots that arrive out of order.
+    private var appliedSnapshotRevision: Int = -1
 
     private let runtimeRefreshDebounceNanoseconds: UInt64 = 150_000_000
     private let maxStoredTimelineEvents = 400
@@ -105,6 +111,9 @@ public final class RunSessionStore: ObservableObject {
                 let outcome = await handleIncomingEvent(event)
                 if outcome.shouldRehydrateSeededSession {
                     await refreshSession()
+                    // Always reload the authoritative snapshot when seeding completes so
+                    // all panels hydrate immediately, not after the debounced refresh window.
+                    await loadRuntimeState(reason: "seeded")
                     await loadAnnotations()
                 }
                 if outcome.shouldRefreshRuntimeState {
@@ -211,12 +220,14 @@ public final class RunSessionStore: ObservableObject {
             logger.info(
                 "Fetched runtime state for simulation \(simulationID, privacy: .public): revision=\(rs.runtimeSnapshot.stateRevision, privacy: .public) status=\(rs.status, privacy: .public)",
             )
+            lastSnapshotRefreshError = nil
             applyRuntimeState(rs, source: reason)
             return rs
         } catch {
             logger.error(
-                "Runtime state fetch failed for simulation \(simulationID, privacy: .public) (\(reason, privacy: .public)): \(error.localizedDescription, privacy: .public)",
+                "Runtime state fetch failed for simulation \(simulationID, privacy: .public) (\(reason, privacy: .public)): \(error, privacy: .public)",
             )
+            lastSnapshotRefreshError = error
             return nil
         }
     }
@@ -273,7 +284,10 @@ public final class RunSessionStore: ObservableObject {
         let historicalEvents = await loadHistoricalEvents(simulationID: session.simulationID)
         applyHistoricalEvents(historicalEvents)
 
-        let eventCursor = state.eventCursor
+        // Prefer the timeline cursor (last historical event) to avoid duplicate delivery.
+        // Fall back to the snapshot's latestEventCursor when no historical events exist,
+        // so we don't restart the stream from the very beginning unnecessarily.
+        let eventCursor = state.eventCursor ?? runtimeState?.runtimeSnapshot.latestEventCursor
         logger.info(
             "Connecting realtime stream for simulation \(session.simulationID, privacy: .public) from cursor \(eventCursor ?? "nil", privacy: .public)",
         )
@@ -1477,43 +1491,23 @@ public final class RunSessionStore: ObservableObject {
         )
     }
 
+    // MARK: - Live event projection (guard-only; canonical panel state comes from snapshot)
+    //
+    // Panel state (scenarioBrief, vitals, annotations, assessmentFindings, etc.) is driven
+    // exclusively by applyRuntimeState() / the authoritative /state/ snapshot.
+    // Events that arrive via SSE or polling trigger a debounced snapshot refresh via
+    // scheduleRuntimeRefresh(), and the seeded lifecycle path forces an immediate refresh.
+    //
+    // The capture helpers below (captureVitalRange, captureInjuryAnnotation, …) are
+    // retained as overlay helpers for future optimistic-UI work but are NOT called from
+    // the main event-handling path.
     private func applyLiveEventProjection(from event: EventEnvelope) {
         switch event.eventType {
         case SimulationEventType.guardStateUpdated, SimulationEventType.guardWarningUpdated:
             Task { await refreshGuardState() }
-
-        case SimulationEventType.simulationBriefCreated, SimulationEventType.simulationBriefUpdated:
-            if let decoded = try? event.payload.decodedPayload(as: ScenarioBriefOut.self) {
-                scenarioBrief = decoded
-            }
-
-        case SimulationEventType.patientAssessmentFindingCreated, SimulationEventType.patientAssessmentFindingUpdated:
-            upsertAssessmentFinding(from: event)
-
-        case SimulationEventType.patientAssessmentFindingRemoved:
-            removeAssessmentFinding(from: event)
-
-        case SimulationEventType.patientDiagnosticResultCreated, SimulationEventType.patientDiagnosticResultUpdated:
-            upsertDiagnosticResult(from: event)
-
-        case SimulationEventType.patientResourceUpdated:
-            upsertResourceState(from: event)
-
-        case SimulationEventType.patientDispositionUpdated:
-            if let decoded = try? event.payload.decodedPayload(as: RuntimeDispositionState.self) {
-                disposition = decoded
-            }
-
         default:
             break
         }
-
-        captureVitalRange(from: event)
-        captureInjuryAnnotation(from: event)
-        captureProblemAnnotation(from: event)
-        captureRecommendedIntervention(from: event)
-        captureInterventionAnnotation(from: event)
-        capturePulseAnnotation(from: event)
     }
 
     private func upsertAssessmentFinding(from event: EventEnvelope) {
@@ -2265,9 +2259,18 @@ public final class RunSessionStore: ObservableObject {
     }
 
     private func applyRuntimeState(_ runtimeState: TrainerRestViewModelDTO, source: String) {
+        let newRevision = runtimeState.runtimeSnapshot.stateRevision
+        guard newRevision >= appliedSnapshotRevision else {
+            logger.info(
+                "Ignoring stale snapshot revision=\(newRevision, privacy: .public) for simulation \(runtimeState.simulationID, privacy: .public) (applied=\(appliedSnapshotRevision, privacy: .public), source=\(source, privacy: .public))",
+            )
+            return
+        }
+        appliedSnapshotRevision = newRevision
+
         let snapshot = runtimeState.scenarioSnapshot
         logger.info(
-            "Applying runtime state for simulation \(runtimeState.simulationID, privacy: .public) from \(source, privacy: .public): revision=\(runtimeState.runtimeSnapshot.stateRevision, privacy: .public)",
+            "Applying runtime state for simulation \(runtimeState.simulationID, privacy: .public) from \(source, privacy: .public): revision=\(newRevision, privacy: .public)",
         )
 
         self.runtimeState = runtimeState
@@ -2326,6 +2329,12 @@ public final class RunSessionStore: ObservableObject {
             }
         }
     }
+
+    // MARK: - Derived mapping from snapshot
+    //
+    // These are pure functions that convert authoritative DTO types into UI-facing annotation
+    // and state types. They are called exclusively from applyRuntimeState() and are the single
+    // place where snapshot data is translated into rendered panel state.
 
     private func makeCauseAnnotation(
         from cause: RuntimeCauseState,

--- a/apps/trainerlab-ios/Sources/SharedModels/Contracts.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/Contracts.swift
@@ -1132,7 +1132,7 @@ public struct RuntimeRecommendedInterventionState: Codable, Sendable {
     public let normalizedKind: String?
     public let normalizedCode: String?
     public let rationale: String?
-    public let priority: String?
+    public let priority: Int?
     public let siteCode: String?
     public let siteLabel: String?
     public let warnings: [String]
@@ -1178,7 +1178,7 @@ public struct RuntimeRecommendedInterventionState: Codable, Sendable {
         normalizedKind = try container.decodeIfPresent(String.self, forKey: .normalizedKind)
         normalizedCode = try container.decodeIfPresent(String.self, forKey: .normalizedCode)
         rationale = try container.decodeIfPresent(String.self, forKey: .rationale)
-        priority = try container.decodeIfPresent(String.self, forKey: .priority)
+        priority = try container.decodeIfPresent(Int.self, forKey: .priority)
         siteCode = try container.decodeIfPresent(String.self, forKey: .siteCode)
         siteLabel = try container.decodeIfPresent(String.self, forKey: .siteLabel)
         warnings = try container.decodeIfPresent([String].self, forKey: .warnings) ?? []

--- a/apps/trainerlab-ios/Sources/SharedModels/RuntimeState.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/RuntimeState.swift
@@ -285,7 +285,7 @@ public struct RecommendedInterventionItem: Identifiable, Equatable, Sendable {
     public let normalizedKind: String?
     public let normalizedCode: String?
     public let rationale: String?
-    public let priority: String?
+    public let priority: Int?
     public let siteCode: String?
     public let siteLabel: String?
     public let warnings: [String]
@@ -308,7 +308,7 @@ public struct RecommendedInterventionItem: Identifiable, Equatable, Sendable {
         normalizedKind: String? = nil,
         normalizedCode: String? = nil,
         rationale: String? = nil,
-        priority: String? = nil,
+        priority: Int? = nil,
         siteCode: String? = nil,
         siteLabel: String? = nil,
         warnings: [String] = [],

--- a/apps/trainerlab-ios/Tests/NetworkingTests/TrainerLabContractTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/TrainerLabContractTests.swift
@@ -972,6 +972,81 @@ final class TrainerLabContractTests: XCTestCase {
         XCTAssertEqual(event.payload["recommendation_id"], .number(91))
     }
 
+    func testRecommendedInterventionNumericPriorityDecodesFromSnapshot() throws {
+        // Backend contract: RecommendedInterventionStateOut.priority: int | None = None
+        // Previously decoded as String? causing typeMismatch that crashed the entire
+        // /state/ decode — leaving all panels empty even though the backend payload was valid.
+        let json = """
+        {
+          "simulation_id": 420,
+          "session_id": 420,
+          "status": "running",
+          "scenario_snapshot": {
+            "causes": [],
+            "problems": [],
+            "recommended_interventions": [
+              {
+                "recommendation_id": 42,
+                "title": "Apply tourniquet",
+                "kind": "tourniquet",
+                "priority": 2,
+                "target_problem_id": 10,
+                "target_cause_id": 11,
+                "warnings": [],
+                "contraindications": []
+              },
+              {
+                "recommendation_id": 43,
+                "title": "Needle decompression",
+                "kind": "needle_decompression",
+                "priority": null,
+                "warnings": [],
+                "contraindications": []
+              }
+            ],
+            "interventions": [],
+            "assessment_findings": [],
+            "diagnostic_results": [],
+            "resources": [],
+            "disposition": null,
+            "vitals": [],
+            "pulses": [],
+            "patient_status": {}
+          },
+          "runtime_snapshot": {
+            "status": "running",
+            "state_revision": 1,
+            "active_elapsed_seconds": 0
+          },
+          "event_timeline": { "events": [], "total_events": 0 },
+          "metadata": {
+            "builder_version": "trainerlab-rest-v1",
+            "schema_version": "trainerlab-state-v2",
+            "snapshot_cache": {
+              "status": "disabled",
+              "authoritative": false,
+              "source": "disabled",
+              "state_revision": null
+            },
+            "event_timeline_count": 0
+          }
+        }
+        """
+
+        let state = try makeContractDecoder().decode(TrainerRestViewModelDTO.self, from: Data(json.utf8))
+        let recommendations = state.scenarioSnapshot.recommendedInterventions
+
+        XCTAssertEqual(recommendations.count, 2)
+
+        let first = try XCTUnwrap(recommendations.first { $0.recommendationID == 42 })
+        XCTAssertEqual(first.priority, 2)
+        XCTAssertEqual(first.targetProblemID, 10)
+        XCTAssertEqual(first.targetCauseID, 11)
+
+        let second = try XCTUnwrap(recommendations.first { $0.recommendationID == 43 })
+        XCTAssertNil(second.priority)
+    }
+
     func testControlPlaneDebugDecodesCurrentBackendShape() throws {
         let json = """
         {

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -1651,6 +1651,11 @@ final class RunSessionStoreTests: XCTestCase {
                     "cause_id": 501,
                     "anatomical_location": "LEFT_ARM",
                 ]],
+                pulses: [[
+                    "location": "radial_left",
+                    "present": false,
+                    "quality": "weak",
+                ]],
                 interventions: [[
                     "intervention_id": 801,
                     "kind": "tourniquet",
@@ -1658,11 +1663,6 @@ final class RunSessionStoreTests: XCTestCase {
                     "site_code": "LEFT_ARM",
                     "target_problem_id": 601,
                     "status": "applied",
-                ]],
-                pulses: [[
-                    "location": "radial_left",
-                    "present": false,
-                    "quality": "weak",
                 ]],
                 assessmentFindings: [[
                     "finding_id": 1001,

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -1951,8 +1951,8 @@ final class RunSessionStoreTests: XCTestCase {
         let service = MockTrainerLabService()
         service.getSessionResult = .success(makeSession(status: .seeded))
         service.getRuntimeStateResultsQueue = try [
-            .success(makeRuntimeState(status: "seeding", stateRevision: 1)),   // bootstrap — seeding in progress
-            .success(makeRuntimeState(                                           // seeded path
+            .success(makeRuntimeState(status: "seeding", stateRevision: 1)), // bootstrap — seeding in progress
+            .success(makeRuntimeState( // seeded path
                 status: "seeded",
                 stateRevision: 2,
                 scenarioBrief: [
@@ -2063,12 +2063,12 @@ final class RunSessionStoreTests: XCTestCase {
         // applied, it must be silently ignored to prevent the UI from regressing.
         let service = MockTrainerLabService()
         service.getRuntimeStateResultsQueue = try [
-            .success(makeRuntimeState(             // bootstrap — revision 5, has brief "A"
+            .success(makeRuntimeState( // bootstrap — revision 5, has brief "A"
                 status: "running",
                 stateRevision: 5,
                 scenarioBrief: ["read_aloud_brief": "Brief A", "environment": "Night"],
             )),
-            .success(makeRuntimeState(             // debounced refresh — revision 3 (stale)
+            .success(makeRuntimeState( // debounced refresh — revision 3 (stale)
                 status: "running",
                 stateRevision: 3,
                 scenarioBrief: ["read_aloud_brief": "Brief B", "environment": "Day"],
@@ -2117,7 +2117,7 @@ final class RunSessionStoreTests: XCTestCase {
                 stateRevision: 1,
                 scenarioBrief: ["read_aloud_brief": "Original brief", "environment": "Night"],
             )),
-            .failure(MockServiceError.unused),  // next fetch fails
+            .failure(MockServiceError.unused), // next fetch fails
         ]
 
         let realtime = MockRealtimeClient()

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -1628,8 +1628,65 @@ final class RunSessionStoreTests: XCTestCase {
     }
 
     func testLivePatientEventsHydrateClinicalStateAcrossFamilies() async throws {
+        // Under the snapshot-authority architecture, live events trigger a debounced /state/
+        // refresh rather than directly mutating panel state. The second mock response contains
+        // the clinical state accumulated by all the events on the backend.
         let service = MockTrainerLabService()
-        service.getRuntimeStateResult = try .success(makeRuntimeState(status: "running"))
+        service.getRuntimeStateResultsQueue = try [
+            .success(makeRuntimeState(status: "running", stateRevision: 1)),
+            .success(makeRuntimeState(
+                status: "running",
+                stateRevision: 2,
+                causes: [[
+                    "id": 501,
+                    "domain_event_id": 501,
+                    "kind": "injury",
+                    "title": "Gunshot wound",
+                    "anatomical_location": "LEFT_ARM",
+                ]],
+                problems: [[
+                    "problem_id": 601,
+                    "title": "External hemorrhage",
+                    "status": "active",
+                    "cause_id": 501,
+                    "anatomical_location": "LEFT_ARM",
+                ]],
+                interventions: [[
+                    "intervention_id": 801,
+                    "kind": "tourniquet",
+                    "title": "Tourniquet",
+                    "site_code": "LEFT_ARM",
+                    "target_problem_id": 601,
+                    "status": "applied",
+                ]],
+                pulses: [[
+                    "location": "radial_left",
+                    "present": false,
+                    "quality": "weak",
+                ]],
+                assessmentFindings: [[
+                    "finding_id": 1001,
+                    "title": "Absent breath sounds",
+                    "status": "present",
+                ]],
+                diagnosticResults: [[
+                    "diagnostic_id": 1101,
+                    "title": "Ultrasound pending",
+                    "status": "queued",
+                ]],
+                resources: [[
+                    "resource_id": 1201,
+                    "title": "Whole blood available",
+                    "status": "ready",
+                ]],
+                disposition: [
+                    "disposition_id": 1301,
+                    "status": "requested",
+                    "destination": "Role 2",
+                    "transport_mode": "ground",
+                ],
+            )),
+        ]
 
         let realtime = MockRealtimeClient()
         let store = RunSessionStore(
@@ -1645,6 +1702,8 @@ final class RunSessionStoreTests: XCTestCase {
             service.getRuntimeStateCalls.count == 1
         }
 
+        // Emit live events — each is a runtime-refresh trigger that coalesces into a single
+        // debounced /state/ fetch returning the second mock state above.
         realtime.emit(event: EventEnvelope(
             eventID: "injury-1",
             eventType: SimulationEventType.patientInjuryCreated,
@@ -1767,10 +1826,12 @@ final class RunSessionStoreTests: XCTestCase {
             ],
         ))
 
+        // Wait for the debounced /state/ refresh to fire (events coalesced) and apply the snapshot.
         await waitUntil(timeout: 2.0) {
-            store.disposition?.dispositionID == 1301
+            service.getRuntimeStateCalls.count == 2 && store.disposition?.dispositionID == 1301
         }
 
+        // Panel state is driven by the authoritative snapshot (second mock response).
         XCTAssertEqual(store.state.causeAnnotations.first?.causeID, 501)
         XCTAssertEqual(store.state.problemAnnotations.first?.problemID, 601)
         XCTAssertEqual(store.state.interventionAnnotations.first?.interventionID, 801)
@@ -1779,7 +1840,10 @@ final class RunSessionStoreTests: XCTestCase {
         XCTAssertEqual(store.diagnosticResults.first?.resultID, 1101)
         XCTAssertEqual(store.resources.first?.resourceID, 1201)
         XCTAssertEqual(store.disposition?.dispositionID, 1301)
+        // Recommendation absent from second snapshot → cleared.
         XCTAssertTrue(store.state.recommendedInterventions.isEmpty)
+        // Timeline is populated from events (independent of snapshot).
+        XCTAssertFalse(store.state.timeline.isEmpty)
     }
 
     func testUnknownEventsNormalizeSafelyWithoutTriggeringRefresh() async throws {
@@ -1876,6 +1940,289 @@ final class RunSessionStoreTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 150_000_000)
         XCTAssertEqual(store.state.session?.status, .seeded)
         XCTAssertEqual(store.state.session?.scenarioSpec, existingScenarioSpec)
+    }
+
+    // MARK: - Snapshot-authority regression tests
+
+    func testSeededTransitionForcesImmediateSnapshotRefreshAndPopulatesPanels() async throws {
+        // When the seeded lifecycle event arrives the store must immediately call
+        // loadRuntimeState() (not just schedule a debounced refresh) so that
+        // scenario brief, vitals and annotations are populated right away.
+        let service = MockTrainerLabService()
+        service.getSessionResult = .success(makeSession(status: .seeded))
+        service.getRuntimeStateResultsQueue = try [
+            .success(makeRuntimeState(status: "seeding", stateRevision: 1)),   // bootstrap — seeding in progress
+            .success(makeRuntimeState(                                           // seeded path
+                status: "seeded",
+                stateRevision: 2,
+                scenarioBrief: [
+                    "read_aloud_brief": "Blast injury patient.",
+                    "environment": "Night operation",
+                ],
+                vitals: [[
+                    "vital_type": "heart_rate",
+                    "min_value": 110,
+                    "max_value": 130,
+                ]],
+            )),
+        ]
+        service.listEventsResult = .success(PaginatedResponse(items: [], nextCursor: nil, hasMore: false))
+        service.listAnnotationsResult = .success([])
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .seeding))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
+
+        realtime.emit(event: makeStatusUpdatedEvent(status: "seeded", stateRevision: 2))
+
+        // The immediate loadRuntimeState in the seeded path must populate panels.
+        await waitUntil(timeout: 2.0) {
+            store.scenarioBrief?.readAloudBrief == "Blast injury patient."
+                && store.state.vitals.first?.key == "heart_rate"
+                && store.state.session?.status == .seeded
+        }
+
+        // At least 2 calls: bootstrap + seeded-path immediate refresh.
+        // A 3rd debounced refresh may also fire from shouldRefreshRuntimeState.
+        XCTAssertGreaterThanOrEqual(service.getRuntimeStateCalls.count, 2)
+        XCTAssertEqual(store.runtimeState?.runtimeSnapshot.stateRevision, 2)
+    }
+
+    func testHistoricalEventsPopulateTimelineButNotPanelState() async throws {
+        // Historical events are applied to the timeline only.
+        // Panel state (brief, vitals, annotations) must come from the /state/ snapshot.
+        let service = MockTrainerLabService()
+
+        // Bootstrap /state/ returns an incomplete snapshot (no brief, no vitals).
+        service.getRuntimeStateResult = try .success(makeRuntimeState(status: "running", stateRevision: 1))
+
+        // Historical events contain a brief.created and a vital.created.
+        service.listEventsResult = .success(PaginatedResponse(
+            items: [
+                EventEnvelope(
+                    eventID: "brief-hist-1",
+                    eventType: SimulationEventType.simulationBriefCreated,
+                    createdAt: Date(timeIntervalSince1970: 5),
+                    correlationID: nil,
+                    payload: [
+                        "read_aloud_brief": .string("Historical brief content"),
+                        "environment": .string("Day"),
+                    ],
+                ),
+                EventEnvelope(
+                    eventID: "vital-hist-1",
+                    eventType: SimulationEventType.patientVitalCreated,
+                    createdAt: Date(timeIntervalSince1970: 6),
+                    correlationID: nil,
+                    payload: [
+                        "vital_type": .string("heart_rate"),
+                        "min_value": .number(80),
+                        "max_value": .number(100),
+                    ],
+                ),
+            ],
+            nextCursor: nil,
+            hasMore: false,
+        ))
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running, runStartedAt: Date()))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        // Wait for bootstrap to finish (runtime state fetched, historical events applied).
+        await waitUntil(timeout: 2.0) {
+            store.state.timeline.count == 2
+        }
+
+        // Timeline contains entries from historical events.
+        XCTAssertEqual(store.state.timeline.map(\.eventID).sorted(), ["brief-hist-1", "vital-hist-1"])
+        // Panel state is NOT hydrated from historical events — only from snapshot.
+        // The bootstrap snapshot had no brief or vitals so panels remain empty.
+        XCTAssertNil(store.scenarioBrief, "Historical events must not project into scenarioBrief")
+        XCTAssertTrue(store.state.vitals.isEmpty, "Historical events must not project into vitals")
+    }
+
+    func testStaleSnapshotRevisionIsIgnoredWhenNewerAlreadyApplied() async throws {
+        // If a /state/ response arrives with an older stateRevision than the one already
+        // applied, it must be silently ignored to prevent the UI from regressing.
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = try [
+            .success(makeRuntimeState(             // bootstrap — revision 5, has brief "A"
+                status: "running",
+                stateRevision: 5,
+                scenarioBrief: ["read_aloud_brief": "Brief A", "environment": "Night"],
+            )),
+            .success(makeRuntimeState(             // debounced refresh — revision 3 (stale)
+                status: "running",
+                stateRevision: 3,
+                scenarioBrief: ["read_aloud_brief": "Brief B", "environment": "Day"],
+            )),
+        ]
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            store.scenarioBrief?.readAloudBrief == "Brief A"
+        }
+
+        // Trigger a refresh — the mock returns the stale revision 3 snapshot.
+        realtime.emit(event: EventEnvelope(
+            eventID: "snap-1",
+            eventType: SimulationEventType.simulationSnapshotUpdated,
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [:],
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2
+        }
+
+        // The stale snapshot (Brief B, revision 3) must not have overwritten Brief A.
+        XCTAssertEqual(store.scenarioBrief?.readAloudBrief, "Brief A")
+        XCTAssertNil(store.lastSnapshotRefreshError)
+    }
+
+    func testSnapshotFetchFailureExposesErrorAndPreservesPreviousState() async throws {
+        // A failed /state/ fetch must surface the error via lastSnapshotRefreshError
+        // and must NOT clear any previously applied panel state.
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = try [
+            .success(makeRuntimeState(
+                status: "running",
+                stateRevision: 1,
+                scenarioBrief: ["read_aloud_brief": "Original brief", "environment": "Night"],
+            )),
+            .failure(MockServiceError.unused),  // next fetch fails
+        ]
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            store.scenarioBrief?.readAloudBrief == "Original brief"
+        }
+        XCTAssertNil(store.lastSnapshotRefreshError, "No error before the failing refresh")
+
+        // Trigger the failing refresh.
+        realtime.emit(event: EventEnvelope(
+            eventID: "snap-fail-1",
+            eventType: SimulationEventType.simulationSnapshotUpdated,
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [:],
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            store.lastSnapshotRefreshError != nil
+        }
+
+        // Error is exposed.
+        XCTAssertNotNil(store.lastSnapshotRefreshError)
+        // Previous panel state is preserved — the brief must still show.
+        XCTAssertEqual(store.scenarioBrief?.readAloudBrief, "Original brief")
+    }
+
+    func testBootstrapUsesSnapshotCursorWhenTimelineIsEmpty() async throws {
+        // When no historical events exist, the SSE stream should start from the
+        // latestEventCursor embedded in the /state/ snapshot rather than nil.
+        // This prevents re-replaying events that the server has already committed.
+        let service = MockTrainerLabService()
+
+        // Build a runtime state with a non-nil latestEventCursor.
+        let payload: [String: Any] = [
+            "simulation_id": 420,
+            "session_id": 420,
+            "status": "running",
+            "scenario_snapshot": [
+                "causes": [],
+                "problems": [],
+                "recommended_interventions": [],
+                "interventions": [],
+                "assessment_findings": [],
+                "diagnostic_results": [],
+                "resources": [],
+                "disposition": NSNull(),
+                "vitals": [],
+                "pulses": [],
+                "patient_status": [:],
+                "scenario_brief": NSNull(),
+            ],
+            "runtime_snapshot": [
+                "status": "running",
+                "state_revision": 1,
+                "active_elapsed_seconds": 0,
+                "tick_interval_seconds": 15,
+                "next_tick_at": NSNull(),
+                "ai_plan": NSNull(),
+                "ai_rationale_notes": [],
+                "pending_runtime_reasons": [],
+                "currently_processing_reasons": [],
+                "last_runtime_error": "",
+                "last_ai_tick_at": NSNull(),
+                "control_plane_debug": [:],
+                "request_metadata": [:],
+                "latest_event_cursor": "snap-cursor-99",
+            ],
+            "event_timeline": [
+                "events": [],
+                "total_events": 0,
+            ],
+            "metadata": makeRuntimeMetadataPayload(stateRevision: 1),
+        ]
+        service.getRuntimeStateResult = try .success(decodeRuntimeStatePayload(payload))
+        // No historical events — empty page, so state.eventCursor will be nil.
+        service.listEventsResult = .success(PaginatedResponse(items: [], nextCursor: nil, hasMore: false))
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 2.0) {
+            !realtime.connectCalls.isEmpty
+        }
+
+        // Bootstrap should have fallen back to the snapshot cursor because listEvents
+        // returned an empty page (state.eventCursor == nil).
+        XCTAssertEqual(realtime.connectCalls.count, 1)
+        XCTAssertEqual(realtime.connectCalls.first?.cursor, "snap-cursor-99")
     }
 
     private func makeSession(

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -53,6 +53,10 @@ echo "== SPM: MedSimShelliOS =="
   swift build
 )
 
+echo "== Prepare simulator =="
+xcrun simctl list devices | grep -q "iPhone 17 Pro" || \
+  xcrun simctl create "iPhone 17 Pro" "iPhone 17 Pro"
+
 echo "== Xcode package resolve =="
 mkdir -p "$CLONED_SOURCE_PACKAGES_DIR"
 xcodebuild -resolvePackageDependencies \


### PR DESCRIPTION
Root cause: `applyLiveEventProjection` was a parallel path that directly
mutated scenarioBrief, vitals, causes, assessmentFindings, diagnosticResults,
resources, and disposition from live SSE events, creating split-brain state
against the snapshot. After seeding, `applyHistoricalEvents` never called
event projection, so panels stayed empty even though timeline entries appeared.

Changes:
- `applyLiveEventProjection` reduced to guard-state-refresh only; all direct
  panel mutations removed. Canonical panel state now comes exclusively from
  `/state/` snapshots applied via `applyRuntimeState`.
- Seeded transition now calls `loadRuntimeState(reason: "seeded")` immediately
  after `refreshSession()`, before `loadAnnotations()`, so panels hydrate right
  away rather than waiting for the 150ms debounce window.
- Bootstrap cursor falls back to `runtimeSnapshot.latestEventCursor` when
  `listEvents` returns an empty page, avoiding unnecessary event replay.
- `appliedSnapshotRevision` stale guard rejects any snapshot whose
  `stateRevision` is older than the last applied revision.
- `lastSnapshotRefreshError` published property surfaces fetch failures for
  debug tooling; cleared on the next successful fetch.

Tests updated/added:
- `testLivePatientEventsHydrateClinicalStateAcrossFamilies`: now validates that
  panel content comes from the second snapshot response (debounced refresh),
  not from event payloads directly.
- `testSeededTransitionForcesImmediateSnapshotRefreshAndPopulatesPanels`: new
- `testHistoricalEventsPopulateTimelineButNotPanelState`: new
- `testStaleSnapshotRevisionIsIgnoredWhenNewerAlreadyApplied`: new
- `testSnapshotFetchFailureExposesErrorAndPreservesPreviousState`: new
- `testBootstrapUsesSnapshotCursorWhenTimelineIsEmpty`: updated to assert
  `connectCalls.first?.cursor == "snap-cursor-99"` (non-nil snapshot cursor).

https://claude.ai/code/session_01AG4x3UbGWQSpD33UFARmtv