### PR TITLE
refactor(trainerlab-ios): unify patient pane accordion

### DIFF
--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -683,13 +683,13 @@ struct PatientDiagramPanel: View {
     }
 
     @ViewBuilder
-    private func accordionSection<TrailingContent: View, SectionContent: View>(
+    private func accordionSection(
         _ section: PatientPaneSection,
         title: String,
         systemImage: String,
         pinEnabled: Bool = false,
-        @ViewBuilder trailingContent: () -> TrailingContent,
-        @ViewBuilder content: () -> SectionContent,
+        @ViewBuilder trailingContent: () -> some View,
+        @ViewBuilder content: () -> some View,
     ) -> some View {
         let isOpen = accordionState.isOpen(section)
 
@@ -757,12 +757,12 @@ struct PatientDiagramPanel: View {
         )
     }
 
-    private func accordionSection<SectionContent: View>(
+    private func accordionSection(
         _ section: PatientPaneSection,
         title: String,
         systemImage: String,
         pinEnabled: Bool = false,
-        @ViewBuilder content: () -> SectionContent,
+        @ViewBuilder content: () -> some View,
     ) -> some View {
         accordionSection(
             section,
@@ -774,12 +774,10 @@ struct PatientDiagramPanel: View {
         )
     }
 
-    @ViewBuilder
     private func countBadge(_ count: Int) -> some View {
         countBadge(String(count))
     }
 
-    @ViewBuilder
     private func countBadge(_ label: String) -> some View {
         Text(label)
             .font(.caption2.bold())

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -454,6 +454,8 @@ private struct PatientPaneAccordionState: Equatable {
     var pinnedDiagram = false
     var openSection: PatientPaneSection = .diagram
 
+    private static let preferredSecondaryOrder: [PatientPaneSection] = [.causes, .problems, .pulses, .recommendations]
+
     func isExpanded(_ section: PatientPaneSection) -> Bool {
         if pinnedDiagram {
             return section == .diagram || section == openSection
@@ -468,12 +470,17 @@ private struct PatientPaneAccordionState: Equatable {
             return
         }
 
+        let availableSecondarySections = secondarySections(from: availableSections)
+        let preferredSecondarySection = fallbackSecondarySection(availableSections: availableSections)
+
         if pinnedDiagram {
-            if let fallback = fallbackSecondarySection(availableSections: availableSections) {
-                if openSection == .diagram || !availableSections.contains(openSection) {
-                    openSection = fallback
+            if let preferredSecondarySection {
+                // Pinned mode is diagram + exactly one non-diagram section whenever one exists.
+                if openSection == .diagram || !availableSecondarySections.contains(openSection) {
+                    openSection = preferredSecondarySection
                 }
             } else {
+                // Edge case: if no secondary sections exist, pinned mode can only show the diagram.
                 openSection = .diagram
             }
             return
@@ -489,6 +496,7 @@ private struct PatientPaneAccordionState: Equatable {
         guard availableSections.contains(section) else { return }
 
         if pinnedDiagram {
+            // The diagram header stays inert while pinned; only the pin button changes pin state.
             guard section != .diagram else { return }
             if openSection != section {
                 openSection = section
@@ -505,23 +513,16 @@ private struct PatientPaneAccordionState: Equatable {
         normalize(availableSections: availableSections)
         guard availableSections.contains(.diagram) else { return }
 
-        if pinnedDiagram {
-            pinnedDiagram = false
-            normalize(availableSections: availableSections)
-            return
-        }
-
-        pinnedDiagram = true
-        if let fallback = fallbackSecondarySection(availableSections: availableSections) {
-            openSection = fallback
-        } else {
-            openSection = .diagram
-        }
+        pinnedDiagram.toggle()
+        normalize(availableSections: availableSections)
     }
 
     func fallbackSecondarySection(availableSections: [PatientPaneSection]) -> PatientPaneSection? {
-        let preferredOrder: [PatientPaneSection] = [.causes, .problems, .pulses, .recommendations]
-        return preferredOrder.first(where: availableSections.contains)
+        Self.preferredSecondaryOrder.first(where: availableSections.contains)
+    }
+
+    func secondarySections(from availableSections: [PatientPaneSection]) -> [PatientPaneSection] {
+        availableSections.filter { $0 != .diagram }
     }
 }
 
@@ -715,7 +716,7 @@ struct PatientDiagramPanel: View {
         VStack(spacing: 0) {
             HStack(spacing: 8) {
                 Button {
-                    accordionState.toggleSection(section, availableSections: availableSections)
+                    handleSectionTap(section)
                 } label: {
                     HStack(spacing: 8) {
                         Image(systemName: systemImage)
@@ -774,6 +775,12 @@ struct PatientDiagramPanel: View {
             RoundedRectangle(cornerRadius: sectionCornerRadius, style: .continuous)
                 .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
         )
+    }
+
+    private func handleSectionTap(_ section: PatientPaneSection) {
+        // Keep the diagram header inert while pinned so the pin affordance is the only diagram-state control.
+        guard !(accordionState.pinnedDiagram && section == .diagram) else { return }
+        accordionState.toggleSection(section, availableSections: availableSections)
     }
 
     private func accordionSection(

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -610,7 +610,7 @@ struct PatientDiagramPanel: View {
                     trailingContent: {
                         countBadge(!allCauses.isEmpty ? allCauses.count : injuries.count)
                     },
-                ) {
+                    content: {
                     VStack(spacing: rowSpacing) {
                         if !allCauses.isEmpty {
                             ForEach(Array(allCauses.enumerated()), id: \.offset) { _, cause in
@@ -622,7 +622,7 @@ struct PatientDiagramPanel: View {
                             }
                         }
                     }
-                }
+                })
             }
 
             if availableSections.contains(.problems) {
@@ -641,13 +641,13 @@ struct PatientDiagramPanel: View {
                             }
                         }
                     },
-                ) {
+                    content: {
                     VStack(spacing: rowSpacing) {
                         ForEach(problems) { problem in
                             problemRow(problem)
                         }
                     }
-                }
+                })
             }
 
             if availableSections.contains(.pulses) {
@@ -658,13 +658,13 @@ struct PatientDiagramPanel: View {
                     trailingContent: {
                         countBadge("\(pulses.filter(\.present).count)/\(pulses.count)")
                     },
-                ) {
+                    content: {
                     VStack(spacing: rowSpacing) {
                         ForEach(pulses) { pulse in
                             pulseRow(pulse)
                         }
                     }
-                }
+                })
             }
 
             if availableSections.contains(.recommendations) {
@@ -675,9 +675,9 @@ struct PatientDiagramPanel: View {
                     trailingContent: {
                         countBadge(recommendations.count)
                     },
-                ) {
+                    content: {
                     recommendationsSectionContent
-                }
+                })
             }
         }
     }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -435,11 +435,77 @@ struct TransportChip: View {
 
 // MARK: - PatientDiagramPanel
 
+enum PatientPaneSection: Hashable {
+    case diagram
+    case causes
+    case problems
+    case pulses
+    case recommendations
+}
+
 enum PatientDiagramSelection: Equatable {
     case injury(InjuryAnnotation)
     case intervention(InterventionAnnotation)
     case problem(ProblemAnnotation)
     case pulse(PulseAnnotation)
+}
+
+private struct PatientPaneAccordionState: Equatable {
+    var pinnedSection: PatientPaneSection?
+    var primaryOpenSection: PatientPaneSection = .diagram
+
+    func isOpen(_ section: PatientPaneSection) -> Bool {
+        section == primaryOpenSection || (pinnedSection == .diagram && section == .diagram)
+    }
+
+    mutating func normalize(availableSections: [PatientPaneSection]) {
+        guard let fallbackSection = availableSections.first else {
+            primaryOpenSection = .diagram
+            pinnedSection = nil
+            return
+        }
+
+        if !availableSections.contains(primaryOpenSection) {
+            primaryOpenSection = fallbackSection
+        }
+
+        if pinnedSection == .diagram, !availableSections.contains(.diagram) {
+            pinnedSection = nil
+        }
+    }
+
+    mutating func open(_ section: PatientPaneSection, availableSections: [PatientPaneSection]) {
+        normalize(availableSections: availableSections)
+        guard availableSections.contains(section) else { return }
+        primaryOpenSection = section
+    }
+
+    mutating func toggle(_ section: PatientPaneSection, availableSections: [PatientPaneSection]) {
+        normalize(availableSections: availableSections)
+        guard availableSections.contains(section) else { return }
+
+        if section == .diagram, pinnedSection == .diagram, primaryOpenSection != .diagram {
+            primaryOpenSection = .diagram
+            return
+        }
+
+        if primaryOpenSection == section {
+            return
+        }
+
+        primaryOpenSection = section
+    }
+
+    mutating func toggleDiagramPin(availableSections: [PatientPaneSection]) {
+        normalize(availableSections: availableSections)
+        guard availableSections.contains(.diagram) else { return }
+
+        if pinnedSection == .diagram {
+            pinnedSection = nil
+        } else {
+            pinnedSection = .diagram
+        }
+    }
 }
 
 struct PatientDiagramPanel: View {
@@ -450,20 +516,335 @@ struct PatientDiagramPanel: View {
     let recommendations: [RecommendedInterventionItem]
     let pulses: [PulseAnnotation]
     let canMutate: Bool
+    let layoutMode: RunConsoleLayoutMode
+    let compactMetrics: RunConsoleCompactMetrics
     var onSelectInjury: ((InjuryAnnotation) -> Void)?
     var onUpdateProblemStatus: ((ProblemAnnotation, ProblemLifecycleState) -> Void)?
 
     @State private var selected: PatientDiagramSelection?
-    @State private var injuriesExpanded = true
-    @State private var problemsExpanded = true
-    @State private var interventionsExpanded = true
-    @State private var pulsesExpanded = false
+    @State private var accordionState = PatientPaneAccordionState()
 
     var body: some View {
-        VStack(spacing: 12) {
-            diagramArea
-            detailPanels
+        VStack(spacing: containerSpacing) {
+            accordionSections
+
+            if !systemicProblems.isEmpty {
+                systemicProblemsBanner(systemicProblems)
+            }
+
+            if let selected {
+                selectedDetailCard(selected)
+            }
         }
+        .onAppear {
+            accordionState.normalize(availableSections: availableSections)
+        }
+        .onChange(of: availableSections) { _, newSections in
+            accordionState.normalize(availableSections: newSections)
+        }
+    }
+
+    private var availableSections: [PatientPaneSection] {
+        var sections: [PatientPaneSection] = [.diagram]
+        if !allCauses.isEmpty || !injuries.isEmpty {
+            sections.append(.causes)
+        }
+        if !problems.isEmpty {
+            sections.append(.problems)
+        }
+        if !pulses.isEmpty {
+            sections.append(.pulses)
+        }
+        if !recommendations.isEmpty {
+            sections.append(.recommendations)
+        }
+        return sections
+    }
+
+    private var systemicProblems: [ProblemAnnotation] {
+        problems.filter { !$0.isAnatomic }
+    }
+
+    private var containerSpacing: CGFloat {
+        layoutMode == .compact ? compactMetrics.sectionSpacing : 10
+    }
+
+    private var accordionSpacing: CGFloat {
+        layoutMode == .compact ? 8 : 10
+    }
+
+    private var sectionCornerRadius: CGFloat {
+        layoutMode == .compact ? 10 : 12
+    }
+
+    private var headerPadding: CGFloat {
+        layoutMode == .compact ? compactMetrics.cardPadding : 10
+    }
+
+    private var sectionContentPadding: CGFloat {
+        layoutMode == .compact ? compactMetrics.cardPadding : 10
+    }
+
+    private var rowSpacing: CGFloat {
+        layoutMode == .compact ? 6 : 8
+    }
+
+    private var diagramHeight: CGFloat {
+        if layoutMode == .compact {
+            return compactMetrics.cardPadding <= 8 ? 220 : 240
+        }
+        return 310
+    }
+
+    private var accordionSections: some View {
+        VStack(spacing: accordionSpacing) {
+            accordionSection(
+                .diagram,
+                title: "Patient Diagram",
+                systemImage: "figure.stand",
+                pinEnabled: true,
+            ) {
+                diagramArea
+                    .frame(height: diagramHeight)
+            }
+
+            if availableSections.contains(.causes) {
+                accordionSection(
+                    .causes,
+                    title: "Causes",
+                    systemImage: "x.circle",
+                    trailingContent: {
+                        countBadge(!allCauses.isEmpty ? allCauses.count : injuries.count)
+                    },
+                ) {
+                    VStack(spacing: rowSpacing) {
+                        if !allCauses.isEmpty {
+                            ForEach(Array(allCauses.enumerated()), id: \.offset) { _, cause in
+                                causeRow(cause)
+                            }
+                        } else {
+                            ForEach(injuries) { injury in
+                                injuryRow(injury)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if availableSections.contains(.problems) {
+                accordionSection(
+                    .problems,
+                    title: "Problems",
+                    systemImage: "circle.circle",
+                    trailingContent: {
+                        let uncontrolledCount = problems.filter(\.isUncontrolled).count
+                        HStack(spacing: 6) {
+                            countBadge(problems.count)
+                            if uncontrolledCount > 0 {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .font(.caption2)
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                    },
+                ) {
+                    VStack(spacing: rowSpacing) {
+                        ForEach(problems) { problem in
+                            problemRow(problem)
+                        }
+                    }
+                }
+            }
+
+            if availableSections.contains(.pulses) {
+                accordionSection(
+                    .pulses,
+                    title: "Pulses",
+                    systemImage: "circle.dotted.circle",
+                    trailingContent: {
+                        countBadge("\(pulses.filter(\.present).count)/\(pulses.count)")
+                    },
+                ) {
+                    VStack(spacing: rowSpacing) {
+                        ForEach(pulses) { pulse in
+                            pulseRow(pulse)
+                        }
+                    }
+                }
+            }
+
+            if availableSections.contains(.recommendations) {
+                accordionSection(
+                    .recommendations,
+                    title: "Recommended Interventions",
+                    systemImage: "cross.case",
+                    trailingContent: {
+                        countBadge(recommendations.count)
+                    },
+                ) {
+                    recommendationsSectionContent
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func accordionSection<TrailingContent: View, SectionContent: View>(
+        _ section: PatientPaneSection,
+        title: String,
+        systemImage: String,
+        pinEnabled: Bool = false,
+        @ViewBuilder trailingContent: () -> TrailingContent,
+        @ViewBuilder content: () -> SectionContent,
+    ) -> some View {
+        let isOpen = accordionState.isOpen(section)
+
+        VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Button {
+                    accordionState.toggle(section, availableSections: availableSections)
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: systemImage)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(TrainerLabTheme.accentBlue)
+
+                        Text(title)
+                            .font(layoutMode == .compact ? .caption.weight(.semibold) : .subheadline.weight(.semibold))
+                            .foregroundStyle(.primary)
+                            .multilineTextAlignment(.leading)
+
+                        Spacer(minLength: 8)
+
+                        trailingContent()
+
+                        Image(systemName: isOpen ? "chevron.up" : "chevron.down")
+                            .font(.caption.bold())
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                if pinEnabled {
+                    Button {
+                        accordionState.toggleDiagramPin(availableSections: availableSections)
+                    } label: {
+                        Image(systemName: accordionState.pinnedSection == .diagram ? "pin.fill" : "pin")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(accordionState.pinnedSection == .diagram ? TrainerLabTheme.accentBlue : .secondary)
+                            .frame(width: 28, height: 28)
+                            .background(Color.white.opacity(0.04))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(accordionState.pinnedSection == .diagram ? "Unpin patient diagram" : "Pin patient diagram")
+                }
+            }
+            .padding(headerPadding)
+
+            if isOpen {
+                Divider()
+                    .overlay(TrainerLabTheme.tacticalBorder.opacity(0.85))
+
+                content()
+                    .padding(sectionContentPadding)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .background(
+            RoundedRectangle(cornerRadius: sectionCornerRadius, style: .continuous)
+                .fill(TrainerLabTheme.tacticalSurfaceElevated),
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: sectionCornerRadius, style: .continuous)
+                .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
+        )
+    }
+
+    private func accordionSection<SectionContent: View>(
+        _ section: PatientPaneSection,
+        title: String,
+        systemImage: String,
+        pinEnabled: Bool = false,
+        @ViewBuilder content: () -> SectionContent,
+    ) -> some View {
+        accordionSection(
+            section,
+            title: title,
+            systemImage: systemImage,
+            pinEnabled: pinEnabled,
+            trailingContent: { EmptyView() },
+            content: content,
+        )
+    }
+
+    @ViewBuilder
+    private func countBadge(_ count: Int) -> some View {
+        countBadge(String(count))
+    }
+
+    @ViewBuilder
+    private func countBadge(_ label: String) -> some View {
+        Text(label)
+            .font(.caption2.bold())
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(Color.white.opacity(0.06))
+            .clipShape(Capsule())
+    }
+
+    private var recommendationsSectionContent: some View {
+        VStack(alignment: .leading, spacing: rowSpacing + 2) {
+            ForEach(groupedRecommendations, id: \.priority) { group in
+                VStack(alignment: .leading, spacing: rowSpacing) {
+                    Text(group.priority)
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+
+                    ForEach(group.items) { recommendation in
+                        recommendationCard(recommendation)
+                    }
+                }
+            }
+        }
+    }
+
+    private func recommendationCard(_ recommendation: RecommendedInterventionItem) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(alignment: .top, spacing: 8) {
+                Text(recommendation.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 8)
+                if let targetProblem = linkedProblemLabel(for: recommendation) {
+                    Text(targetProblem)
+                        .font(.caption2.bold())
+                        .foregroundStyle(TrainerLabTheme.accentBlue)
+                        .multilineTextAlignment(.trailing)
+                }
+            }
+
+            if let rationale = recommendation.rationale, !rationale.isEmpty {
+                Text(rationale)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let validationStatus = recommendation.validationStatus, !validationStatus.isEmpty {
+                Text(validationStatus.replacingOccurrences(of: "_", with: " ").capitalized)
+                    .font(.caption2.bold())
+                    .foregroundStyle(TrainerLabTheme.warning)
+            }
+        }
+        .padding(layoutMode == .compact ? 8 : 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     // MARK: - Body Diagram
@@ -655,40 +1036,10 @@ struct PatientDiagramPanel: View {
         }
     }
 
-    // MARK: - Detail Panels
-
-    private var detailPanels: some View {
-        VStack(spacing: 6) {
-            // Systemic problems floating badges (non-anatomic)
-            let systemicProblems = problems.filter { !$0.isAnatomic }
-            if !systemicProblems.isEmpty {
-                systemicProblemsBanner(systemicProblems)
-            }
-
-            if !allCauses.isEmpty || !injuries.isEmpty {
-                causesDisclosure
-            }
-            if !problems.isEmpty {
-                problemsDisclosure
-            }
-            if !interventions.isEmpty {
-                interventionsDisclosure
-            }
-            if !pulses.isEmpty {
-                pulsesDisclosure
-            }
-
-            // Selected detail overlay
-            if let selected {
-                selectedDetailCard(selected)
-            }
-        }
-    }
-
     // MARK: - Systemic Problems Banner
 
     private func systemicProblemsBanner(_ systemicProblems: [ProblemAnnotation]) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: rowSpacing) {
             ForEach(systemicProblems) { problem in
                 HStack(spacing: 6) {
                     Image(systemName: "circle.circle.fill")
@@ -716,83 +1067,6 @@ struct PatientDiagramPanel: View {
                 )
             }
         }
-    }
-
-    // MARK: - Disclosure Groups
-
-    private var causesDisclosure: some View {
-        DisclosureGroup(isExpanded: $injuriesExpanded) {
-            VStack(spacing: 4) {
-                if !allCauses.isEmpty {
-                    ForEach(Array(allCauses.enumerated()), id: \.offset) { _, cause in
-                        causeRow(cause)
-                    }
-                } else {
-                    ForEach(injuries) { injury in
-                        injuryRow(injury)
-                    }
-                }
-            }
-        } label: {
-            Label("Causes (\(!allCauses.isEmpty ? allCauses.count : injuries.count))", systemImage: "x.circle")
-                .font(.caption.bold())
-                .foregroundStyle(.primary)
-        }
-        .tint(.secondary)
-    }
-
-    private var problemsDisclosure: some View {
-        DisclosureGroup(isExpanded: $problemsExpanded) {
-            VStack(spacing: 4) {
-                ForEach(problems) { problem in
-                    problemRow(problem)
-                }
-            }
-        } label: {
-            let uncontrolledCount = problems.filter(\.isUncontrolled).count
-            HStack(spacing: 4) {
-                Label("Problems (\(problems.count))", systemImage: "circle.circle")
-                    .font(.caption.bold())
-                    .foregroundStyle(.primary)
-                if uncontrolledCount > 0 {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.caption2)
-                        .foregroundStyle(.yellow)
-                }
-            }
-        }
-        .tint(.secondary)
-    }
-
-    private var interventionsDisclosure: some View {
-        DisclosureGroup(isExpanded: $interventionsExpanded) {
-            VStack(spacing: 4) {
-                ForEach(interventions) { intervention in
-                    interventionRow(intervention)
-                }
-            }
-        } label: {
-            Label("Interventions (\(interventions.count))", systemImage: "plus.circle")
-                .font(.caption.bold())
-                .foregroundStyle(.primary)
-        }
-        .tint(.secondary)
-    }
-
-    private var pulsesDisclosure: some View {
-        let presentCount = pulses.filter(\.present).count
-        return DisclosureGroup(isExpanded: $pulsesExpanded) {
-            VStack(spacing: 4) {
-                ForEach(pulses) { pulse in
-                    pulseRow(pulse)
-                }
-            }
-        } label: {
-            Label("Pulses (\(presentCount)/\(pulses.count))", systemImage: "circle.dotted.circle")
-                .font(.caption.bold())
-                .foregroundStyle(.primary)
-        }
-        .tint(.secondary)
     }
 
     // MARK: - Row Views
@@ -1055,6 +1329,32 @@ struct PatientDiagramPanel: View {
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
         )
+    }
+
+    private var groupedRecommendations: [(priority: String, items: [RecommendedInterventionItem])] {
+        let grouped = Dictionary(grouping: recommendations) { recommendation in
+            recommendation.priority?.capitalized ?? "Unprioritized"
+        }
+        return grouped
+            .map { (priority: $0.key, items: $0.value.sorted { $0.title < $1.title }) }
+            .sorted { lhs, rhs in
+                recommendationPriorityRank(lhs.priority) < recommendationPriorityRank(rhs.priority)
+            }
+    }
+
+    private func recommendationPriorityRank(_ priority: String) -> Int {
+        switch priority.lowercased() {
+        case "critical": 0
+        case "high": 1
+        case "medium", "moderate": 2
+        case "low": 3
+        default: 4
+        }
+    }
+
+    private func linkedProblemLabel(for recommendation: RecommendedInterventionItem) -> String? {
+        guard let problemID = recommendation.targetProblemID else { return nil }
+        return problems.first(where: { $0.problemID == problemID })?.label
     }
 
     private func recommendations(for problem: ProblemAnnotation) -> [RecommendedInterventionItem] {

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -474,12 +474,6 @@ private struct PatientPaneAccordionState: Equatable {
         }
     }
 
-    mutating func open(_ section: PatientPaneSection, availableSections: [PatientPaneSection]) {
-        normalize(availableSections: availableSections)
-        guard availableSections.contains(section) else { return }
-        primaryOpenSection = section
-    }
-
     mutating func toggle(_ section: PatientPaneSection, availableSections: [PatientPaneSection]) {
         normalize(availableSections: availableSections)
         guard availableSections.contains(section) else { return }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -451,54 +451,77 @@ enum PatientDiagramSelection: Equatable {
 }
 
 private struct PatientPaneAccordionState: Equatable {
-    var pinnedSection: PatientPaneSection?
-    var primaryOpenSection: PatientPaneSection = .diagram
+    var pinnedDiagram = false
+    var openSection: PatientPaneSection = .diagram
 
-    func isOpen(_ section: PatientPaneSection) -> Bool {
-        section == primaryOpenSection || (pinnedSection == .diagram && section == .diagram)
+    func isExpanded(_ section: PatientPaneSection) -> Bool {
+        if pinnedDiagram {
+            return section == .diagram || section == openSection
+        }
+        return section == openSection
     }
 
     mutating func normalize(availableSections: [PatientPaneSection]) {
-        guard let fallbackSection = availableSections.first else {
-            primaryOpenSection = .diagram
-            pinnedSection = nil
+        guard !availableSections.isEmpty else {
+            pinnedDiagram = false
+            openSection = .diagram
             return
         }
 
-        if !availableSections.contains(primaryOpenSection) {
-            primaryOpenSection = fallbackSection
+        if pinnedDiagram {
+            if let fallback = fallbackSecondarySection(availableSections: availableSections) {
+                if openSection == .diagram || !availableSections.contains(openSection) {
+                    openSection = fallback
+                }
+            } else {
+                openSection = .diagram
+            }
+            return
         }
 
-        if pinnedSection == .diagram, !availableSections.contains(.diagram) {
-            pinnedSection = nil
+        if !availableSections.contains(openSection) {
+            openSection = availableSections.first ?? .diagram
         }
     }
 
-    mutating func toggle(_ section: PatientPaneSection, availableSections: [PatientPaneSection]) {
+    mutating func toggleSection(_ section: PatientPaneSection, availableSections: [PatientPaneSection]) {
         normalize(availableSections: availableSections)
         guard availableSections.contains(section) else { return }
 
-        if section == .diagram, pinnedSection == .diagram, primaryOpenSection != .diagram {
-            primaryOpenSection = .diagram
+        if pinnedDiagram {
+            guard section != .diagram else { return }
+            if openSection != section {
+                openSection = section
+            }
             return
         }
 
-        if primaryOpenSection == section {
-            return
+        if openSection != section {
+            openSection = section
         }
-
-        primaryOpenSection = section
     }
 
     mutating func toggleDiagramPin(availableSections: [PatientPaneSection]) {
         normalize(availableSections: availableSections)
         guard availableSections.contains(.diagram) else { return }
 
-        if pinnedSection == .diagram {
-            pinnedSection = nil
-        } else {
-            pinnedSection = .diagram
+        if pinnedDiagram {
+            pinnedDiagram = false
+            normalize(availableSections: availableSections)
+            return
         }
+
+        pinnedDiagram = true
+        if let fallback = fallbackSecondarySection(availableSections: availableSections) {
+            openSection = fallback
+        } else {
+            openSection = .diagram
+        }
+    }
+
+    func fallbackSecondarySection(availableSections: [PatientPaneSection]) -> PatientPaneSection? {
+        let preferredOrder: [PatientPaneSection] = [.causes, .problems, .pulses, .recommendations]
+        return preferredOrder.first(where: availableSections.contains)
     }
 }
 
@@ -521,10 +544,6 @@ struct PatientDiagramPanel: View {
     var body: some View {
         VStack(spacing: containerSpacing) {
             accordionSections
-
-            if !systemicProblems.isEmpty {
-                systemicProblemsBanner(systemicProblems)
-            }
 
             if let selected {
                 selectedDetailCard(selected)
@@ -553,10 +572,6 @@ struct PatientDiagramPanel: View {
             sections.append(.recommendations)
         }
         return sections
-    }
-
-    private var systemicProblems: [ProblemAnnotation] {
-        problems.filter { !$0.isAnatomic }
     }
 
     private var containerSpacing: CGFloat {
@@ -611,18 +626,19 @@ struct PatientDiagramPanel: View {
                         countBadge(!allCauses.isEmpty ? allCauses.count : injuries.count)
                     },
                     content: {
-                    VStack(spacing: rowSpacing) {
-                        if !allCauses.isEmpty {
-                            ForEach(Array(allCauses.enumerated()), id: \.offset) { _, cause in
-                                causeRow(cause)
-                            }
-                        } else {
-                            ForEach(injuries) { injury in
-                                injuryRow(injury)
+                        VStack(spacing: rowSpacing) {
+                            if !allCauses.isEmpty {
+                                ForEach(Array(allCauses.enumerated()), id: \.offset) { _, cause in
+                                    causeRow(cause)
+                                }
+                            } else {
+                                ForEach(injuries) { injury in
+                                    injuryRow(injury)
+                                }
                             }
                         }
-                    }
-                })
+                    },
+                )
             }
 
             if availableSections.contains(.problems) {
@@ -642,12 +658,13 @@ struct PatientDiagramPanel: View {
                         }
                     },
                     content: {
-                    VStack(spacing: rowSpacing) {
-                        ForEach(problems) { problem in
-                            problemRow(problem)
+                        VStack(spacing: rowSpacing) {
+                            ForEach(problems) { problem in
+                                problemRow(problem)
+                            }
                         }
-                    }
-                })
+                    },
+                )
             }
 
             if availableSections.contains(.pulses) {
@@ -659,12 +676,13 @@ struct PatientDiagramPanel: View {
                         countBadge("\(pulses.filter(\.present).count)/\(pulses.count)")
                     },
                     content: {
-                    VStack(spacing: rowSpacing) {
-                        ForEach(pulses) { pulse in
-                            pulseRow(pulse)
+                        VStack(spacing: rowSpacing) {
+                            ForEach(pulses) { pulse in
+                                pulseRow(pulse)
+                            }
                         }
-                    }
-                })
+                    },
+                )
             }
 
             if availableSections.contains(.recommendations) {
@@ -676,8 +694,9 @@ struct PatientDiagramPanel: View {
                         countBadge(recommendations.count)
                     },
                     content: {
-                    recommendationsSectionContent
-                })
+                        recommendationsSectionContent
+                    },
+                )
             }
         }
     }
@@ -691,12 +710,12 @@ struct PatientDiagramPanel: View {
         @ViewBuilder trailingContent: () -> some View,
         @ViewBuilder content: () -> some View,
     ) -> some View {
-        let isOpen = accordionState.isOpen(section)
+        let isOpen = accordionState.isExpanded(section)
 
         VStack(spacing: 0) {
             HStack(spacing: 8) {
                 Button {
-                    accordionState.toggle(section, availableSections: availableSections)
+                    accordionState.toggleSection(section, availableSections: availableSections)
                 } label: {
                     HStack(spacing: 8) {
                         Image(systemName: systemImage)
@@ -725,15 +744,15 @@ struct PatientDiagramPanel: View {
                     Button {
                         accordionState.toggleDiagramPin(availableSections: availableSections)
                     } label: {
-                        Image(systemName: accordionState.pinnedSection == .diagram ? "pin.fill" : "pin")
+                        Image(systemName: accordionState.pinnedDiagram ? "pin.fill" : "pin")
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(accordionState.pinnedSection == .diagram ? TrainerLabTheme.accentBlue : .secondary)
+                            .foregroundStyle(accordionState.pinnedDiagram ? TrainerLabTheme.accentBlue : .secondary)
                             .frame(width: 28, height: 28)
                             .background(Color.white.opacity(0.04))
                             .clipShape(Circle())
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel(accordionState.pinnedSection == .diagram ? "Unpin patient diagram" : "Pin patient diagram")
+                    .accessibilityLabel(accordionState.pinnedDiagram ? "Unpin patient diagram" : "Pin patient diagram")
                 }
             }
             .padding(headerPadding)
@@ -1025,39 +1044,6 @@ struct PatientDiagramPanel: View {
     private func standaloneProblems(from problems: [ProblemAnnotation], injuries: [InjuryAnnotation]) -> [ProblemAnnotation] {
         problems.filter { problem in
             !injuries.contains { injury in isColocated(problem, with: injury) }
-        }
-    }
-
-    // MARK: - Systemic Problems Banner
-
-    private func systemicProblemsBanner(_ systemicProblems: [ProblemAnnotation]) -> some View {
-        VStack(spacing: rowSpacing) {
-            ForEach(systemicProblems) { problem in
-                HStack(spacing: 6) {
-                    Image(systemName: "circle.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(problem.isUncontrolled ? TrainerLabTheme.danger : TrainerLabTheme.success)
-                        .modifier(PulsingModifier(active: problem.isUncontrolled))
-                    if problem.isUncontrolled {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.caption2)
-                            .foregroundStyle(.yellow)
-                    }
-                    Text(problem.label)
-                        .font(.caption.bold())
-                        .foregroundStyle(problem.isUncontrolled ? TrainerLabTheme.danger : .primary)
-                    Spacer()
-                    Text(problem.controlState.uppercased())
-                        .font(.caption2.bold())
-                        .foregroundStyle(problem.isUncontrolled ? TrainerLabTheme.danger : TrainerLabTheme.success)
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(problem.isUncontrolled ? TrainerLabTheme.danger.opacity(0.12) : TrainerLabTheme.success.opacity(0.08)),
-                )
-            }
         }
     }
 

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -445,21 +445,30 @@ public struct RunConsoleView: View {
             Text("Patient State")
                 .font(layoutMode == .compact ? .subheadline.bold() : .headline)
 
-            Group {
-                if layoutMode == .regular {
-                    ScrollView {
-                        patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
-                            .padding(.trailing, 2)
-                    }
-                    .scrollIndicators(.hidden)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                } else {
-                    patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
-                }
-            }
+            patientPaneSurface(layoutMode: layoutMode, compactMetrics: compactMetrics)
         }
         .trainerCardStyle()
         .frame(maxHeight: layoutMode == .regular ? .infinity : nil, alignment: .top)
+    }
+
+    @ViewBuilder
+    private func patientPaneSurface(
+        layoutMode: RunConsoleLayoutMode,
+        compactMetrics: RunConsoleCompactMetrics,
+    ) -> some View {
+        if layoutMode == .regular {
+            // In the two-column layout, the patient pane scrolls independently so the left rail stays usable
+            // while the timeline and info stack scroll on the right.
+            ScrollView {
+                patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
+                    .padding(.trailing, 2)
+            }
+            .scrollIndicators(.hidden)
+            .frame(maxHeight: .infinity, alignment: .top)
+        } else {
+            // On compact screens, rely on the page-level scroll view to avoid awkward nested scrolling.
+            patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
+        }
     }
 
     private func patientPaneContent(

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -159,7 +159,7 @@ public struct RunConsoleView: View {
 
             HStack(alignment: .top, spacing: 10) {
                 leftPatientPane(layoutMode: .regular, compactMetrics: .standard)
-                    .frame(minWidth: 420, idealWidth: 440, maxWidth: 520)
+                    .frame(minWidth: 420, idealWidth: 440, maxWidth: 520, maxHeight: .infinity, alignment: .top)
 
                 ScrollView {
                     VStack(spacing: 10) {
@@ -452,12 +452,14 @@ public struct RunConsoleView: View {
                             .padding(.trailing, 2)
                     }
                     .scrollIndicators(.hidden)
+                    .frame(maxHeight: .infinity, alignment: .top)
                 } else {
                     patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
                 }
             }
         }
         .trainerCardStyle()
+        .frame(maxHeight: layoutMode == .regular ? .infinity : nil, alignment: .top)
     }
 
     private func patientPaneContent(
@@ -2088,32 +2090,6 @@ public struct RunConsoleView: View {
         }
     }
 
-    private var groupedRecommendations: [(priority: String, items: [RecommendedInterventionItem])] {
-        let grouped = Dictionary(grouping: store.state.recommendedInterventions) { recommendation in
-            recommendation.priority?.capitalized ?? "Unprioritized"
-        }
-        return grouped
-            .map { (priority: $0.key, items: $0.value.sorted { $0.title < $1.title }) }
-            .sorted { lhs, rhs in
-                recommendationPriorityRank(lhs.priority) < recommendationPriorityRank(rhs.priority)
-            }
-    }
-
-    private func recommendationPriorityRank(_ priority: String) -> Int {
-        switch priority.lowercased() {
-        case "critical": 0
-        case "high": 1
-        case "medium", "moderate": 2
-        case "low": 3
-        default: 4
-        }
-    }
-
-    private func linkedProblemLabel(for recommendation: RecommendedInterventionItem) -> String? {
-        guard let problemID = recommendation.targetProblemID else { return nil }
-        return store.state.problemAnnotations.first(where: { $0.problemID == problemID })?.label
-    }
-
     private var operationalItems: [EventEnvelope] {
         var seen = Set<String>()
         var result: [EventEnvelope] = []
@@ -2183,10 +2159,6 @@ public struct RunConsoleView: View {
 
     private func compactAVPUColumns(for compactMetrics: RunConsoleCompactMetrics) -> [GridItem] {
         [GridItem(.flexible(minimum: compactMetrics.controlColumnMinimum), spacing: compactMetrics.gridSpacing), GridItem(.flexible(minimum: compactMetrics.controlColumnMinimum), spacing: compactMetrics.gridSpacing)]
-    }
-
-    private var compactActionColumns: [GridItem] {
-        [GridItem(.flexible(minimum: 120), spacing: 8), GridItem(.flexible(minimum: 120), spacing: 8)]
     }
 
     // MARK: - Button helpers

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -158,7 +158,7 @@ public struct RunConsoleView: View {
             guardWarningBanner
 
             HStack(alignment: .top, spacing: 10) {
-                leftPatientPane(layoutMode: .regular)
+                leftPatientPane(layoutMode: .regular, compactMetrics: .standard)
                     .frame(minWidth: 420, idealWidth: 440, maxWidth: 520)
 
                 ScrollView {
@@ -192,7 +192,7 @@ public struct RunConsoleView: View {
                     conflictBanner
                 }
                 guardWarningBanner
-                leftPatientPane(layoutMode: .compact)
+                leftPatientPane(layoutMode: .compact, compactMetrics: compactMetrics)
                 combinedInfoPanel
                 centerTimelinePane(layoutMode: .compact)
                 bottomLogPane(layoutMode: .compact)
@@ -208,7 +208,7 @@ public struct RunConsoleView: View {
         layoutMode: RunConsoleLayoutMode,
         compactMetrics: RunConsoleCompactMetrics,
     ) -> some View {
-        VStack(alignment: .leading, spacing: layoutMode == .compact ? 6 : 4) {
+        VStack(alignment: .leading, spacing: layoutMode == .compact ? compactMetrics.sectionSpacing : 8) {
             Text("Patient Vitals")
                 .font(layoutMode == .compact ? .subheadline.bold() : .headline)
 
@@ -243,6 +243,11 @@ public struct RunConsoleView: View {
                     }
                 }
             }
+
+            Divider()
+                .overlay(TrainerLabTheme.tacticalBorder.opacity(0.85))
+
+            avpuControlSection(layoutMode: layoutMode, compactMetrics: compactMetrics)
         }
         .modifier(
             RunConsoleCardModifier(
@@ -430,97 +435,78 @@ public struct RunConsoleView: View {
         }
     }
 
-    // MARK: - Patient pane (body diagram + detail panels + AVPU)
+    // MARK: - Patient pane
 
-    private func leftPatientPane(layoutMode: RunConsoleLayoutMode) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
+    private func leftPatientPane(
+        layoutMode: RunConsoleLayoutMode,
+        compactMetrics: RunConsoleCompactMetrics,
+    ) -> some View {
+        VStack(alignment: .leading, spacing: layoutMode == .compact ? compactMetrics.sectionSpacing : 12) {
             Text("Patient State")
                 .font(layoutMode == .compact ? .subheadline.bold() : .headline)
 
-            PatientDiagramPanel(
-                injuries: store.state.injuryAnnotations,
-                allCauses: store.hydratedCauses,
-                interventions: store.state.interventionAnnotations,
-                problems: store.state.problemAnnotations,
-                recommendations: store.state.recommendedInterventions,
-                pulses: store.state.pulseAnnotations,
-                canMutate: canMutate,
-                onSelectInjury: { injury in
-                    guard canIntervene else { return }
-                    quickActionInjury = injury
-                },
-                onUpdateProblemStatus: { problem, status in
-                    if let problemID = problem.problemID {
-                        store.updateProblemStatus(problemID: problemID, status: status)
+            Group {
+                if layoutMode == .regular {
+                    ScrollView {
+                        patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
+                            .padding(.trailing, 2)
                     }
-                },
-            )
-            .frame(minHeight: 380, maxHeight: .infinity)
-
-            if !store.state.recommendedInterventions.isEmpty {
-                recommendedInterventionsPanel
-            }
-
-            Text("AVPU")
-                .font(.subheadline.bold())
-
-            if layoutMode == .regular {
-                HStack(spacing: 8) {
-                    avpuButton(.alert, label: "Alert")
-                    avpuButton(.verbal, label: "Verbal")
-                    avpuButton(.pain, label: "Pain")
-                    avpuButton(.unalert, label: "Unalert")
-                }
-            } else {
-                LazyVGrid(columns: compactActionColumns, spacing: 8) {
-                    avpuButton(.alert, label: "Alert")
-                    avpuButton(.verbal, label: "Verbal")
-                    avpuButton(.pain, label: "Pain")
-                    avpuButton(.unalert, label: "Unalert")
+                    .scrollIndicators(.hidden)
+                } else {
+                    patientPaneContent(layoutMode: layoutMode, compactMetrics: compactMetrics)
                 }
             }
         }
         .trainerCardStyle()
     }
 
-    private var recommendedInterventionsPanel: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Recommended Interventions")
-                .font(.subheadline.bold())
+    private func patientPaneContent(
+        layoutMode: RunConsoleLayoutMode,
+        compactMetrics: RunConsoleCompactMetrics,
+    ) -> some View {
+        PatientDiagramPanel(
+            injuries: store.state.injuryAnnotations,
+            allCauses: store.hydratedCauses,
+            interventions: store.state.interventionAnnotations,
+            problems: store.state.problemAnnotations,
+            recommendations: store.state.recommendedInterventions,
+            pulses: store.state.pulseAnnotations,
+            canMutate: canMutate,
+            layoutMode: layoutMode,
+            compactMetrics: compactMetrics,
+            onSelectInjury: { injury in
+                guard canIntervene else { return }
+                quickActionInjury = injury
+            },
+            onUpdateProblemStatus: { problem, status in
+                if let problemID = problem.problemID {
+                    store.updateProblemStatus(problemID: problemID, status: status)
+                }
+            },
+        )
+    }
 
-            ForEach(groupedRecommendations, id: \.priority) { group in
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(group.priority)
-                        .font(.caption.bold())
-                        .foregroundStyle(.secondary)
-                    ForEach(group.items) { recommendation in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(alignment: .top, spacing: 8) {
-                                Text(recommendation.title)
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                if let targetProblem = linkedProblemLabel(for: recommendation) {
-                                    Text(targetProblem)
-                                        .font(.caption2.bold())
-                                        .foregroundStyle(TrainerLabTheme.accentBlue)
-                                }
-                            }
-                            if let rationale = recommendation.rationale, !rationale.isEmpty {
-                                Text(rationale)
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                            if let validationStatus = recommendation.validationStatus, !validationStatus.isEmpty {
-                                Text(validationStatus.replacingOccurrences(of: "_", with: " ").capitalized)
-                                    .font(.caption2.bold())
-                                    .foregroundStyle(TrainerLabTheme.warning)
-                            }
-                        }
-                        .padding(8)
-                        .background(Color.white.opacity(0.05))
-                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                    }
+    private func avpuControlSection(
+        layoutMode: RunConsoleLayoutMode,
+        compactMetrics: RunConsoleCompactMetrics,
+    ) -> some View {
+        VStack(alignment: .leading, spacing: layoutMode == .compact ? 6 : 8) {
+            Text("AVPU")
+                .font(layoutMode == .compact ? .caption.weight(.semibold) : .subheadline.bold())
+
+            if layoutMode == .regular {
+                HStack(spacing: 8) {
+                    avpuButton(.alert, label: "Alert", compact: false, compactMetrics: compactMetrics)
+                    avpuButton(.verbal, label: "Verbal", compact: false, compactMetrics: compactMetrics)
+                    avpuButton(.pain, label: "Pain", compact: false, compactMetrics: compactMetrics)
+                    avpuButton(.unalert, label: "Unalert", compact: false, compactMetrics: compactMetrics)
+                }
+            } else {
+                LazyVGrid(columns: compactAVPUColumns(for: compactMetrics), spacing: compactMetrics.gridSpacing) {
+                    avpuButton(.alert, label: "Alert", compact: true, compactMetrics: compactMetrics)
+                    avpuButton(.verbal, label: "Verbal", compact: true, compactMetrics: compactMetrics)
+                    avpuButton(.pain, label: "Pain", compact: true, compactMetrics: compactMetrics)
+                    avpuButton(.unalert, label: "Unalert", compact: true, compactMetrics: compactMetrics)
                 }
             }
         }
@@ -2020,16 +2006,22 @@ public struct RunConsoleView: View {
         }
     }
 
-    private func avpuButton(_ stateValue: AVPUState, label: String) -> some View {
+    private func avpuButton(
+        _ stateValue: AVPUState,
+        label: String,
+        compact: Bool,
+        compactMetrics: RunConsoleCompactMetrics,
+    ) -> some View {
         Button {
             selectedAVPU = stateValue
             store.adjustAVPU(stateValue)
         } label: {
             Text(label)
-                .font(.caption.bold())
+                .font(compact ? compactMetrics.buttonFont : .caption.bold())
                 .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
+                .frame(minHeight: compact ? compactMetrics.buttonMinHeight : 0)
+                .padding(.vertical, compact ? 0 : 8)
                 .background(avpuColor(stateValue))
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .overlay(
@@ -2187,6 +2179,10 @@ public struct RunConsoleView: View {
 
     private func compactVitalsColumns(for compactMetrics: RunConsoleCompactMetrics) -> [GridItem] {
         Array(repeating: GridItem(.flexible(minimum: compactMetrics.vitalsColumnMinimum), spacing: compactMetrics.gridSpacing), count: compactMetrics.compactVitalsColumnCount)
+    }
+
+    private func compactAVPUColumns(for compactMetrics: RunConsoleCompactMetrics) -> [GridItem] {
+        [GridItem(.flexible(minimum: compactMetrics.controlColumnMinimum), spacing: compactMetrics.gridSpacing), GridItem(.flexible(minimum: compactMetrics.controlColumnMinimum), spacing: compactMetrics.gridSpacing)]
     }
 
     private var compactActionColumns: [GridItem] {


### PR DESCRIPTION
## Summary
- consolidate the patient-state pane into a single accordion model with diagram pinning and one-open-section behavior
- move recommended interventions into the shared accordion and make the patient pane scroll as one surface
- relocate AVPU controls into Patient Vitals and tighten compact-layout spacing

## Testing
- Not run (not requested)