### PR TITLE
feat(trainerlab-ios): add intervention overlay support

### DIFF
--- a/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
@@ -1,0 +1,890 @@
+import DesignSystem
+import Sessions
+import SharedModels
+import SwiftUI
+
+enum InterventionComposerSection: Hashable {
+    case target
+    case type
+    case site
+    case review
+    case notes
+}
+
+struct InterventionComposerPrefill: Equatable {
+    let interventionType: String
+    let siteCode: String?
+    let targetProblemID: Int?
+    let status: InterventionStatus
+    let effectiveness: InterventionEffectiveness
+    let notes: String
+    let tourniquetApplicationMode: TourniquetApplicationMode?
+
+    init(
+        interventionType: String,
+        siteCode: String? = nil,
+        targetProblemID: Int? = nil,
+        status: InterventionStatus = .applied,
+        effectiveness: InterventionEffectiveness = .effective,
+        notes: String = "",
+        tourniquetApplicationMode: TourniquetApplicationMode? = nil
+    ) {
+        self.interventionType = interventionType
+        self.siteCode = siteCode
+        self.targetProblemID = targetProblemID
+        self.status = status
+        self.effectiveness = effectiveness
+        self.notes = notes
+        self.tourniquetApplicationMode = tourniquetApplicationMode
+    }
+}
+
+struct InterventionComposerDraft: Equatable {
+    var selectedTargetProblemID: Int?
+    var selectedType: String?
+    var selectedLocationLabel: String?
+    var selectedLaterality: String?
+    var status: InterventionStatus = .applied
+    var effectiveness: InterventionEffectiveness = .effective
+    var tourniquetApplicationMode: TourniquetApplicationMode = .hasty
+    var notes = ""
+    var activeSection: InterventionComposerSection = .target
+    var notesExpanded = false
+
+    init(prefilledTargetProblemID: Int? = nil) {
+        selectedTargetProblemID = prefilledTargetProblemID
+        activeSection = prefilledTargetProblemID == nil ? .target : .type
+    }
+
+    var selectedTourniquetApplicationMode: TourniquetApplicationMode? {
+        selectedType == "tourniquet" ? tourniquetApplicationMode : nil
+    }
+
+    mutating func applyPrefill(_ prefill: InterventionComposerPrefill, dictionary: [InterventionGroup]) {
+        selectedTargetProblemID = prefill.targetProblemID
+        selectedType = prefill.interventionType
+        status = prefill.status
+        effectiveness = prefill.effectiveness
+        notes = prefill.notes
+        notesExpanded = !prefill.notes.isEmpty
+        if let mode = prefill.tourniquetApplicationMode {
+            tourniquetApplicationMode = mode
+        }
+
+        selectedLocationLabel = nil
+        selectedLaterality = nil
+        if
+            let group = dictionary.first(where: { $0.interventionType == prefill.interventionType }),
+            let siteCode = prefill.siteCode,
+            let site = group.sites.first(where: { $0.code.caseInsensitiveCompare(siteCode) == .orderedSame })
+        {
+            selectedLocationLabel = site.locationLabel
+            selectedLaterality = site.laterality
+            activeSection = .review
+        } else {
+            activeSection = .type
+        }
+    }
+
+    func resolvedSiteCode(in sites: [InterventionSite]) -> String? {
+        guard let selectedLocationLabel else {
+            return sites.count == 1 ? sites.first?.code : nil
+        }
+
+        let matchingSites = sites.filter { $0.locationLabel == selectedLocationLabel }
+        if matchingSites.count == 1 {
+            return matchingSites.first?.code
+        }
+        if let selectedLaterality {
+            return matchingSites.first(where: { $0.laterality == selectedLaterality })?.code
+        }
+        return nil
+    }
+}
+
+struct AvailableAccessInventory: Equatable {
+    let ivSites: [InterventionAnnotation]
+    let ioSites: [InterventionAnnotation]
+
+    init(interventions: [InterventionAnnotation]) {
+        let active = interventions
+            .filter { $0.status.lowercased() != InterventionStatus.removed.rawValue }
+            .sorted { $0.updatedAt > $1.updatedAt }
+
+        ivSites = active.filter { $0.interventionType == "iv_access" }
+        ioSites = active.filter { $0.interventionType == "io_access" }
+    }
+
+    var hasIV: Bool { !ivSites.isEmpty }
+    var hasIO: Bool { !ioSites.isEmpty }
+
+    var preferredRouteToken: String? {
+        if let newestIV = ivSites.first, let newestIO = ioSites.first {
+            return newestIV.updatedAt >= newestIO.updatedAt ? "IV" : "IO"
+        }
+        if hasIV { return "IV" }
+        if hasIO { return "IO" }
+        return nil
+    }
+
+    func filteredSites(for group: InterventionGroup) -> [InterventionSite] {
+        guard group.interventionType == "fluid_resuscitation" || group.interventionType == "blood_transfusion" else {
+            return group.sites
+        }
+
+        var sites = group.sites.filter { site in
+            (hasIV && site.code.uppercased().contains("IV")) || (hasIO && site.code.uppercased().contains("IO"))
+        }
+
+        if let preferredRouteToken {
+            sites.sort { lhs, rhs in
+                let leftPreferred = lhs.code.uppercased().contains(preferredRouteToken)
+                let rightPreferred = rhs.code.uppercased().contains(preferredRouteToken)
+                if leftPreferred != rightPreferred {
+                    return leftPreferred
+                }
+                return lhs.label < rhs.label
+            }
+        }
+
+        return sites
+    }
+
+    func disabledReason(for group: InterventionGroup) -> String? {
+        guard group.interventionType == "fluid_resuscitation" || group.interventionType == "blood_transfusion" else {
+            return nil
+        }
+        return hasIV || hasIO ? nil : "Requires IV or IO access"
+    }
+}
+
+struct InterventionDisabledOption: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let reason: String
+}
+
+struct RecommendedInterventionAction: Identifiable, Equatable {
+    let recommendationID: Int
+    let title: String
+    let subtitle: String?
+    let validationStatus: String?
+    let siteSummary: String?
+    let disabledReason: String?
+    let prefill: InterventionComposerPrefill
+
+    var id: Int { recommendationID }
+    var isEnabled: Bool { disabledReason == nil && prefill.siteCode != nil }
+}
+
+struct InterventionMenuContext {
+    let selectedProblem: ProblemAnnotation?
+    let accessInventory: AvailableAccessInventory
+    let recommendedActions: [RecommendedInterventionAction]
+    let availableGroups: [InterventionGroup]
+    let disabledItems: [InterventionDisabledOption]
+    let availableSitesByType: [String: [InterventionSite]]
+
+    init(
+        dictionary: [InterventionGroup],
+        problems: [ProblemAnnotation],
+        recommendations: [RecommendedInterventionItem],
+        interventions: [InterventionAnnotation],
+        selectedTargetProblemID: Int?
+    ) {
+        let selectedProblem = problems.first(where: { $0.problemID == selectedTargetProblemID })
+        let accessInventory = AvailableAccessInventory(interventions: interventions)
+
+        var availableSitesByType: [String: [InterventionSite]] = [:]
+        var disabledItems: [InterventionDisabledOption] = []
+        for group in dictionary {
+            let filteredSites = accessInventory.filteredSites(for: group)
+            availableSitesByType[group.interventionType] = filteredSites
+            if let reason = accessInventory.disabledReason(for: group) {
+                disabledItems.append(
+                    InterventionDisabledOption(
+                        id: group.interventionType,
+                        title: group.label,
+                        reason: reason
+                    )
+                )
+            }
+        }
+
+        let linkedRecommendations = recommendations
+            .filter { selectedTargetProblemID != nil && $0.targetProblemID == selectedTargetProblemID }
+            .sorted(by: Self.recommendationSortOrder)
+
+        let recommendedActions: [RecommendedInterventionAction] = linkedRecommendations.compactMap { recommendation -> RecommendedInterventionAction? in
+            guard let interventionType = Self.recommendedInterventionType(for: recommendation, dictionary: dictionary) else {
+                return nil
+            }
+            guard let group = dictionary.first(where: { $0.interventionType == interventionType }) else { return nil }
+
+            let prefill = Self.prefill(
+                for: group,
+                recommendation: recommendation,
+                selectedProblem: selectedProblem,
+                accessInventory: accessInventory,
+                availableSites: availableSitesByType[group.interventionType] ?? group.sites
+            )
+            let disabledReason = accessInventory.disabledReason(for: group)
+                ?? (prefill.siteCode == nil && (availableSitesByType[group.interventionType] ?? group.sites).count > 1 ? "Choose site in edit" : nil)
+
+            return RecommendedInterventionAction(
+                recommendationID: recommendation.recommendationID,
+                title: recommendation.title,
+                subtitle: recommendation.rationale,
+                validationStatus: recommendation.validationStatus,
+                siteSummary: InterventionDisplayText.siteLabel(
+                    siteCode: prefill.siteCode,
+                    siteLabel: recommendation.siteLabel,
+                    interventionType: interventionType,
+                    dictionary: dictionary
+                ),
+                disabledReason: disabledReason,
+                prefill: prefill
+            )
+        }
+
+        let recommendedTypes = linkedRecommendations.compactMap { Self.recommendedInterventionType(for: $0, dictionary: dictionary) }
+        let priorityOrder = Array(NSOrderedSet(array: recommendedTypes)) as? [String] ?? []
+        var ordered = dictionary.sorted { lhs, rhs in
+            let leftIndex = priorityOrder.firstIndex(of: lhs.interventionType) ?? .max
+            let rightIndex = priorityOrder.firstIndex(of: rhs.interventionType) ?? .max
+            if leftIndex != rightIndex {
+                return leftIndex < rightIndex
+            }
+            return lhs.label < rhs.label
+        }
+        ordered.removeAll { accessInventory.disabledReason(for: $0) != nil }
+
+        self.selectedProblem = selectedProblem
+        self.accessInventory = accessInventory
+        self.recommendedActions = recommendedActions
+        self.availableSitesByType = availableSitesByType
+        self.disabledItems = disabledItems
+        self.availableGroups = ordered
+    }
+
+    func availableSites(for group: InterventionGroup) -> [InterventionSite] {
+        availableSitesByType[group.interventionType] ?? group.sites
+    }
+
+    func prefill(for interventionType: String) -> InterventionComposerPrefill? {
+        guard let group = availableGroups.first(where: { $0.interventionType == interventionType }) else { return nil }
+        return Self.prefill(
+            for: group,
+            recommendation: nil,
+            selectedProblem: selectedProblem,
+            accessInventory: accessInventory,
+            availableSites: availableSites(for: group)
+        )
+    }
+
+    private static func recommendedInterventionType(
+        for recommendation: RecommendedInterventionItem,
+        dictionary: [InterventionGroup]
+    ) -> String? {
+        let candidates = [
+            recommendation.normalizedKind,
+            recommendation.kind,
+            recommendation.normalizedCode,
+            recommendation.code,
+        ].compactMap { candidate -> String? in
+            guard let candidate, !candidate.isEmpty else { return nil }
+            return candidate
+        }
+
+        return candidates.first { candidate in
+            dictionary.contains(where: { $0.interventionType == candidate })
+        }
+    }
+
+    private static func recommendationSortOrder(
+        _ lhs: RecommendedInterventionItem,
+        _ rhs: RecommendedInterventionItem
+    ) -> Bool {
+        let leftPriority = lhs.priority ?? .max
+        let rightPriority = rhs.priority ?? .max
+        if leftPriority != rightPriority {
+            return leftPriority < rightPriority
+        }
+        return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+    }
+
+    private static func prefill(
+        for group: InterventionGroup,
+        recommendation: RecommendedInterventionItem?,
+        selectedProblem: ProblemAnnotation?,
+        accessInventory: AvailableAccessInventory,
+        availableSites: [InterventionSite]
+    ) -> InterventionComposerPrefill {
+        let explicitSiteCode = recommendation?.siteCode
+        let inferredSiteCode = explicitSiteCode.flatMap { siteCode in
+            availableSites.first(where: { $0.code.caseInsensitiveCompare(siteCode) == .orderedSame })?.code
+        } ?? inferredSiteCode(for: group, selectedProblem: selectedProblem, availableSites: availableSites, accessInventory: accessInventory)
+
+        return InterventionComposerPrefill(
+            interventionType: group.interventionType,
+            siteCode: inferredSiteCode,
+            targetProblemID: recommendation?.targetProblemID ?? selectedProblem?.problemID,
+            status: .applied,
+            effectiveness: .effective,
+            notes: "",
+            tourniquetApplicationMode: group.interventionType == "tourniquet" ? .hasty : nil
+        )
+    }
+
+    private static func inferredSiteCode(
+        for group: InterventionGroup,
+        selectedProblem: ProblemAnnotation?,
+        availableSites: [InterventionSite],
+        accessInventory: AvailableAccessInventory
+    ) -> String? {
+        if group.interventionType == "fluid_resuscitation" || group.interventionType == "blood_transfusion" {
+            return availableSites.first?.code
+        }
+
+        guard let selectedProblem else {
+            return availableSites.count == 1 ? availableSites.first?.code : nil
+        }
+
+        guard let locationCode = selectedProblem.locationCode?.uppercased(), !locationCode.isEmpty else {
+            return availableSites.count == 1 ? availableSites.first?.code : nil
+        }
+
+        if let exactMatch = availableSites.first(where: { $0.code.uppercased() == locationCode }) {
+            return exactMatch.code
+        }
+
+        let locationTokens = Set(locationCode.split(whereSeparator: { $0 == "_" || $0 == "-" }).map(String.init))
+        let preferredLaterality = locationTokens.contains("LEFT") ? "left" : (locationTokens.contains("RIGHT") ? "right" : nil)
+
+        let sortedCandidates = availableSites
+            .filter { site in
+                preferredLaterality == nil || site.laterality == preferredLaterality
+            }
+            .sorted { lhs, rhs in
+                let leftScore = siteScore(lhs, locationTokens: locationTokens)
+                let rightScore = siteScore(rhs, locationTokens: locationTokens)
+                if leftScore != rightScore {
+                    return leftScore > rightScore
+                }
+                return lhs.label < rhs.label
+            }
+
+        if let best = sortedCandidates.first, siteScore(best, locationTokens: locationTokens) > 0 {
+            return best.code
+        }
+
+        return availableSites.count == 1 ? availableSites.first?.code : nil
+    }
+
+    private static func siteScore(_ site: InterventionSite, locationTokens: Set<String>) -> Int {
+        let tokens = Set(
+            site.code.uppercased()
+                .split(whereSeparator: { $0 == "_" || $0 == "-" })
+                .map(String.init)
+        )
+        return tokens.intersection(locationTokens).count
+    }
+}
+
+struct InterventionComposerSheet: View {
+    let dictionary: [InterventionGroup]
+    let problems: [ProblemAnnotation]
+    let recommendations: [RecommendedInterventionItem]
+    let interventions: [InterventionAnnotation]
+    let prefilledTargetProblemID: Int?
+    let canMutate: Bool
+    let onSubmit: (String, String, Int?, InterventionStatus, InterventionEffectiveness, String, TourniquetApplicationMode?) -> Void
+
+    @State private var draft: InterventionComposerDraft
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        dictionary: [InterventionGroup],
+        problems: [ProblemAnnotation],
+        recommendations: [RecommendedInterventionItem],
+        interventions: [InterventionAnnotation],
+        prefilledTargetProblemID: Int?,
+        canMutate: Bool,
+        onSubmit: @escaping (String, String, Int?, InterventionStatus, InterventionEffectiveness, String, TourniquetApplicationMode?) -> Void
+    ) {
+        self.dictionary = dictionary
+        self.problems = problems
+        self.recommendations = recommendations
+        self.interventions = interventions
+        self.prefilledTargetProblemID = prefilledTargetProblemID
+        self.canMutate = canMutate
+        self.onSubmit = onSubmit
+        _draft = State(initialValue: InterventionComposerDraft(prefilledTargetProblemID: prefilledTargetProblemID))
+    }
+
+    private var context: InterventionMenuContext {
+        InterventionMenuContext(
+            dictionary: dictionary,
+            problems: problems,
+            recommendations: recommendations,
+            interventions: interventions,
+            selectedTargetProblemID: draft.selectedTargetProblemID
+        )
+    }
+
+    private var selectedGroup: InterventionGroup? {
+        guard let selectedType = draft.selectedType else { return nil }
+        return dictionary.first(where: { $0.interventionType == selectedType })
+    }
+
+    private var selectedSites: [InterventionSite] {
+        guard let selectedGroup else { return [] }
+        return context.availableSites(for: selectedGroup)
+    }
+
+    private var locationGroups: [(location: String, sites: [InterventionSite])] {
+        InterventionSite.grouped(selectedSites)
+    }
+
+    private var canSubmit: Bool {
+        guard canMutate, let selectedType = draft.selectedType else { return false }
+        guard let group = dictionary.first(where: { $0.interventionType == selectedType }) else { return false }
+        return draft.resolvedSiteCode(in: context.availableSites(for: group)) != nil
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    targetProblemSection
+                    if !context.recommendedActions.isEmpty {
+                        recommendedSection
+                    }
+                    fullFormSection
+                    if !context.disabledItems.isEmpty {
+                        disabledItemsSection
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Add Intervention")
+            .modifier(InterventionComposerInlineTitleModifier())
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Apply", action: submitCurrentDraft)
+                        .disabled(!canSubmit)
+                }
+            }
+        }
+    }
+
+    private var targetProblemSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Target Problem")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+            Button {
+                draft.selectedTargetProblemID = nil
+                draft.activeSection = .type
+            } label: {
+                selectionRow(
+                    title: "General intervention",
+                    subtitle: "Not tied to a single problem",
+                    selected: draft.selectedTargetProblemID == nil
+                )
+            }
+            .buttonStyle(.plain)
+
+            ForEach(problems) { problem in
+                Button {
+                    draft.selectedTargetProblemID = problem.problemID
+                    draft.activeSection = .type
+                    refreshDefaultsForCurrentType()
+                } label: {
+                    selectionRow(
+                        title: problem.label,
+                        subtitle: problem.status.rawValue.capitalized,
+                        selected: draft.selectedTargetProblemID == problem.problemID
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var recommendedSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Recommended")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+            ForEach(context.recommendedActions) { action in
+                HStack(alignment: .top, spacing: 10) {
+                    Button(action: { submit(action) }) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(action.title)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.primary)
+                            if let subtitle = action.subtitle, !subtitle.isEmpty {
+                                Text(subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            if let siteSummary = action.siteSummary, !siteSummary.isEmpty {
+                                Text(siteSummary)
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundStyle(TrainerLabTheme.accentBlue)
+                            }
+                            if let disabledReason = action.disabledReason {
+                                Text(disabledReason)
+                                    .font(.caption2)
+                                    .foregroundStyle(TrainerLabTheme.warning)
+                            } else if let validationStatus = action.validationStatus {
+                                Text(SimulationEventRegistry.humanizedLabel(validationStatus))
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .background(Color.white.opacity(0.04))
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!action.isEnabled || !canMutate)
+
+                    Button {
+                        draft.applyPrefill(action.prefill, dictionary: dictionary)
+                        draft.activeSection = .review
+                    } label: {
+                        Image(systemName: "pencil")
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(TrainerLabTheme.accentBlue)
+                            .frame(width: 34, height: 34)
+                            .background(Color.white.opacity(0.06))
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var fullFormSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Full Form")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+            collapsibleSection(
+                title: "Intervention Type",
+                section: .type,
+                summary: draft.selectedType.map { InterventionDisplayText.interventionTypeLabel($0, dictionary: dictionary) }
+            ) {
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                    ForEach(context.availableGroups, id: \.id) { group in
+                        compactChip(
+                            title: group.label,
+                            selected: draft.selectedType == group.interventionType
+                        ) {
+                            selectInterventionType(group.interventionType)
+                        }
+                    }
+                }
+            }
+
+            if selectedGroup != nil {
+                collapsibleSection(
+                    title: "Site",
+                    section: .site,
+                    summary: draft.resolvedSiteCode(in: selectedSites).flatMap {
+                        InterventionDisplayText.siteLabel(
+                            siteCode: $0,
+                            siteLabel: nil,
+                            interventionType: draft.selectedType,
+                            dictionary: dictionary
+                        )
+                    }
+                ) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                            ForEach(locationGroups, id: \.location) { entry in
+                                compactChip(
+                                    title: entry.location,
+                                    selected: draft.selectedLocationLabel == entry.location
+                                ) {
+                                    draft.selectedLocationLabel = entry.location
+                                    draft.selectedLaterality = entry.sites.count == 1 ? entry.sites.first?.laterality : nil
+                                    draft.activeSection = draft.resolvedSiteCode(in: selectedSites) == nil ? .site : .review
+                                }
+                            }
+                        }
+
+                        let matchingSites = selectedSites.filter { $0.locationLabel == draft.selectedLocationLabel }
+                        if matchingSites.contains(where: { $0.laterality != nil }) {
+                            HStack(spacing: 8) {
+                                compactChip(title: "Left", selected: draft.selectedLaterality == "left") {
+                                    draft.selectedLaterality = draft.selectedLaterality == "left" ? nil : "left"
+                                    draft.activeSection = draft.resolvedSiteCode(in: selectedSites) == nil ? .site : .review
+                                }
+                                compactChip(title: "Right", selected: draft.selectedLaterality == "right") {
+                                    draft.selectedLaterality = draft.selectedLaterality == "right" ? nil : "right"
+                                    draft.activeSection = draft.resolvedSiteCode(in: selectedSites) == nil ? .site : .review
+                                }
+                                Spacer()
+                            }
+                        }
+                    }
+                }
+
+                collapsibleSection(
+                    title: "Status & Effectiveness",
+                    section: .review,
+                    summary: "\(draft.status.rawValue.capitalized) · \(SimulationEventRegistry.humanizedLabel(draft.effectiveness.rawValue))"
+                ) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(alignment: .top, spacing: 10) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Status")
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                                chipGrid(
+                                    items: InterventionStatus.allCases.map { ($0.rawValue.capitalized, $0) },
+                                    selected: draft.status
+                                ) { value in
+                                    draft.status = value
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Effectiveness")
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                                chipGrid(
+                                    items: InterventionEffectiveness.allCases.map { (SimulationEventRegistry.humanizedLabel($0.rawValue), $0) },
+                                    selected: draft.effectiveness
+                                ) { value in
+                                    draft.effectiveness = value
+                                }
+                            }
+                        }
+
+                        if draft.selectedType == "tourniquet" {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Application Mode")
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                                chipGrid(
+                                    items: TourniquetApplicationMode.allCases.map { (SimulationEventRegistry.humanizedLabel($0.rawValue), $0) },
+                                    selected: draft.tourniquetApplicationMode
+                                ) { value in
+                                    draft.tourniquetApplicationMode = value
+                                }
+                            }
+                        }
+                    }
+                }
+
+                collapsibleSection(
+                    title: "Notes",
+                    section: .notes,
+                    summary: draft.notes.isEmpty ? nil : draft.notes
+                ) {
+                    TextField("Optional notes", text: $draft.notes, axis: .vertical)
+                        .lineLimit(2 ... 4)
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var disabledItemsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Unavailable Right Now")
+                .font(.caption.bold())
+                .foregroundStyle(.secondary)
+
+            ForEach(context.disabledItems) { item in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title)
+                        .font(.caption.weight(.semibold))
+                    Text(item.reason)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.white.opacity(0.03))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+        }
+        .padding(12)
+        .background(Color.white.opacity(0.05))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func collapsibleSection<Content: View>(
+        title: String,
+        section: InterventionComposerSection,
+        summary: String?,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                draft.activeSection = section
+                if section == .notes {
+                    draft.notesExpanded = true
+                }
+            } label: {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .font(.caption.bold())
+                            .foregroundStyle(.secondary)
+                        if let summary, draft.activeSection != section {
+                            Text(summary)
+                                .font(.caption)
+                                .foregroundStyle(.primary)
+                                .lineLimit(2)
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: draft.activeSection == section ? "chevron.up" : "chevron.down")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if draft.activeSection == section || (section == .notes && draft.notesExpanded) {
+                content()
+            }
+        }
+    }
+
+    private func chipGrid<Value: Hashable>(
+        items: [(String, Value)],
+        selected: Value,
+        onSelect: @escaping (Value) -> Void
+    ) -> some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+            ForEach(items, id: \.0) { item in
+                compactChip(title: item.0, selected: item.1 == selected) {
+                    onSelect(item.1)
+                }
+            }
+        }
+    }
+
+    private func compactChip(title: String, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(selected ? .white : .primary)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 9)
+                .padding(.horizontal, 8)
+                .background(selected ? TrainerLabTheme.accentBlue : Color.secondary.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func selectionRow(title: String, subtitle: String, selected: Bool) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if selected {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(TrainerLabTheme.accentBlue)
+            }
+        }
+        .padding(10)
+        .background(Color.white.opacity(selected ? 0.08 : 0.03))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func selectInterventionType(_ interventionType: String) {
+        draft.selectedType = interventionType
+        draft.selectedLocationLabel = nil
+        draft.selectedLaterality = nil
+        draft.notes = ""
+        draft.notesExpanded = false
+        draft.tourniquetApplicationMode = .hasty
+        refreshDefaultsForCurrentType()
+    }
+
+    private func refreshDefaultsForCurrentType() {
+        guard let selectedType = draft.selectedType, let prefill = context.prefill(for: selectedType) else {
+            draft.activeSection = .type
+            return
+        }
+        draft.applyPrefill(prefill, dictionary: dictionary)
+        draft.activeSection = prefill.siteCode == nil ? .site : .review
+    }
+
+    private func submitCurrentDraft() {
+        guard
+            let selectedType = draft.selectedType,
+            let selectedGroup,
+            let siteCode = draft.resolvedSiteCode(in: context.availableSites(for: selectedGroup))
+        else {
+            return
+        }
+
+        onSubmit(
+            selectedType,
+            siteCode,
+            draft.selectedTargetProblemID,
+            draft.status,
+            draft.effectiveness,
+            draft.notes,
+            draft.selectedTourniquetApplicationMode
+        )
+        dismiss()
+    }
+
+    private func submit(_ action: RecommendedInterventionAction) {
+        guard action.isEnabled, let siteCode = action.prefill.siteCode else { return }
+        onSubmit(
+            action.prefill.interventionType,
+            siteCode,
+            action.prefill.targetProblemID,
+            action.prefill.status,
+            action.prefill.effectiveness,
+            action.prefill.notes,
+            action.prefill.tourniquetApplicationMode
+        )
+        dismiss()
+    }
+}
+
+private struct InterventionComposerInlineTitleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        #if os(iOS)
+            content.navigationBarTitleDisplayMode(.inline)
+        #else
+            content
+        #endif
+    }
+}

--- a/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
@@ -27,7 +27,7 @@ struct InterventionComposerPrefill: Equatable {
         status: InterventionStatus = .applied,
         effectiveness: InterventionEffectiveness = .effective,
         notes: String = "",
-        tourniquetApplicationMode: TourniquetApplicationMode? = nil
+        tourniquetApplicationMode: TourniquetApplicationMode? = nil,
     ) {
         self.interventionType = interventionType
         self.siteCode = siteCode
@@ -115,8 +115,13 @@ struct AvailableAccessInventory: Equatable {
         ioSites = active.filter { $0.interventionType == "io_access" }
     }
 
-    var hasIV: Bool { !ivSites.isEmpty }
-    var hasIO: Bool { !ioSites.isEmpty }
+    var hasIV: Bool {
+        !ivSites.isEmpty
+    }
+
+    var hasIO: Bool {
+        !ioSites.isEmpty
+    }
 
     var preferredRouteToken: String? {
         if let newestIV = ivSites.first, let newestIO = ioSites.first {
@@ -173,8 +178,13 @@ struct RecommendedInterventionAction: Identifiable, Equatable {
     let disabledReason: String?
     let prefill: InterventionComposerPrefill
 
-    var id: Int { recommendationID }
-    var isEnabled: Bool { disabledReason == nil && prefill.siteCode != nil }
+    var id: Int {
+        recommendationID
+    }
+
+    var isEnabled: Bool {
+        disabledReason == nil && prefill.siteCode != nil
+    }
 }
 
 struct InterventionMenuContext {
@@ -190,7 +200,7 @@ struct InterventionMenuContext {
         problems: [ProblemAnnotation],
         recommendations: [RecommendedInterventionItem],
         interventions: [InterventionAnnotation],
-        selectedTargetProblemID: Int?
+        selectedTargetProblemID: Int?,
     ) {
         let selectedProblem = problems.first(where: { $0.problemID == selectedTargetProblemID })
         let accessInventory = AvailableAccessInventory(interventions: interventions)
@@ -205,8 +215,8 @@ struct InterventionMenuContext {
                     InterventionDisabledOption(
                         id: group.interventionType,
                         title: group.label,
-                        reason: reason
-                    )
+                        reason: reason,
+                    ),
                 )
             }
         }
@@ -226,7 +236,7 @@ struct InterventionMenuContext {
                 recommendation: recommendation,
                 selectedProblem: selectedProblem,
                 accessInventory: accessInventory,
-                availableSites: availableSitesByType[group.interventionType] ?? group.sites
+                availableSites: availableSitesByType[group.interventionType] ?? group.sites,
             )
             let disabledReason = accessInventory.disabledReason(for: group)
                 ?? (prefill.siteCode == nil && (availableSitesByType[group.interventionType] ?? group.sites).count > 1 ? "Choose site in edit" : nil)
@@ -240,10 +250,10 @@ struct InterventionMenuContext {
                     siteCode: prefill.siteCode,
                     siteLabel: recommendation.siteLabel,
                     interventionType: interventionType,
-                    dictionary: dictionary
+                    dictionary: dictionary,
                 ),
                 disabledReason: disabledReason,
-                prefill: prefill
+                prefill: prefill,
             )
         }
 
@@ -264,7 +274,7 @@ struct InterventionMenuContext {
         self.recommendedActions = recommendedActions
         self.availableSitesByType = availableSitesByType
         self.disabledItems = disabledItems
-        self.availableGroups = ordered
+        availableGroups = ordered
     }
 
     func availableSites(for group: InterventionGroup) -> [InterventionSite] {
@@ -278,13 +288,13 @@ struct InterventionMenuContext {
             recommendation: nil,
             selectedProblem: selectedProblem,
             accessInventory: accessInventory,
-            availableSites: availableSites(for: group)
+            availableSites: availableSites(for: group),
         )
     }
 
     private static func recommendedInterventionType(
         for recommendation: RecommendedInterventionItem,
-        dictionary: [InterventionGroup]
+        dictionary: [InterventionGroup],
     ) -> String? {
         let candidates = [
             recommendation.normalizedKind,
@@ -303,7 +313,7 @@ struct InterventionMenuContext {
 
     private static func recommendationSortOrder(
         _ lhs: RecommendedInterventionItem,
-        _ rhs: RecommendedInterventionItem
+        _ rhs: RecommendedInterventionItem,
     ) -> Bool {
         let leftPriority = lhs.priority ?? .max
         let rightPriority = rhs.priority ?? .max
@@ -318,7 +328,7 @@ struct InterventionMenuContext {
         recommendation: RecommendedInterventionItem?,
         selectedProblem: ProblemAnnotation?,
         accessInventory: AvailableAccessInventory,
-        availableSites: [InterventionSite]
+        availableSites: [InterventionSite],
     ) -> InterventionComposerPrefill {
         let explicitSiteCode = recommendation?.siteCode
         let inferredSiteCode = explicitSiteCode.flatMap { siteCode in
@@ -332,7 +342,7 @@ struct InterventionMenuContext {
             status: .applied,
             effectiveness: .effective,
             notes: "",
-            tourniquetApplicationMode: group.interventionType == "tourniquet" ? .hasty : nil
+            tourniquetApplicationMode: group.interventionType == "tourniquet" ? .hasty : nil,
         )
     }
 
@@ -340,7 +350,7 @@ struct InterventionMenuContext {
         for group: InterventionGroup,
         selectedProblem: ProblemAnnotation?,
         availableSites: [InterventionSite],
-        accessInventory: AvailableAccessInventory
+        accessInventory _: AvailableAccessInventory,
     ) -> String? {
         if group.interventionType == "fluid_resuscitation" || group.interventionType == "blood_transfusion" {
             return availableSites.first?.code
@@ -385,7 +395,7 @@ struct InterventionMenuContext {
         let tokens = Set(
             site.code.uppercased()
                 .split(whereSeparator: { $0 == "_" || $0 == "-" })
-                .map(String.init)
+                .map(String.init),
         )
         return tokens.intersection(locationTokens).count
     }
@@ -410,7 +420,7 @@ struct InterventionComposerSheet: View {
         interventions: [InterventionAnnotation],
         prefilledTargetProblemID: Int?,
         canMutate: Bool,
-        onSubmit: @escaping (String, String, Int?, InterventionStatus, InterventionEffectiveness, String, TourniquetApplicationMode?) -> Void
+        onSubmit: @escaping (String, String, Int?, InterventionStatus, InterventionEffectiveness, String, TourniquetApplicationMode?) -> Void,
     ) {
         self.dictionary = dictionary
         self.problems = problems
@@ -428,7 +438,7 @@ struct InterventionComposerSheet: View {
             problems: problems,
             recommendations: recommendations,
             interventions: interventions,
-            selectedTargetProblemID: draft.selectedTargetProblemID
+            selectedTargetProblemID: draft.selectedTargetProblemID,
         )
     }
 
@@ -494,7 +504,7 @@ struct InterventionComposerSheet: View {
                 selectionRow(
                     title: "General intervention",
                     subtitle: "Not tied to a single problem",
-                    selected: draft.selectedTargetProblemID == nil
+                    selected: draft.selectedTargetProblemID == nil,
                 )
             }
             .buttonStyle(.plain)
@@ -508,7 +518,7 @@ struct InterventionComposerSheet: View {
                     selectionRow(
                         title: problem.label,
                         subtitle: problem.status.rawValue.capitalized,
-                        selected: draft.selectedTargetProblemID == problem.problemID
+                        selected: draft.selectedTargetProblemID == problem.problemID,
                     )
                 }
                 .buttonStyle(.plain)
@@ -527,36 +537,39 @@ struct InterventionComposerSheet: View {
 
             ForEach(context.recommendedActions) { action in
                 HStack(alignment: .top, spacing: 10) {
-                    Button(action: { submit(action) }) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(action.title)
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.primary)
-                            if let subtitle = action.subtitle, !subtitle.isEmpty {
-                                Text(subtitle)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
+                    Button(
+                        action: { submit(action) },
+                        label: {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(action.title)
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(.primary)
+                                if let subtitle = action.subtitle, !subtitle.isEmpty {
+                                    Text(subtitle)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                if let siteSummary = action.siteSummary, !siteSummary.isEmpty {
+                                    Text(siteSummary)
+                                        .font(.caption2.weight(.semibold))
+                                        .foregroundStyle(TrainerLabTheme.accentBlue)
+                                }
+                                if let disabledReason = action.disabledReason {
+                                    Text(disabledReason)
+                                        .font(.caption2)
+                                        .foregroundStyle(TrainerLabTheme.warning)
+                                } else if let validationStatus = action.validationStatus {
+                                    Text(SimulationEventRegistry.humanizedLabel(validationStatus))
+                                        .font(.caption2)
+                                        .foregroundStyle(.secondary)
+                                }
                             }
-                            if let siteSummary = action.siteSummary, !siteSummary.isEmpty {
-                                Text(siteSummary)
-                                    .font(.caption2.weight(.semibold))
-                                    .foregroundStyle(TrainerLabTheme.accentBlue)
-                            }
-                            if let disabledReason = action.disabledReason {
-                                Text(disabledReason)
-                                    .font(.caption2)
-                                    .foregroundStyle(TrainerLabTheme.warning)
-                            } else if let validationStatus = action.validationStatus {
-                                Text(SimulationEventRegistry.humanizedLabel(validationStatus))
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(10)
-                        .background(Color.white.opacity(0.04))
-                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                    }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                            .background(Color.white.opacity(0.04))
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        },
+                    )
                     .buttonStyle(.plain)
                     .disabled(!action.isEnabled || !canMutate)
 
@@ -589,13 +602,13 @@ struct InterventionComposerSheet: View {
             collapsibleSection(
                 title: "Intervention Type",
                 section: .type,
-                summary: draft.selectedType.map { InterventionDisplayText.interventionTypeLabel($0, dictionary: dictionary) }
+                summary: draft.selectedType.map { InterventionDisplayText.interventionTypeLabel($0, dictionary: dictionary) },
             ) {
                 LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
                     ForEach(context.availableGroups, id: \.id) { group in
                         compactChip(
                             title: group.label,
-                            selected: draft.selectedType == group.interventionType
+                            selected: draft.selectedType == group.interventionType,
                         ) {
                             selectInterventionType(group.interventionType)
                         }
@@ -612,16 +625,16 @@ struct InterventionComposerSheet: View {
                             siteCode: $0,
                             siteLabel: nil,
                             interventionType: draft.selectedType,
-                            dictionary: dictionary
+                            dictionary: dictionary,
                         )
-                    }
+                    },
                 ) {
                     VStack(alignment: .leading, spacing: 10) {
                         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
                             ForEach(locationGroups, id: \.location) { entry in
                                 compactChip(
                                     title: entry.location,
-                                    selected: draft.selectedLocationLabel == entry.location
+                                    selected: draft.selectedLocationLabel == entry.location,
                                 ) {
                                     draft.selectedLocationLabel = entry.location
                                     draft.selectedLaterality = entry.sites.count == 1 ? entry.sites.first?.laterality : nil
@@ -650,7 +663,7 @@ struct InterventionComposerSheet: View {
                 collapsibleSection(
                     title: "Status & Effectiveness",
                     section: .review,
-                    summary: "\(draft.status.rawValue.capitalized) · \(SimulationEventRegistry.humanizedLabel(draft.effectiveness.rawValue))"
+                    summary: "\(draft.status.rawValue.capitalized) · \(SimulationEventRegistry.humanizedLabel(draft.effectiveness.rawValue))",
                 ) {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(alignment: .top, spacing: 10) {
@@ -660,7 +673,7 @@ struct InterventionComposerSheet: View {
                                     .foregroundStyle(.secondary)
                                 chipGrid(
                                     items: InterventionStatus.allCases.map { ($0.rawValue.capitalized, $0) },
-                                    selected: draft.status
+                                    selected: draft.status,
                                 ) { value in
                                     draft.status = value
                                 }
@@ -672,7 +685,7 @@ struct InterventionComposerSheet: View {
                                     .foregroundStyle(.secondary)
                                 chipGrid(
                                     items: InterventionEffectiveness.allCases.map { (SimulationEventRegistry.humanizedLabel($0.rawValue), $0) },
-                                    selected: draft.effectiveness
+                                    selected: draft.effectiveness,
                                 ) { value in
                                     draft.effectiveness = value
                                 }
@@ -686,7 +699,7 @@ struct InterventionComposerSheet: View {
                                     .foregroundStyle(.secondary)
                                 chipGrid(
                                     items: TourniquetApplicationMode.allCases.map { (SimulationEventRegistry.humanizedLabel($0.rawValue), $0) },
-                                    selected: draft.tourniquetApplicationMode
+                                    selected: draft.tourniquetApplicationMode,
                                 ) { value in
                                     draft.tourniquetApplicationMode = value
                                 }
@@ -698,7 +711,7 @@ struct InterventionComposerSheet: View {
                 collapsibleSection(
                     title: "Notes",
                     section: .notes,
-                    summary: draft.notes.isEmpty ? nil : draft.notes
+                    summary: draft.notes.isEmpty ? nil : draft.notes,
                 ) {
                     TextField("Optional notes", text: $draft.notes, axis: .vertical)
                         .lineLimit(2 ... 4)
@@ -736,11 +749,11 @@ struct InterventionComposerSheet: View {
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
-    private func collapsibleSection<Content: View>(
+    private func collapsibleSection(
         title: String,
         section: InterventionComposerSection,
         summary: String?,
-        @ViewBuilder content: () -> Content
+        @ViewBuilder content: () -> some View,
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Button {
@@ -778,7 +791,7 @@ struct InterventionComposerSheet: View {
     private func chipGrid<Value: Hashable>(
         items: [(String, Value)],
         selected: Value,
-        onSelect: @escaping (Value) -> Void
+        onSelect: @escaping (Value) -> Void,
     ) -> some View {
         LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
             ForEach(items, id: \.0) { item in
@@ -859,7 +872,7 @@ struct InterventionComposerSheet: View {
             draft.status,
             draft.effectiveness,
             draft.notes,
-            draft.selectedTourniquetApplicationMode
+            draft.selectedTourniquetApplicationMode,
         )
         dismiss()
     }
@@ -873,7 +886,7 @@ struct InterventionComposerSheet: View {
             action.prefill.status,
             action.prefill.effectiveness,
             action.prefill.notes,
-            action.prefill.tourniquetApplicationMode
+            action.prefill.tourniquetApplicationMode,
         )
         dismiss()
     }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -449,6 +449,7 @@ struct PatientDiagramPanel: View {
     let problems: [ProblemAnnotation]
     let recommendations: [RecommendedInterventionItem]
     let pulses: [PulseAnnotation]
+    let pendingInterventionProblemIDs: Set<Int>
     let canMutate: Bool
     var onSelectInjury: ((InjuryAnnotation) -> Void)?
     var onUpdateProblemStatus: ((ProblemAnnotation, ProblemLifecycleState) -> Void)?
@@ -866,6 +867,10 @@ struct PatientDiagramPanel: View {
                 }
             }
             Spacer()
+            if let problemID = problem.problemID, pendingInterventionProblemIDs.contains(problemID) {
+                ProgressView()
+                    .controlSize(.mini)
+            }
             Text(problem.status.rawValue.uppercased())
                 .font(.caption2.bold())
                 .foregroundStyle(problem.isUncontrolled ? TrainerLabTheme.danger : TrainerLabTheme.success)
@@ -879,15 +884,19 @@ struct PatientDiagramPanel: View {
     }
 
     private func interventionRow(_ intervention: InterventionAnnotation) -> some View {
-        HStack(spacing: 6) {
+        let siteSummary = InterventionDisplayText.siteLabel(
+            siteCode: intervention.siteCode,
+            siteLabel: intervention.siteLabel
+        ) ?? intervention.siteCode
+        return HStack(spacing: 6) {
             Image(systemName: "plus.circle.fill")
                 .font(.caption)
                 .foregroundStyle(TrainerLabTheme.accentBlue)
             VStack(alignment: .leading, spacing: 1) {
-                Text(intervention.interventionType.replacingOccurrences(of: "_", with: " ").capitalized)
+                Text(SimulationEventRegistry.humanizedLabel(intervention.interventionType))
                     .font(.caption2.bold())
                     .lineLimit(1)
-                Text("\(intervention.siteCode.replacingOccurrences(of: "_", with: " ").capitalized) — \(intervention.effectiveness.capitalized)")
+                Text("\(siteSummary) — \(SimulationEventRegistry.humanizedLabel(intervention.effectiveness))")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
             }
@@ -958,12 +967,16 @@ struct PatientDiagramPanel: View {
                 }
             case let .intervention(intervention):
                 VStack(alignment: .leading, spacing: 4) {
+                    let siteSummary = InterventionDisplayText.siteLabel(
+                        siteCode: intervention.siteCode,
+                        siteLabel: intervention.siteLabel
+                    ) ?? intervention.siteCode
                     Text(intervention.title)
                         .font(.caption.bold())
-                    Text("Site: \(intervention.siteCode.replacingOccurrences(of: "_", with: " ").capitalized) · \(intervention.side.rawValue.capitalized)")
+                    Text("Site: \(siteSummary) · \(intervention.side.rawValue.capitalized)")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                    Text("Effectiveness: \(intervention.effectiveness.capitalized) — \(intervention.status.capitalized)")
+                    Text("Effectiveness: \(SimulationEventRegistry.humanizedLabel(intervention.effectiveness)) — \(intervention.status.capitalized)")
                         .font(.caption2)
                     if let validationStatus = intervention.validationStatus {
                         Text("Validation: \(validationStatus.replacingOccurrences(of: "_", with: " ").capitalized)")
@@ -980,6 +993,15 @@ struct PatientDiagramPanel: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(problem.label)
                         .font(.caption.bold())
+                    if let problemID = problem.problemID, pendingInterventionProblemIDs.contains(problemID) {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .controlSize(.mini)
+                            Text("Intervention pending")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                     Text("Status: \(problem.status.rawValue.capitalized)")
                         .font(.caption2)
                         .foregroundStyle(problem.isUncontrolled ? TrainerLabTheme.danger : TrainerLabTheme.success)

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -325,6 +325,38 @@ struct RunConsoleCompactMetrics {
     )
 }
 
+struct RunConsoleRegularVitalsMetrics {
+    let sectionSpacing: CGFloat
+    let cardPadding: CGFloat
+    let maxHeight: CGFloat
+    let inlineGroupSpacing: CGFloat
+    let fallbackRowSpacing: CGFloat
+    let vitalsRowSpacing: CGFloat
+    let vitalCellSpacing: CGFloat
+    let vitalValueFont: Font
+    let vitalValueVerticalPadding: CGFloat
+    let avpuSpacing: CGFloat
+    let avpuChipSpacing: CGFloat
+    let avpuChipHorizontalPadding: CGFloat
+    let avpuChipMinHeight: CGFloat
+
+    static let standard = Self(
+        sectionSpacing: 8,
+        cardPadding: 8,
+        maxHeight: 112,
+        inlineGroupSpacing: 18,
+        fallbackRowSpacing: 10,
+        vitalsRowSpacing: 12,
+        vitalCellSpacing: 2,
+        vitalValueFont: .subheadline.monospacedDigit(),
+        vitalValueVerticalPadding: 6,
+        avpuSpacing: 10,
+        avpuChipSpacing: 6,
+        avpuChipHorizontalPadding: 10,
+        avpuChipMinHeight: 32,
+    )
+}
+
 // MARK: - InterventionMARCHGroup
 
 enum InterventionMARCHGroup: String, CaseIterable {

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -1145,7 +1145,7 @@ struct PatientDiagramPanel: View {
     private func interventionRow(_ intervention: InterventionAnnotation) -> some View {
         let siteSummary = InterventionDisplayText.siteLabel(
             siteCode: intervention.siteCode,
-            siteLabel: intervention.siteLabel
+            siteLabel: intervention.siteLabel,
         ) ?? intervention.siteCode
         return HStack(spacing: 6) {
             Image(systemName: "plus.circle.fill")
@@ -1228,7 +1228,7 @@ struct PatientDiagramPanel: View {
                 VStack(alignment: .leading, spacing: 4) {
                     let siteSummary = InterventionDisplayText.siteLabel(
                         siteCode: intervention.siteCode,
-                        siteLabel: intervention.siteLabel
+                        siteLabel: intervention.siteLabel,
                     ) ?? intervention.siteCode
                     Text(intervention.title)
                         .font(.caption.bold())

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -444,6 +444,7 @@ public struct RunConsoleView: View {
                 problems: store.state.problemAnnotations,
                 recommendations: store.state.recommendedInterventions,
                 pulses: store.state.pulseAnnotations,
+                pendingInterventionProblemIDs: store.pendingInterventionProblemIDs,
                 canMutate: canMutate,
                 onSelectInjury: { injury in
                     guard canIntervene else { return }
@@ -1548,9 +1549,11 @@ public struct RunConsoleView: View {
     // MARK: - Intervention sheet (structured picker)
 
     private var interventionSheet: some View {
-        InterventionPickerSheet(
+        InterventionComposerSheet(
             dictionary: store.interventionDictionary,
             problems: store.state.problemAnnotations,
+            recommendations: store.state.recommendedInterventions,
+            interventions: store.state.interventionAnnotations,
             prefilledTargetProblemID: interventionTargetProblemID,
             canMutate: canIntervene,
         ) { type, siteCode, targetProblemID, status, effectiveness, notes, tourniquetApplicationMode in
@@ -2250,13 +2253,16 @@ public struct RunConsoleView: View {
         let button = Button {
             performControl(control)
         } label: {
-            Label {
+            HStack(spacing: 6) {
+                Image(systemName: control.systemImage)
                 Text(control.title)
                     .lineLimit(multiline ? 2 : 1)
                     .multilineTextAlignment(fullWidth ? .center : .leading)
                     .fixedSize(horizontal: false, vertical: true)
-            } icon: {
-                Image(systemName: control.systemImage)
+                if isPendingInterventionControl(control) {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
             }
             .font(compact ? compactMetrics.buttonFont : .body)
             .frame(maxWidth: fullWidth ? .infinity : nil, alignment: fullWidth ? .center : .leading)
@@ -2315,322 +2321,10 @@ public struct RunConsoleView: View {
         .background(TrainerLabTheme.tacticalSurface)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
-}
 
-// MARK: - Intervention picker sheet
-
-private struct InterventionPickerSheet: View {
-    let dictionary: [InterventionGroup]
-    let problems: [ProblemAnnotation]
-    let prefilledTargetProblemID: Int?
-    let canMutate: Bool
-    let onSubmit: (String, String, Int?, InterventionStatus, InterventionEffectiveness, String, TourniquetApplicationMode?) -> Void
-
-    @State private var selectedType: String?
-    @State private var selectedTargetProblemID: Int?
-    @State private var selectedLocationLabel: String?
-    @State private var selectedLaterality: String?
-    @State private var status: InterventionStatus = .applied
-    @State private var effectiveness: InterventionEffectiveness = .effective
-    @State private var tourniquetApplicationMode: TourniquetApplicationMode = .hasty
-    @State private var notes = ""
-    @Environment(\.dismiss) private var dismiss
-
-    private var selectedGroup: InterventionGroup? {
-        guard let type = selectedType else { return nil }
-        return dictionary.first { $0.interventionType == type }
-    }
-
-    private var locationGroups: [(location: String, sites: [InterventionSite])] {
-        guard let group = selectedGroup else { return [] }
-        return InterventionSite.grouped(group.sites)
-    }
-
-    private var resolvedSiteCode: String? {
-        guard let group = selectedGroup, let locLabel = selectedLocationLabel else { return nil }
-        let matchingSites = group.sites.filter { $0.locationLabel == locLabel }
-        if matchingSites.count == 1 {
-            return matchingSites.first?.code
-        }
-        if let lat = selectedLaterality {
-            return matchingSites.first { $0.laterality == lat }?.code
-        }
-        return nil
-    }
-
-    private var canSubmit: Bool {
-        canMutate && resolvedSiteCode != nil
-    }
-
-    private var selectedTourniquetApplicationMode: TourniquetApplicationMode? {
-        selectedType == "tourniquet" ? tourniquetApplicationMode : nil
-    }
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                if !problems.isEmpty {
-                    Section("Target Problem (Optional)") {
-                        Button {
-                            selectedTargetProblemID = nil
-                        } label: {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text("No specific problem")
-                                        .foregroundStyle(.primary)
-                                    Text("Record this as a general intervention.")
-                                        .font(.caption2)
-                                        .foregroundStyle(.secondary)
-                                }
-                                Spacer()
-                                if selectedTargetProblemID == nil {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundStyle(Color.accentColor)
-                                }
-                            }
-                        }
-
-                        ForEach(problems) { problem in
-                            Button {
-                                selectedTargetProblemID = problem.problemID
-                            } label: {
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(problem.label)
-                                            .foregroundStyle(.primary)
-                                        Text(problem.status.rawValue.capitalized)
-                                            .font(.caption2)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    Spacer()
-                                    if selectedTargetProblemID == problem.problemID {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundStyle(Color.accentColor)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    Section("Target Problem (Optional)") {
-                        Text("Leave this blank to record a general intervention.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                // Step 1: Intervention type (MARCH grouped)
-                Section("Intervention Type") {
-                    if let type = selectedType {
-                        let label = dictionary.first { $0.interventionType == type }?.label ?? type
-                        selectedChip(label) {
-                            selectedType = nil
-                            selectedLocationLabel = nil
-                            selectedLaterality = nil
-                        }
-                    } else {
-                        VStack(alignment: .leading, spacing: 10) {
-                            ForEach(InterventionMARCHGroup.allCases, id: \.self) { marchGroup in
-                                let types = marchGroup.interventionTypes.compactMap { code in
-                                    dictionary.first { $0.interventionType == code }
-                                }
-                                if !types.isEmpty {
-                                    Text(marchGroup.rawValue)
-                                        .font(.caption.bold())
-                                        .foregroundStyle(.secondary)
-                                    LazyVGrid(
-                                        columns: [GridItem(.adaptive(minimum: 140), spacing: 8)],
-                                        spacing: 8,
-                                    ) {
-                                        ForEach(types) { group in
-                                            typeChip(group)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                .listRowBackground(Color.clear)
-                .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
-
-                // Step 2: Location (visible after type selected)
-                if let group = selectedGroup, !locationGroups.isEmpty {
-                    Section("Location") {
-                        if let locLabel = selectedLocationLabel {
-                            selectedChip(locLabel) {
-                                selectedLocationLabel = nil
-                                selectedLaterality = nil
-                            }
-                            // Laterality inline after location selected
-                            let sites = group.sites.filter { $0.locationLabel == locLabel }
-                            let needsLat = sites.contains { $0.laterality != nil }
-                            if needsLat {
-                                if let lat = selectedLaterality {
-                                    selectedChip(lat.capitalized) { selectedLaterality = nil }
-                                } else {
-                                    HStack(spacing: 8) {
-                                        lateralityChip("left", label: "Left")
-                                        lateralityChip("right", label: "Right")
-                                        Spacer()
-                                    }
-                                }
-                            }
-                        } else {
-                            LazyVGrid(
-                                columns: [GridItem(.adaptive(minimum: 110), spacing: 8)],
-                                spacing: 8,
-                            ) {
-                                ForEach(locationGroups, id: \.location) { entry in
-                                    locationChip(entry.location)
-                                }
-                            }
-                        }
-                    }
-                    .listRowBackground(Color.clear)
-                    .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
-                }
-
-                // Effectiveness + Status + Notes (visible after type selected)
-                if selectedType != nil {
-                    Section("Effectiveness") {
-                        Picker("Effectiveness", selection: $effectiveness) {
-                            Text("Unknown").tag(InterventionEffectiveness.unknown)
-                            Text("Effective").tag(InterventionEffectiveness.effective)
-                            Text("Partial").tag(InterventionEffectiveness.partiallyEffective)
-                            Text("Ineffective").tag(InterventionEffectiveness.ineffective)
-                        }
-                        .pickerStyle(.segmented)
-                        .listRowBackground(Color.clear)
-                    }
-
-                    Section("Status") {
-                        Picker("Status", selection: $status) {
-                            Text("Applied").tag(InterventionStatus.applied)
-                            Text("Adjusted").tag(InterventionStatus.adjusted)
-                            Text("Reassessed").tag(InterventionStatus.reassessed)
-                            Text("Removed").tag(InterventionStatus.removed)
-                        }
-                        .pickerStyle(.segmented)
-                        .listRowBackground(Color.clear)
-                    }
-
-                    if selectedType == "tourniquet" {
-                        Section("Application Mode") {
-                            Picker("Application Mode", selection: $tourniquetApplicationMode) {
-                                Text("Hasty").tag(TourniquetApplicationMode.hasty)
-                                Text("Deliberate").tag(TourniquetApplicationMode.deliberate)
-                            }
-                            .pickerStyle(.segmented)
-                            .listRowBackground(Color.clear)
-                        }
-                    }
-
-                    Section("Notes (optional)") {
-                        TextField("Additional notes...", text: $notes, axis: .vertical)
-                            .lineLimit(1 ... 3)
-                    }
-                }
-            }
-            .navigationTitle("Add Intervention")
-            .inlineNavBarTitle()
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Apply") {
-                        guard let siteCode = resolvedSiteCode,
-                              let type = selectedType else { return }
-                        onSubmit(
-                            type,
-                            siteCode,
-                            selectedTargetProblemID,
-                            status,
-                            effectiveness,
-                            notes,
-                            selectedTourniquetApplicationMode,
-                        )
-                    }
-                    .disabled(!canSubmit)
-                }
-            }
-        }
-        .onAppear {
-            if selectedTargetProblemID == nil {
-                selectedTargetProblemID = prefilledTargetProblemID
-            }
-        }
-    }
-
-    private func selectedChip(_ label: String, onClear: @escaping () -> Void) -> some View {
-        HStack(spacing: 8) {
-            Text(label)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.white)
-                .padding(.vertical, 7)
-                .padding(.horizontal, 12)
-                .background(Color.accentColor)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            Button(action: onClear) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-            Spacer()
-        }
-    }
-
-    private func typeChip(_ group: InterventionGroup) -> some View {
-        Button {
-            selectedType = group.interventionType
-            selectedLocationLabel = nil
-            selectedLaterality = nil
-            tourniquetApplicationMode = .hasty
-        } label: {
-            Text(group.label)
-                .font(.caption.weight(.semibold))
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.primary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .padding(.horizontal, 6)
-                .background(Color.secondary.opacity(0.12))
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func locationChip(_ location: String) -> some View {
-        Button {
-            selectedLocationLabel = location
-            selectedLaterality = nil
-        } label: {
-            Text(location)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.primary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 8)
-                .background(Color.secondary.opacity(0.12))
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func lateralityChip(_ lat: String, label: String) -> some View {
-        let selected = selectedLaterality == lat
-        return Button {
-            selectedLaterality = selected ? nil : lat
-        } label: {
-            Text(label)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(selected ? .white : .primary)
-                .frame(maxWidth: 80)
-                .padding(.vertical, 8)
-                .background(selected ? Color.accentColor : Color.secondary.opacity(0.12))
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-        .buttonStyle(.plain)
+    private func isPendingInterventionControl(_ control: RunConsoleControlItem) -> Bool {
+        guard case .quick(.intervention) = control else { return false }
+        return store.hasPendingInterventions
     }
 }
 

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -50,6 +50,16 @@ public struct RunConsoleView: View {
 
     @State private var terminalCardDismissed = false
 
+    private struct AVPUOption: Identifiable {
+        let state: AVPUState
+        let shortLabel: String
+        let fullLabel: String
+
+        var id: String {
+            shortLabel
+        }
+    }
+
     public init(
         store: RunSessionStore,
         onBack: @escaping () -> Void,
@@ -208,7 +218,9 @@ public struct RunConsoleView: View {
         layoutMode: RunConsoleLayoutMode,
         compactMetrics: RunConsoleCompactMetrics,
     ) -> some View {
-        VStack(alignment: .leading, spacing: layoutMode == .compact ? compactMetrics.sectionSpacing : 8) {
+        let regularVitalsMetrics = RunConsoleRegularVitalsMetrics.standard
+
+        return VStack(alignment: .leading, spacing: layoutMode == .compact ? compactMetrics.sectionSpacing : regularVitalsMetrics.sectionSpacing) {
             Text("Patient Vitals")
                 .font(layoutMode == .compact ? .subheadline.bold() : .headline)
 
@@ -220,19 +232,11 @@ public struct RunConsoleView: View {
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            } else if layoutMode == .regular {
-                HStack(spacing: 8) {
-                    ForEach(orderedVitals) { vital in
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(vitalDisplayName(vital.key))
-                                .font(.caption2.bold())
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                            VitalValueCell(vital: vital, valueText: displayValue(vital))
-                        }
-                        .frame(maxWidth: .infinity)
-                    }
+                if layoutMode == .regular {
+                    regularAVPUInlineControl(metrics: regularVitalsMetrics)
                 }
+            } else if layoutMode == .regular {
+                regularVitalsContent(metrics: regularVitalsMetrics)
             } else {
                 LazyVGrid(
                     columns: compactVitalsColumns(for: compactMetrics),
@@ -244,17 +248,21 @@ public struct RunConsoleView: View {
                 }
             }
 
-            Divider()
-                .overlay(TrainerLabTheme.tacticalBorder.opacity(0.85))
+            if layoutMode == .compact {
+                Divider()
+                    .overlay(TrainerLabTheme.tacticalBorder.opacity(0.3))
 
-            avpuControlSection(layoutMode: layoutMode, compactMetrics: compactMetrics)
+                avpuControlSection(layoutMode: layoutMode, compactMetrics: compactMetrics)
+            }
         }
         .modifier(
             RunConsoleCardModifier(
                 background: TrainerLabTheme.tacticalSurfaceElevated,
-                padding: layoutMode == .compact ? compactMetrics.cardPadding : 8,
+                padding: layoutMode == .compact ? compactMetrics.cardPadding : regularVitalsMetrics.cardPadding,
             ),
         )
+        .frame(maxHeight: layoutMode == .regular ? regularVitalsMetrics.maxHeight : nil, alignment: .top)
+        .fixedSize(horizontal: false, vertical: layoutMode == .regular)
     }
 
     // MARK: - Command bars
@@ -501,24 +509,11 @@ public struct RunConsoleView: View {
         layoutMode: RunConsoleLayoutMode,
         compactMetrics: RunConsoleCompactMetrics,
     ) -> some View {
-        VStack(alignment: .leading, spacing: layoutMode == .compact ? 6 : 8) {
-            Text("AVPU")
-                .font(layoutMode == .compact ? .caption.weight(.semibold) : .subheadline.bold())
-
+        Group {
             if layoutMode == .regular {
-                HStack(spacing: 8) {
-                    avpuButton(.alert, label: "Alert", compact: false, compactMetrics: compactMetrics)
-                    avpuButton(.verbal, label: "Verbal", compact: false, compactMetrics: compactMetrics)
-                    avpuButton(.pain, label: "Pain", compact: false, compactMetrics: compactMetrics)
-                    avpuButton(.unalert, label: "Unalert", compact: false, compactMetrics: compactMetrics)
-                }
+                regularAVPUInlineControl(metrics: .standard)
             } else {
-                LazyVGrid(columns: compactAVPUColumns(for: compactMetrics), spacing: compactMetrics.gridSpacing) {
-                    avpuButton(.alert, label: "Alert", compact: true, compactMetrics: compactMetrics)
-                    avpuButton(.verbal, label: "Verbal", compact: true, compactMetrics: compactMetrics)
-                    avpuButton(.pain, label: "Pain", compact: true, compactMetrics: compactMetrics)
-                    avpuButton(.unalert, label: "Unalert", compact: true, compactMetrics: compactMetrics)
-                }
+                compactAVPUControl(compactMetrics: compactMetrics)
             }
         }
     }
@@ -2022,6 +2017,7 @@ public struct RunConsoleView: View {
     private func avpuButton(
         _ stateValue: AVPUState,
         label: String,
+        accessibilityLabel: String? = nil,
         compact: Bool,
         compactMetrics: RunConsoleCompactMetrics,
     ) -> some View {
@@ -2043,6 +2039,7 @@ public struct RunConsoleView: View {
                 )
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel ?? label)
         .disabled(!canMutate)
         .opacity(canMutate ? 1 : 0.55)
     }
@@ -2168,8 +2165,13 @@ public struct RunConsoleView: View {
         Array(repeating: GridItem(.flexible(minimum: compactMetrics.vitalsColumnMinimum), spacing: compactMetrics.gridSpacing), count: compactMetrics.compactVitalsColumnCount)
     }
 
-    private func compactAVPUColumns(for compactMetrics: RunConsoleCompactMetrics) -> [GridItem] {
-        [GridItem(.flexible(minimum: compactMetrics.controlColumnMinimum), spacing: compactMetrics.gridSpacing), GridItem(.flexible(minimum: compactMetrics.controlColumnMinimum), spacing: compactMetrics.gridSpacing)]
+    private var avpuOptions: [AVPUOption] {
+        [
+            AVPUOption(state: .alert, shortLabel: "A", fullLabel: "Alert"),
+            AVPUOption(state: .verbal, shortLabel: "V", fullLabel: "Verbal"),
+            AVPUOption(state: .pain, shortLabel: "P", fullLabel: "Pain"),
+            AVPUOption(state: .unalert, shortLabel: "U", fullLabel: "Unalert"),
+        ]
     }
 
     // MARK: - Button helpers
@@ -2301,6 +2303,114 @@ public struct RunConsoleView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(TrainerLabTheme.tacticalSurface)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func regularVitalCell(
+        _ vital: VitalStatusSnapshot,
+        metrics: RunConsoleRegularVitalsMetrics,
+    ) -> some View {
+        VStack(alignment: .leading, spacing: metrics.vitalCellSpacing) {
+            Text(vitalDisplayName(vital.key))
+                .font(.caption2.bold())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            VitalValueCell(
+                vital: vital,
+                valueText: displayValue(vital),
+                font: metrics.vitalValueFont,
+                verticalPadding: metrics.vitalValueVerticalPadding,
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func regularVitalsContent(metrics: RunConsoleRegularVitalsMetrics) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .center, spacing: metrics.inlineGroupSpacing) {
+                regularVitalsRow(metrics: metrics)
+                regularAVPUInlineControl(metrics: metrics)
+            }
+
+            VStack(alignment: .leading, spacing: metrics.fallbackRowSpacing) {
+                regularVitalsRow(metrics: metrics)
+                regularAVPUInlineControl(metrics: metrics)
+            }
+        }
+    }
+
+    private func regularVitalsRow(metrics: RunConsoleRegularVitalsMetrics) -> some View {
+        HStack(alignment: .top, spacing: metrics.vitalsRowSpacing) {
+            ForEach(orderedVitals) { vital in
+                regularVitalCell(vital, metrics: metrics)
+            }
+        }
+    }
+
+    private func regularAVPUInlineControl(metrics: RunConsoleRegularVitalsMetrics) -> some View {
+        HStack(alignment: .center, spacing: metrics.avpuSpacing) {
+            avpuInlineLabel
+            regularAVPUChipRow(metrics: metrics)
+        }
+        .fixedSize(horizontal: true, vertical: true)
+    }
+
+    private var avpuInlineLabel: some View {
+        Text("AVPU")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+    }
+
+    private func regularAVPUChipRow(metrics: RunConsoleRegularVitalsMetrics) -> some View {
+        HStack(spacing: metrics.avpuChipSpacing) {
+            ForEach(avpuOptions) { option in
+                regularAVPUChip(option, metrics: metrics)
+            }
+        }
+    }
+
+    private func regularAVPUChip(
+        _ option: AVPUOption,
+        metrics: RunConsoleRegularVitalsMetrics,
+    ) -> some View {
+        Button {
+            selectedAVPU = option.state
+            store.adjustAVPU(option.state)
+        } label: {
+            Text(option.fullLabel)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .padding(.horizontal, metrics.avpuChipHorizontalPadding)
+                .frame(minHeight: metrics.avpuChipMinHeight)
+                .background(avpuColor(option.state))
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(selectedAVPU == option.state ? Color.white : Color.clear, lineWidth: 2),
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.fullLabel)
+        .accessibilityAddTraits(selectedAVPU == option.state ? .isSelected : [])
+        .help(option.fullLabel)
+        .disabled(!canMutate)
+        .opacity(canMutate ? 1 : 0.55)
+    }
+
+    private func compactAVPUControl(compactMetrics: RunConsoleCompactMetrics) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("AVPU")
+                .font(.caption.weight(.semibold))
+
+            HStack(spacing: compactMetrics.gridSpacing) {
+                avpuButton(.alert, label: "A", accessibilityLabel: "Alert", compact: true, compactMetrics: compactMetrics)
+                avpuButton(.verbal, label: "V", accessibilityLabel: "Verbal", compact: true, compactMetrics: compactMetrics)
+                avpuButton(.pain, label: "P", accessibilityLabel: "Pain", compact: true, compactMetrics: compactMetrics)
+                avpuButton(.unalert, label: "U", accessibilityLabel: "Unalert", compact: true, compactMetrics: compactMetrics)
+            }
+        }
     }
 
     private func isPendingInterventionControl(_ control: RunConsoleControlItem) -> Bool {

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -77,7 +77,7 @@ public final class RunSessionStore: ObservableObject {
         let canonicalEventType: String
     }
 
-    private struct PendingInterventionState: Equatable, Sendable {
+    private struct PendingInterventionState: Equatable {
         let idempotencyKey: String
         let interventionType: String
         let siteCode: String
@@ -85,7 +85,7 @@ public final class RunSessionStore: ObservableObject {
         let createdAt: Date
     }
 
-    private struct TrainerRuntimeOverlayState: Sendable {
+    private struct TrainerRuntimeOverlayState {
         var pendingInterventions: [PendingInterventionState] = []
         var confirmedProblemOverlays: [String: ProblemAnnotation] = [:]
         var confirmedInterventionOverlays: [String: InterventionAnnotation] = [:]
@@ -2472,14 +2472,14 @@ public final class RunSessionStore: ObservableObject {
         let normalizedSiteCode = siteCode.uppercased()
         guard
             let matchIndex = runtimeOverlayState.pendingInterventions
-                .enumerated()
-                .filter({
-                    $0.element.interventionType == interventionType
-                        && $0.element.siteCode == normalizedSiteCode
-                        && $0.element.targetProblemID == targetProblemID
-                })
-                .min(by: { lhs, rhs in lhs.element.createdAt < rhs.element.createdAt })?
-                .offset
+            .enumerated()
+            .filter({
+                $0.element.interventionType == interventionType
+                    && $0.element.siteCode == normalizedSiteCode
+                    && $0.element.targetProblemID == targetProblemID
+            })
+            .min(by: { lhs, rhs in lhs.element.createdAt < rhs.element.createdAt })?
+            .offset
         else {
             return
         }
@@ -2490,7 +2490,7 @@ public final class RunSessionStore: ObservableObject {
 
     private func syncPendingInterventionPublishedState() {
         pendingInterventionProblemIDs = Set(runtimeOverlayState.pendingInterventions.compactMap(\.targetProblemID))
-        pendingGeneralInterventionCount = runtimeOverlayState.pendingInterventions.filter { $0.targetProblemID == nil }.count
+        pendingGeneralInterventionCount = runtimeOverlayState.pendingInterventions.count(where: { $0.targetProblemID == nil })
     }
 
     private func rebuildRenderedRuntimeProjection() {

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -32,6 +32,8 @@ public final class RunSessionStore: ObservableObject {
     @Published public private(set) var patientStatus: RuntimePatientStatus = .init()
     @Published public private(set) var aiInstructorIntent: RuntimeInstructorIntent?
     @Published public private(set) var aiInstructorNotes: [String] = []
+    @Published public private(set) var pendingInterventionProblemIDs: Set<Int> = []
+    @Published public private(set) var pendingGeneralInterventionCount = 0
     /// Set whenever a `/state/` fetch fails; cleared on the next successful fetch.
     /// Exposed for debug surfaces and diagnostic tooling.
     @Published public private(set) var lastSnapshotRefreshError: Error?
@@ -48,6 +50,10 @@ public final class RunSessionStore: ObservableObject {
     /// Highest `stateRevision` successfully applied from a snapshot.
     /// Used to reject stale snapshots that arrive out of order.
     private var appliedSnapshotRevision: Int = -1
+    private var snapshotProblemAnnotations: [ProblemAnnotation] = []
+    private var snapshotInterventionAnnotations: [InterventionAnnotation] = []
+    private var snapshotRecommendedInterventions: [RecommendedInterventionItem] = []
+    private var runtimeOverlayState = TrainerRuntimeOverlayState()
 
     private let runtimeRefreshDebounceNanoseconds: UInt64 = 150_000_000
     private let maxStoredTimelineEvents = 400
@@ -71,6 +77,30 @@ public final class RunSessionStore: ObservableObject {
         let canonicalEventType: String
     }
 
+    private struct PendingInterventionState: Equatable, Sendable {
+        let idempotencyKey: String
+        let interventionType: String
+        let siteCode: String
+        let targetProblemID: Int?
+        let createdAt: Date
+    }
+
+    private struct TrainerRuntimeOverlayState: Sendable {
+        var pendingInterventions: [PendingInterventionState] = []
+        var confirmedProblemOverlays: [String: ProblemAnnotation] = [:]
+        var confirmedInterventionOverlays: [String: InterventionAnnotation] = [:]
+        var confirmedRecommendationOverlays: [Int: RecommendedInterventionItem] = [:]
+        var removedRecommendationIDs: Set<Int> = []
+
+        mutating func clear() {
+            pendingInterventions = []
+            confirmedProblemOverlays = [:]
+            confirmedInterventionOverlays = [:]
+            confirmedRecommendationOverlays = [:]
+            removedRecommendationIDs = []
+        }
+    }
+
     public init(
         service: TrainerLabServiceProtocol,
         realtimeClient: RealtimeClientProtocol,
@@ -92,6 +122,17 @@ public final class RunSessionStore: ObservableObject {
         seedHydrationFromSessionRuntimeState(session)
         syncStopwatchState()
         syncTransportPresentation(for: state.transportState)
+    }
+
+    public var hasPendingInterventions: Bool {
+        pendingGeneralInterventionCount > 0 || !pendingInterventionProblemIDs.isEmpty
+    }
+
+    public func hasPendingIntervention(for problemID: Int?) -> Bool {
+        guard let problemID else {
+            return pendingGeneralInterventionCount > 0
+        }
+        return pendingInterventionProblemIDs.contains(problemID)
     }
 
     public func startConsole() {
@@ -216,6 +257,11 @@ public final class RunSessionStore: ObservableObject {
         state.interventionAnnotations = []
         state.pulseAnnotations = []
         state.vitals = []
+        snapshotProblemAnnotations = []
+        snapshotInterventionAnnotations = []
+        snapshotRecommendedInterventions = []
+        runtimeOverlayState.clear()
+        syncPendingInterventionPublishedState()
         appliedSnapshotRevision = -1
         lastAppliedLifecycleRevision = nil
     }
@@ -573,13 +619,16 @@ public final class RunSessionStore: ObservableObject {
             let envelope = makeCommandEnvelope(endpoint: endpoint, simulationID: simulationID)
 
             // Optimistic local timeline entry
-            let typeLabel = interventionDictionary
-                .first(where: { $0.interventionType == interventionType })?.label
-                ?? interventionType.replacingOccurrences(of: "_", with: " ").capitalized
-            let siteLabel = interventionDictionary
-                .first(where: { $0.interventionType == interventionType })?
-                .sites.first(where: { $0.code == siteCode })?.label
-                ?? siteCode.replacingOccurrences(of: "_", with: " ").capitalized
+            let typeLabel = InterventionDisplayText.interventionTypeLabel(
+                interventionType,
+                dictionary: interventionDictionary,
+            )
+            let siteLabel = InterventionDisplayText.siteLabel(
+                siteCode: siteCode,
+                siteLabel: nil,
+                interventionType: interventionType,
+                dictionary: interventionDictionary,
+            ) ?? siteCode
             let message = siteCode.isEmpty ? typeLabel : "\(typeLabel) — \(siteLabel)"
             addClinicalTimelineEntry(
                 dedupeKey: "opt:\(envelope.idempotencyKey)",
@@ -593,6 +642,12 @@ public final class RunSessionStore: ObservableObject {
                     "effectiveness": effectiveness.rawValue,
                     "intervention_status": status.rawValue,
                 ],
+            )
+            addPendingIntervention(
+                idempotencyKey: envelope.idempotencyKey,
+                interventionType: interventionType,
+                siteCode: siteCode,
+                targetProblemID: targetProblemID,
             )
 
             await executeQueuedAckCommand(envelope: envelope) {
@@ -905,6 +960,7 @@ public final class RunSessionStore: ObservableObject {
     }
 
     private func handleCommandError(_ error: Error, envelope: PendingCommandEnvelope) async {
+        discardPendingIntervention(idempotencyKey: envelope.idempotencyKey)
         if let apiError = error as? APIClientError, case let .http(statusCode, detail, _) = apiError, statusCode == 409 {
             state = RunSessionReducer.reduce(state: state, action: .conflict(conflictMessage(for: apiError, fallbackDetail: detail)))
             conflictError = AppErrorPresenter.present(apiError)
@@ -1356,12 +1412,16 @@ public final class RunSessionStore: ObservableObject {
                 ?? jsonString(event.payload["superseded_by"])
 
             // Build human label from dictionary if available
-            let typeLabel = interventionDictionary.first(where: { $0.interventionType == interventionType })?.label
-                ?? interventionType.replacingOccurrences(of: "_", with: " ").capitalized
-            let siteLabel = interventionDictionary
-                .first(where: { $0.interventionType == interventionType })?
-                .sites.first(where: { $0.code == siteCode })?.label
-                ?? siteCode.replacingOccurrences(of: "_", with: " ").capitalized
+            let typeLabel = InterventionDisplayText.interventionTypeLabel(
+                interventionType,
+                dictionary: interventionDictionary,
+            )
+            let siteLabel = InterventionDisplayText.siteLabel(
+                siteCode: siteCode,
+                siteLabel: jsonString(event.payload["site_label"]),
+                interventionType: interventionType,
+                dictionary: interventionDictionary,
+            ) ?? siteCode
 
             let message = siteCode.isEmpty ? typeLabel : "\(typeLabel) — \(siteLabel)"
 
@@ -1537,6 +1597,14 @@ public final class RunSessionStore: ObservableObject {
     /// the main event-handling path.
     private func applyLiveEventProjection(from event: EventEnvelope) {
         switch event.eventType {
+        case SimulationEventType.patientInterventionCreated:
+            captureInterventionAnnotation(from: event)
+        case SimulationEventType.patientProblemUpdated:
+            captureProblemAnnotation(from: event)
+        case SimulationEventType.patientRecommendedInterventionCreated,
+             SimulationEventType.patientRecommendedInterventionUpdated,
+             SimulationEventType.patientRecommendedInterventionRemoved:
+            captureRecommendedIntervention(from: event)
         case SimulationEventType.guardStateUpdated, SimulationEventType.guardWarningUpdated:
             Task { await refreshGuardState() }
         default:
@@ -1955,6 +2023,13 @@ public final class RunSessionStore: ObservableObject {
         let siteCode = (jsonString(event.payload["site_code"]) ?? "").uppercased()
         let effectiveness = jsonString(event.payload["effectiveness"]) ?? "unknown"
         let status = jsonString(event.payload["status"]) ?? "applied"
+        let targetProblemID = jsonInt(event.payload["target_problem_id"])
+
+        reconcilePendingIntervention(
+            interventionType: interventionType,
+            siteCode: siteCode,
+            targetProblemID: targetProblemID,
+        )
 
         guard let zone = interventionZone(for: siteCode) else { return }
 
@@ -1970,7 +2045,7 @@ public final class RunSessionStore: ObservableObject {
             title: eventPrimaryLabel(from: event.payload) ?? interventionType,
             siteCode: siteCode,
             siteLabel: jsonString(event.payload["site_label"]),
-            targetProblemID: jsonInt(event.payload["target_problem_id"]),
+            targetProblemID: targetProblemID,
             targetCauseID: jsonInt(event.payload["target_cause_id"]),
             targetCauseKind: jsonString(event.payload["target_cause_kind"]),
             validationStatus: jsonString(event.payload["validation_status"]),
@@ -1984,12 +2059,8 @@ public final class RunSessionStore: ObservableObject {
             status: status,
             updatedAt: event.createdAt,
         )
-
-        if let idx = state.interventionAnnotations.firstIndex(where: { $0.id == annotation.id }) {
-            state.interventionAnnotations[idx] = annotation
-        } else {
-            state.interventionAnnotations.append(annotation)
-        }
+        runtimeOverlayState.confirmedInterventionOverlays[annotation.id] = annotation
+        rebuildRenderedRuntimeProjection()
     }
 
     private func interventionZone(for siteCode: String) -> (side: InjuryZoneSide, x: Double, y: Double)? {
@@ -2044,12 +2115,8 @@ public final class RunSessionStore: ObservableObject {
             adjudicationReason: jsonString(event.payload["adjudication_reason"]),
             updatedAt: event.createdAt,
         )
-
-        if let idx = state.problemAnnotations.firstIndex(where: { $0.id == annotation.id }) {
-            state.problemAnnotations[idx] = annotation
-        } else {
-            state.problemAnnotations.append(annotation)
-        }
+        runtimeOverlayState.confirmedProblemOverlays[annotation.id] = annotation
+        rebuildRenderedRuntimeProjection()
     }
 
     private func captureRecommendedIntervention(from event: EventEnvelope) {
@@ -2058,7 +2125,9 @@ public final class RunSessionStore: ObservableObject {
 
         guard let recommendationID = jsonInt(event.payload["recommendation_id"]) else { return }
         if eventType == SimulationEventType.patientRecommendedInterventionRemoved {
-            state.recommendedInterventions.removeAll { $0.recommendationID == recommendationID }
+            runtimeOverlayState.confirmedRecommendationOverlays.removeValue(forKey: recommendationID)
+            runtimeOverlayState.removedRecommendationIDs.insert(recommendationID)
+            rebuildRenderedRuntimeProjection()
             return
         }
 
@@ -2081,12 +2150,9 @@ public final class RunSessionStore: ObservableObject {
             warnings: jsonStringArray(event.payload["warnings"]),
             contraindications: jsonStringArray(event.payload["contraindications"]),
         )
-
-        if let idx = state.recommendedInterventions.firstIndex(where: { $0.recommendationID == recommendationID }) {
-            state.recommendedInterventions[idx] = item
-        } else {
-            state.recommendedInterventions.append(item)
-        }
+        runtimeOverlayState.removedRecommendationIDs.remove(recommendationID)
+        runtimeOverlayState.confirmedRecommendationOverlays[recommendationID] = item
+        rebuildRenderedRuntimeProjection()
     }
 
     // MARK: - Pulse Annotations
@@ -2341,17 +2407,19 @@ public final class RunSessionStore: ObservableObject {
                     hydratedProblems.first(where: { $0.causeID == causeID })
                 })
             }
-            state.problemAnnotations = hydratedProblems.map { problem in
+        }
+        if snapshot.presence.problems {
+            snapshotProblemAnnotations = hydratedProblems.map { problem in
                 makeProblemAnnotation(from: problem, causesByID: causesByID)
             }
         }
         if snapshot.presence.recommendedInterventions {
-            state.recommendedInterventions = snapshot.recommendedInterventions.map { recommendation in
+            snapshotRecommendedInterventions = snapshot.recommendedInterventions.map { recommendation in
                 makeRecommendedInterventionItem(from: recommendation, problemsByID: problemsByID)
             }
         }
         if snapshot.presence.interventions {
-            state.interventionAnnotations = snapshot.interventions.compactMap(makeInterventionAnnotation)
+            snapshotInterventionAnnotations = snapshot.interventions.compactMap(makeInterventionAnnotation)
         }
         if snapshot.presence.pulses {
             state.pulseAnnotations = snapshot.pulses.compactMap(makePulseAnnotation)
@@ -2363,6 +2431,136 @@ public final class RunSessionStore: ObservableObject {
                 return makeVitalSnapshot(from: vitalState, existing: existing)
             }
         }
+        runtimeOverlayState.clear()
+        rebuildRenderedRuntimeProjection()
+    }
+
+    private func addPendingIntervention(
+        idempotencyKey: String,
+        interventionType: String,
+        siteCode: String,
+        targetProblemID: Int?,
+    ) {
+        runtimeOverlayState.pendingInterventions.append(
+            PendingInterventionState(
+                idempotencyKey: idempotencyKey,
+                interventionType: interventionType,
+                siteCode: siteCode.uppercased(),
+                targetProblemID: targetProblemID,
+                createdAt: Date(),
+            ),
+        )
+        syncPendingInterventionPublishedState()
+    }
+
+    private func discardPendingIntervention(idempotencyKey: String) {
+        let originalCount = runtimeOverlayState.pendingInterventions.count
+        runtimeOverlayState.pendingInterventions.removeAll { $0.idempotencyKey == idempotencyKey }
+        guard originalCount != runtimeOverlayState.pendingInterventions.count else { return }
+        syncPendingInterventionPublishedState()
+    }
+
+    private func reconcilePendingIntervention(
+        interventionType: String,
+        siteCode: String,
+        targetProblemID: Int?,
+    ) {
+        let normalizedSiteCode = siteCode.uppercased()
+        guard
+            let matchIndex = runtimeOverlayState.pendingInterventions
+                .enumerated()
+                .filter({
+                    $0.element.interventionType == interventionType
+                        && $0.element.siteCode == normalizedSiteCode
+                        && $0.element.targetProblemID == targetProblemID
+                })
+                .min(by: { lhs, rhs in lhs.element.createdAt < rhs.element.createdAt })?
+                .offset
+        else {
+            return
+        }
+
+        runtimeOverlayState.pendingInterventions.remove(at: matchIndex)
+        syncPendingInterventionPublishedState()
+    }
+
+    private func syncPendingInterventionPublishedState() {
+        pendingInterventionProblemIDs = Set(runtimeOverlayState.pendingInterventions.compactMap(\.targetProblemID))
+        pendingGeneralInterventionCount = runtimeOverlayState.pendingInterventions.filter { $0.targetProblemID == nil }.count
+    }
+
+    private func rebuildRenderedRuntimeProjection() {
+        state.problemAnnotations = mergedProblemAnnotations()
+        state.interventionAnnotations = mergedInterventionAnnotations()
+        state.recommendedInterventions = mergedRecommendedInterventions()
+        syncPendingInterventionPublishedState()
+    }
+
+    private func mergedProblemAnnotations() -> [ProblemAnnotation] {
+        mergeAnnotations(
+            base: snapshotProblemAnnotations,
+            overlays: Array(runtimeOverlayState.confirmedProblemOverlays.values),
+        ) { lhs, rhs in
+            if let leftID = lhs.problemID, let rightID = rhs.problemID {
+                return leftID == rightID
+            }
+            return lhs.id == rhs.id
+        }
+    }
+
+    private func mergedInterventionAnnotations() -> [InterventionAnnotation] {
+        mergeAnnotations(
+            base: snapshotInterventionAnnotations,
+            overlays: Array(runtimeOverlayState.confirmedInterventionOverlays.values),
+        ) { lhs, rhs in
+            if let leftID = lhs.interventionID, let rightID = rhs.interventionID {
+                return leftID == rightID
+            }
+            return lhs.id == rhs.id
+        }
+    }
+
+    private func mergedRecommendedInterventions() -> [RecommendedInterventionItem] {
+        var merged = snapshotRecommendedInterventions.filter { recommendation in
+            !runtimeOverlayState.removedRecommendationIDs.contains(recommendation.recommendationID)
+        }
+
+        for overlay in runtimeOverlayState.confirmedRecommendationOverlays.values.sorted(by: recommendationSortOrder) {
+            if let index = merged.firstIndex(where: { $0.recommendationID == overlay.recommendationID }) {
+                merged[index] = overlay
+            } else {
+                merged.append(overlay)
+            }
+        }
+
+        return merged
+            .filter { !runtimeOverlayState.removedRecommendationIDs.contains($0.recommendationID) }
+            .sorted(by: recommendationSortOrder)
+    }
+
+    private func mergeAnnotations<Item>(
+        base: [Item],
+        overlays: [Item],
+        matches: (Item, Item) -> Bool,
+    ) -> [Item] {
+        var merged = base
+        for overlay in overlays {
+            if let index = merged.firstIndex(where: { matches($0, overlay) }) {
+                merged[index] = overlay
+            } else {
+                merged.append(overlay)
+            }
+        }
+        return merged
+    }
+
+    private func recommendationSortOrder(_ lhs: RecommendedInterventionItem, _ rhs: RecommendedInterventionItem) -> Bool {
+        let leftPriority = lhs.priority ?? .max
+        let rightPriority = rhs.priority ?? .max
+        if leftPriority != rightPriority {
+            return leftPriority < rightPriority
+        }
+        return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
     }
 
     // MARK: - Derived mapping from snapshot

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -92,12 +92,16 @@ public final class RunSessionStore: ObservableObject {
         var confirmedRecommendationOverlays: [Int: RecommendedInterventionItem] = [:]
         var removedRecommendationIDs: Set<Int> = []
 
-        mutating func clear() {
-            pendingInterventions = []
+        mutating func clearConfirmedOverlays() {
             confirmedProblemOverlays = [:]
             confirmedInterventionOverlays = [:]
             confirmedRecommendationOverlays = [:]
             removedRecommendationIDs = []
+        }
+
+        mutating func clearAll() {
+            pendingInterventions = []
+            clearConfirmedOverlays()
         }
     }
 
@@ -260,7 +264,7 @@ public final class RunSessionStore: ObservableObject {
         snapshotProblemAnnotations = []
         snapshotInterventionAnnotations = []
         snapshotRecommendedInterventions = []
-        runtimeOverlayState.clear()
+        runtimeOverlayState.clearAll()
         syncPendingInterventionPublishedState()
         appliedSnapshotRevision = -1
         lastAppliedLifecycleRevision = nil
@@ -2431,7 +2435,7 @@ public final class RunSessionStore: ObservableObject {
                 return makeVitalSnapshot(from: vitalState, existing: existing)
             }
         }
-        runtimeOverlayState.clear()
+        runtimeOverlayState.clearConfirmedOverlays()
         rebuildRenderedRuntimeProjection()
     }
 

--- a/apps/trainerlab-ios/Sources/SharedModels/InterventionDisplayText.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/InterventionDisplayText.swift
@@ -67,7 +67,7 @@ public enum InterventionDisplayText {
     }
 }
 
-private extension Array where Element == String {
+private extension [String] {
     func droppingAccessRoutePrefix() -> [String] {
         guard let first, ["IV", "IO"].contains(first), count > 1 else {
             return self

--- a/apps/trainerlab-ios/Sources/SharedModels/InterventionDisplayText.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/InterventionDisplayText.swift
@@ -41,16 +41,8 @@ public enum InterventionDisplayText {
 
         guard !rawTokens.isEmpty else { return siteCode }
 
-        let formattedTokens = rawTokens.map(formatToken)
-
-        if rawTokens.first == "IV", rawTokens.count >= 3 {
-            return (formattedTokens.dropFirst() + ["IV"]).joined(separator: " ")
-        }
-        if rawTokens.first == "IO", rawTokens.count >= 3 {
-            return (formattedTokens.dropFirst() + ["IO"]).joined(separator: " ")
-        }
-
-        return formattedTokens.joined(separator: " ")
+        let displayTokens = rawTokens.droppingAccessRoutePrefix()
+        return displayTokens.map(formatToken).joined(separator: " ")
     }
 
     private static func formatToken(_ token: String) -> String {
@@ -72,5 +64,14 @@ public enum InterventionDisplayText {
         default:
             token.capitalized
         }
+    }
+}
+
+private extension Array where Element == String {
+    func droppingAccessRoutePrefix() -> [String] {
+        guard let first, ["IV", "IO"].contains(first), count > 1 else {
+            return self
+        }
+        return Array(dropFirst())
     }
 }

--- a/apps/trainerlab-ios/Sources/SharedModels/InterventionDisplayText.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/InterventionDisplayText.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public enum InterventionDisplayText {
+    public static func interventionTypeLabel(
+        _ interventionType: String,
+        dictionary: [InterventionGroup] = [],
+    ) -> String {
+        dictionary.first(where: { $0.interventionType == interventionType })?.label
+            ?? SimulationEventRegistry.humanizedLabel(interventionType)
+    }
+
+    public static func siteLabel(
+        siteCode: String?,
+        siteLabel: String?,
+        interventionType: String? = nil,
+        dictionary: [InterventionGroup] = [],
+    ) -> String? {
+        if let siteLabel, !siteLabel.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return siteLabel
+        }
+
+        if
+            let interventionType,
+            let siteCode,
+            let group = dictionary.first(where: { $0.interventionType == interventionType }),
+            let label = group.sites.first(where: { $0.code.caseInsensitiveCompare(siteCode) == .orderedSame })?.label
+        {
+            return label
+        }
+
+        guard let siteCode, !siteCode.isEmpty else { return nil }
+        return normalizedSiteCode(siteCode)
+    }
+
+    public static func normalizedSiteCode(_ siteCode: String) -> String {
+        let separatorSet = CharacterSet(charactersIn: "_-")
+        let rawTokens = siteCode
+            .uppercased()
+            .components(separatedBy: separatorSet)
+            .filter { !$0.isEmpty }
+
+        guard !rawTokens.isEmpty else { return siteCode }
+
+        let formattedTokens = rawTokens.map(formatToken)
+
+        if rawTokens.first == "IV", rawTokens.count >= 3 {
+            return (formattedTokens.dropFirst() + ["IV"]).joined(separator: " ")
+        }
+        if rawTokens.first == "IO", rawTokens.count >= 3 {
+            return (formattedTokens.dropFirst() + ["IO"]).joined(separator: " ")
+        }
+
+        return formattedTokens.joined(separator: " ")
+    }
+
+    private static func formatToken(_ token: String) -> String {
+        switch token {
+        case "IV", "IO", "AC", "EJ", "ICS", "NPA", "OPA":
+            token
+        case "PROX":
+            "Proximal"
+        case "DIST":
+            "Distal"
+        case "FEM":
+            "Femoral"
+        case "ANT":
+            "Anterior"
+        case "LAT":
+            "Lateral"
+        case "MIDLINE":
+            "Midline"
+        default:
+            token.capitalized
+        }
+    }
+}

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -312,13 +312,13 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
                     sites: [
                         InterventionSite(code: "FR-IV-LINE", label: "IV Line"),
                         InterventionSite(code: "FR-IO-LINE", label: "IO Line"),
-                    ]
+                    ],
                 ),
             ],
             problems: [],
             recommendations: [],
             interventions: [],
-            selectedTargetProblemID: nil
+            selectedTargetProblemID: nil,
         )
 
         XCTAssertTrue(context.availableGroups.isEmpty)
@@ -333,7 +333,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
                 sites: [
                     InterventionSite(code: "RIGHT_LEG", label: "Right Leg"),
                     InterventionSite(code: "LEFT_LEG", label: "Left Leg"),
-                ]
+                ],
             ),
             InterventionGroup(
                 interventionType: "pressure_dressing",
@@ -341,7 +341,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
                 sites: [
                     InterventionSite(code: "RIGHT_LEG", label: "Right Leg"),
                     InterventionSite(code: "LEFT_LEG", label: "Left Leg"),
-                ]
+                ],
             ),
         ]
         let problem = ProblemAnnotation(
@@ -354,14 +354,14 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
             side: .front,
             x: 0.4,
             y: 0.7,
-            status: .active
+            status: .active,
         )
         let recommendation = RecommendedInterventionItem(
             recommendationID: 7,
             title: "Apply tourniquet",
             kind: "tourniquet",
             targetProblemID: 41,
-            priority: 1
+            priority: 1,
         )
 
         let context = InterventionMenuContext(
@@ -369,7 +369,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
             problems: [problem],
             recommendations: [recommendation],
             interventions: [],
-            selectedTargetProblemID: 41
+            selectedTargetProblemID: 41,
         )
 
         XCTAssertEqual(context.availableGroups.map(\.interventionType), ["tourniquet", "pressure_dressing"])
@@ -384,7 +384,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
                 sites: [
                     InterventionSite(code: "RIGHT_LEG", label: "Right Leg"),
                     InterventionSite(code: "LEFT_LEG", label: "Left Leg"),
-                ]
+                ],
             ),
         ]
         var draft = InterventionComposerDraft(prefilledTargetProblemID: 41)
@@ -392,9 +392,9 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
             InterventionComposerPrefill(
                 interventionType: "tourniquet",
                 siteCode: "LEFT_LEG",
-                targetProblemID: 41
+                targetProblemID: 41,
             ),
-            dictionary: dictionary
+            dictionary: dictionary,
         )
 
         XCTAssertEqual(draft.selectedType, "tourniquet")
@@ -407,7 +407,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("IV-RIGHT-AC"), "Right AC")
         XCTAssertEqual(
             InterventionDisplayText.siteLabel(siteCode: "IO-LEFT-PROX-TIBIA", siteLabel: nil),
-            "Left Proximal Tibia"
+            "Left Proximal Tibia",
         )
         XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("LEFT_LEG"), "Left Leg")
         XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("RIGHT_CHEST"), "Right Chest")
@@ -418,7 +418,7 @@ private func makeInterventionAnnotation(
     id: String,
     type: String,
     siteCode: String,
-    updatedAt: Date
+    updatedAt: Date,
 ) -> InterventionAnnotation {
     InterventionAnnotation(
         id: id,
@@ -430,6 +430,6 @@ private func makeInterventionAnnotation(
         y: 0.4,
         effectiveness: "effective",
         status: InterventionStatus.applied.rawValue,
-        updatedAt: updatedAt
+        updatedAt: updatedAt,
     )
 }

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -282,4 +282,152 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         XCTAssertNil(row.detail)
         XCTAssertEqual(row.canonicalEventType, SimulationEventType.simulationSummaryUpdated)
     }
+
+    func testAvailableAccessInventoryDerivesIVAndIOAvailability() {
+        let none = AvailableAccessInventory(interventions: [])
+        XCTAssertFalse(none.hasIV)
+        XCTAssertFalse(none.hasIO)
+
+        let ivOnly = AvailableAccessInventory(interventions: [
+            makeInterventionAnnotation(id: "iv-1", type: "iv_access", siteCode: "IV-RIGHT-AC", updatedAt: Date(timeIntervalSince1970: 20)),
+        ])
+        XCTAssertTrue(ivOnly.hasIV)
+        XCTAssertFalse(ivOnly.hasIO)
+
+        let both = AvailableAccessInventory(interventions: [
+            makeInterventionAnnotation(id: "iv-1", type: "iv_access", siteCode: "IV-RIGHT-AC", updatedAt: Date(timeIntervalSince1970: 10)),
+            makeInterventionAnnotation(id: "io-1", type: "io_access", siteCode: "IO-LEFT-PROX-TIBIA", updatedAt: Date(timeIntervalSince1970: 20)),
+        ])
+        XCTAssertTrue(both.hasIV)
+        XCTAssertTrue(both.hasIO)
+        XCTAssertEqual(both.preferredRouteToken, "IO")
+    }
+
+    func testInterventionMenuContextDisablesFluidActionsWithoutAccess() {
+        let context = InterventionMenuContext(
+            dictionary: [
+                InterventionGroup(
+                    interventionType: "fluid_resuscitation",
+                    label: "Fluid Resuscitation",
+                    sites: [
+                        InterventionSite(code: "FR-IV-LINE", label: "IV Line"),
+                        InterventionSite(code: "FR-IO-LINE", label: "IO Line"),
+                    ]
+                ),
+            ],
+            problems: [],
+            recommendations: [],
+            interventions: [],
+            selectedTargetProblemID: nil
+        )
+
+        XCTAssertTrue(context.availableGroups.isEmpty)
+        XCTAssertEqual(context.disabledItems.first?.reason, "Requires IV or IO access")
+    }
+
+    func testInterventionMenuContextPrefersRecommendedTypesAndProblemSiteDefaults() {
+        let dictionary = [
+            InterventionGroup(
+                interventionType: "tourniquet",
+                label: "Tourniquet",
+                sites: [
+                    InterventionSite(code: "RIGHT_LEG", label: "Right Leg"),
+                    InterventionSite(code: "LEFT_LEG", label: "Left Leg"),
+                ]
+            ),
+            InterventionGroup(
+                interventionType: "pressure_dressing",
+                label: "Pressure Dressing",
+                sites: [
+                    InterventionSite(code: "RIGHT_LEG", label: "Right Leg"),
+                    InterventionSite(code: "LEFT_LEG", label: "Left Leg"),
+                ]
+            ),
+        ]
+        let problem = ProblemAnnotation(
+            id: "problem-1",
+            problemID: 41,
+            title: "Massive hemorrhage",
+            description: "Left lower leg bleeding",
+            isAnatomic: true,
+            locationCode: "LEFT_LOWER_LEG",
+            side: .front,
+            x: 0.4,
+            y: 0.7,
+            status: .active
+        )
+        let recommendation = RecommendedInterventionItem(
+            recommendationID: 7,
+            title: "Apply tourniquet",
+            kind: "tourniquet",
+            targetProblemID: 41,
+            priority: 1
+        )
+
+        let context = InterventionMenuContext(
+            dictionary: dictionary,
+            problems: [problem],
+            recommendations: [recommendation],
+            interventions: [],
+            selectedTargetProblemID: 41
+        )
+
+        XCTAssertEqual(context.availableGroups.map(\.interventionType), ["tourniquet", "pressure_dressing"])
+        XCTAssertEqual(context.recommendedActions.first?.prefill.siteCode, "LEFT_LEG")
+    }
+
+    func testInterventionComposerDraftAppliesPrefillAndResolvesSiteCode() {
+        let dictionary = [
+            InterventionGroup(
+                interventionType: "tourniquet",
+                label: "Tourniquet",
+                sites: [
+                    InterventionSite(code: "RIGHT_LEG", label: "Right Leg"),
+                    InterventionSite(code: "LEFT_LEG", label: "Left Leg"),
+                ]
+            ),
+        ]
+        var draft = InterventionComposerDraft(prefilledTargetProblemID: 41)
+        draft.applyPrefill(
+            InterventionComposerPrefill(
+                interventionType: "tourniquet",
+                siteCode: "LEFT_LEG",
+                targetProblemID: 41
+            ),
+            dictionary: dictionary
+        )
+
+        XCTAssertEqual(draft.selectedType, "tourniquet")
+        XCTAssertEqual(draft.selectedLocationLabel, "Leg")
+        XCTAssertEqual(draft.selectedLaterality, "left")
+        XCTAssertEqual(draft.resolvedSiteCode(in: dictionary[0].sites), "LEFT_LEG")
+    }
+
+    func testInterventionDisplayTextHumanizesSiteCodes() {
+        XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("IV-RIGHT-AC"), "Right AC IV")
+        XCTAssertEqual(
+            InterventionDisplayText.siteLabel(siteCode: "IO-LEFT-PROX-TIBIA", siteLabel: nil),
+            "Left Proximal Tibia IO"
+        )
+    }
+}
+
+private func makeInterventionAnnotation(
+    id: String,
+    type: String,
+    siteCode: String,
+    updatedAt: Date
+) -> InterventionAnnotation {
+    InterventionAnnotation(
+        id: id,
+        interventionID: Int(id.split(separator: "-").last ?? "1"),
+        interventionType: type,
+        siteCode: siteCode,
+        side: .front,
+        x: 0.4,
+        y: 0.4,
+        effectiveness: "effective",
+        status: InterventionStatus.applied.rawValue,
+        updatedAt: updatedAt
+    )
 }

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -404,11 +404,13 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
     }
 
     func testInterventionDisplayTextHumanizesSiteCodes() {
-        XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("IV-RIGHT-AC"), "Right AC IV")
+        XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("IV-RIGHT-AC"), "Right AC")
         XCTAssertEqual(
             InterventionDisplayText.siteLabel(siteCode: "IO-LEFT-PROX-TIBIA", siteLabel: nil),
-            "Left Proximal Tibia IO"
+            "Left Proximal Tibia"
         )
+        XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("LEFT_LEG"), "Left Leg")
+        XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("RIGHT_CHEST"), "Right Chest")
     }
 }
 

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -36,6 +36,7 @@ private final class MockTrainerLabService: TrainerLabServiceProtocol, @unchecked
     var runCommandResult: Result<TrainerSessionDTO, Error> = .failure(MockServiceError.unused)
     var injectInterventionCalls: [InterventionEventRequest] = []
     var injectInterventionResult: Result<TrainerCommandAck, Error> = .failure(MockServiceError.unused)
+    var injectInterventionDelayNanoseconds: UInt64 = 0
 
     func accessMe() async throws -> LabAccess {
         throw MockServiceError.unused
@@ -138,6 +139,9 @@ private final class MockTrainerLabService: TrainerLabServiceProtocol, @unchecked
 
     func injectInterventionEvent(simulationID _: Int, request: InterventionEventRequest, idempotencyKey _: String) async throws -> TrainerCommandAck {
         injectInterventionCalls.append(request)
+        if injectInterventionDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: injectInterventionDelayNanoseconds)
+        }
         return try injectInterventionResult.get()
     }
 
@@ -1404,6 +1408,173 @@ final class RunSessionStoreTests: XCTestCase {
         XCTAssertTrue(store.hasPendingInterventions)
         XCTAssertTrue(store.state.problemAnnotations.isEmpty)
         XCTAssertTrue(store.state.interventionAnnotations.isEmpty)
+    }
+
+    func testPendingInterventionPersistsAcrossSnapshotRefreshUntilConfirmedEvent() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = try [
+            .success(makeRuntimeState(
+                status: "running",
+                stateRevision: 1,
+                problems: [[
+                    "problem_id": 55,
+                    "title": "External hemorrhage",
+                    "status": "active",
+                    "anatomical_location": "LEFT_ARM",
+                ]],
+            )),
+            .success(makeRuntimeState(
+                status: "running",
+                stateRevision: 2,
+                problems: [[
+                    "problem_id": 55,
+                    "title": "External hemorrhage",
+                    "status": "active",
+                    "anatomical_location": "LEFT_ARM",
+                ]],
+            )),
+        ]
+        service.listEventsResult = .success(PaginatedResponse(items: [], nextCursor: nil, hasMore: false))
+        service.listAnnotationsResult = .success([])
+        service.injectInterventionResult = .success(TrainerCommandAck(commandID: "cmd-1", status: "accepted"))
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1 && store.state.problemAnnotations.first?.problemID == 55
+        }
+
+        store.addIntervention(
+            interventionType: "tourniquet",
+            siteCode: "LEFT_ARM",
+            targetProblemID: 55,
+        )
+
+        await waitUntil(timeout: 1.0) {
+            store.hasPendingIntervention(for: 55) && service.injectInterventionCalls.count == 1
+        }
+
+        realtime.emit(event: EventEnvelope(
+            eventID: "snapshot-refresh",
+            eventType: SimulationEventType.simulationSnapshotUpdated,
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [:],
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2
+        }
+
+        XCTAssertTrue(store.hasPendingIntervention(for: 55))
+        XCTAssertTrue(store.hasPendingInterventions)
+        XCTAssertTrue(store.state.interventionAnnotations.isEmpty)
+    }
+
+    func testPendingInterventionClearsWhenMatchingBackendEventArrives() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResult = try .success(makeRuntimeState(status: "running"))
+        service.listEventsResult = .success(PaginatedResponse(items: [], nextCursor: nil, hasMore: false))
+        service.listAnnotationsResult = .success([])
+        service.injectInterventionResult = .success(TrainerCommandAck(commandID: "cmd-1", status: "accepted"))
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
+
+        store.addIntervention(
+            interventionType: "tourniquet",
+            siteCode: "LEFT_ARM",
+            targetProblemID: 55,
+        )
+
+        await waitUntil(timeout: 1.0) {
+            store.hasPendingIntervention(for: 55) && service.injectInterventionCalls.count == 1
+        }
+
+        realtime.emit(event: EventEnvelope(
+            eventID: "intervention-created",
+            eventType: SimulationEventType.patientInterventionCreated,
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [
+                "domain_event_id": .number(801),
+                "intervention_id": .number(801),
+                "intervention_type": .string("tourniquet"),
+                "title": .string("Tourniquet"),
+                "site_code": .string("LEFT_ARM"),
+                "target_problem_id": .number(55),
+                "status": .string("applied"),
+                "effectiveness": .string("effective"),
+            ],
+        ))
+
+        await waitUntil(timeout: 1.0) {
+            !store.hasPendingIntervention(for: 55)
+                && !store.hasPendingInterventions
+                && store.state.interventionAnnotations.first?.interventionID == 801
+        }
+    }
+
+    func testPendingInterventionClearsOnCommandFailure() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResult = try .success(makeRuntimeState(status: "running"))
+        service.listEventsResult = .success(PaginatedResponse(items: [], nextCursor: nil, hasMore: false))
+        service.listAnnotationsResult = .success([])
+        service.injectInterventionDelayNanoseconds = 150_000_000
+        service.injectInterventionResult = .failure(APIClientError.http(
+            statusCode: 500,
+            detail: "Server error",
+            correlationID: nil,
+        ))
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
+
+        store.addIntervention(
+            interventionType: "tourniquet",
+            siteCode: "LEFT_ARM",
+            targetProblemID: 55,
+        )
+
+        await waitUntil(timeout: 1.0) {
+            store.hasPendingIntervention(for: 55)
+        }
+
+        await waitUntil(timeout: 2.0) {
+            service.injectInterventionCalls.count == 1 && !store.hasPendingInterventions
+        }
+
+        XCTAssertFalse(store.hasPendingIntervention(for: 55))
     }
 
     func testReplayPendingCommandsOnlyReplaysRowsForBoundSimulation() async throws {

--- a/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
+++ b/apps/trainerlab-ios/Tests/SessionsTests/RunSessionStoreTests.swift
@@ -1390,6 +1390,10 @@ final class RunSessionStoreTests: XCTestCase {
             notes: "Applied prophylactically",
         )
 
+        await waitUntil(timeout: 1.0) {
+            store.hasPendingInterventions
+        }
+
         await waitUntil(timeout: 1.5) {
             service.injectInterventionCalls.count == 1
         }
@@ -1397,6 +1401,9 @@ final class RunSessionStoreTests: XCTestCase {
         XCTAssertNil(service.injectInterventionCalls.first?.targetProblemID)
         XCTAssertNil(store.state.conflictBanner)
         XCTAssertEqual(store.state.clinicalTimelineEntries.first?.kind, .intervention)
+        XCTAssertTrue(store.hasPendingInterventions)
+        XCTAssertTrue(store.state.problemAnnotations.isEmpty)
+        XCTAssertTrue(store.state.interventionAnnotations.isEmpty)
     }
 
     func testReplayPendingCommandsOnlyReplaysRowsForBoundSimulation() async throws {
@@ -1628,9 +1635,9 @@ final class RunSessionStoreTests: XCTestCase {
     }
 
     func testLivePatientEventsHydrateClinicalStateAcrossFamilies() async throws {
-        // Under the snapshot-authority architecture, live events trigger a debounced /state/
-        // refresh rather than directly mutating panel state. The second mock response contains
-        // the clinical state accumulated by all the events on the backend.
+        // Under the snapshot-authority architecture, live events still trigger a debounced /state/
+        // refresh. Problem/intervention/recommendation payloads also apply a thin temporary
+        // overlay so the UI reflects backend-confirmed deltas before the snapshot lands.
         let service = MockTrainerLabService()
         service.getRuntimeStateResultsQueue = try [
             .success(makeRuntimeState(status: "running", stateRevision: 1)),
@@ -1826,6 +1833,15 @@ final class RunSessionStoreTests: XCTestCase {
             ],
         ))
 
+        await waitUntil(timeout: 1.0) {
+            store.state.problemAnnotations.first?.problemID == 601
+                && store.state.interventionAnnotations.first?.interventionID == 801
+        }
+
+        XCTAssertEqual(store.state.problemAnnotations.first?.problemID, 601)
+        XCTAssertEqual(store.state.interventionAnnotations.first?.interventionID, 801)
+        XCTAssertEqual(service.getRuntimeStateCalls.count, 1)
+
         // Wait for the debounced /state/ refresh to fire (events coalesced) and apply the snapshot.
         await waitUntil(timeout: 2.0) {
             service.getRuntimeStateCalls.count == 2 && store.disposition?.dispositionID == 1301
@@ -1844,6 +1860,66 @@ final class RunSessionStoreTests: XCTestCase {
         XCTAssertTrue(store.state.recommendedInterventions.isEmpty)
         // Timeline is populated from events (independent of snapshot).
         XCTAssertFalse(store.state.timeline.isEmpty)
+    }
+
+    func testRecommendationOverlayAppliesImmediatelyAndClearsOnSnapshotRefresh() async throws {
+        let service = MockTrainerLabService()
+        service.getRuntimeStateResultsQueue = try [
+            .success(makeRuntimeState(status: "running", stateRevision: 1)),
+            .success(makeRuntimeState(
+                status: "running",
+                stateRevision: 2,
+                recommendedInterventions: [],
+            )),
+        ]
+        service.listEventsResult = .success(PaginatedResponse(items: [], nextCursor: nil, hasMore: false))
+        service.listAnnotationsResult = .success([])
+
+        let realtime = MockRealtimeClient()
+        let store = RunSessionStore(
+            service: service,
+            realtimeClient: realtime,
+            commandQueue: InMemoryCommandQueueStore(),
+        )
+        store.bind(session: makeSession(status: .running))
+        store.startConsole()
+        defer { store.stopConsole() }
+
+        await waitUntil(timeout: 1.5) {
+            service.getRuntimeStateCalls.count == 1
+        }
+
+        realtime.emit(event: EventEnvelope(
+            eventID: "recommendation-created",
+            eventType: SimulationEventType.patientRecommendedInterventionCreated,
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [
+                "recommendation_id": .number(912),
+                "title": .string("Give blood"),
+                "kind": .string("blood_transfusion"),
+                "target_problem_id": .number(55),
+                "priority": .number(1),
+            ],
+        ))
+
+        await waitUntil(timeout: 1.0) {
+            store.state.recommendedInterventions.contains(where: { $0.recommendationID == 912 })
+        }
+
+        XCTAssertEqual(service.getRuntimeStateCalls.count, 1)
+
+        realtime.emit(event: EventEnvelope(
+            eventID: "snapshot-refresh",
+            eventType: SimulationEventType.simulationSnapshotUpdated,
+            createdAt: Date(),
+            correlationID: nil,
+            payload: [:],
+        ))
+
+        await waitUntil(timeout: 2.0) {
+            service.getRuntimeStateCalls.count == 2 && store.state.recommendedInterventions.isEmpty
+        }
     }
 
     func testUnknownEventsNormalizeSafelyWithoutTriggeringRefresh() async throws {


### PR DESCRIPTION
## Summary
- add intervention display text support for the run console overlay
- update run console view and layout support to present intervention content
- extend session store handling for intervention overlay state
- add coverage for layout support and session store behavior

## Testing
- Not run (not requested)