### PR TITLE
feat(iOS): add shared feedback flow

### DIFF
--- a/MedSim.xcodeproj/project.pbxproj
+++ b/MedSim.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -514,6 +515,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/apps/chatlab-ios/Package.swift
+++ b/apps/chatlab-ios/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
                 .product(name: "Networking", package: "trainerlab-ios"),
                 .product(name: "Persistence", package: "trainerlab-ios"),
                 .product(name: "DesignSystem", package: "trainerlab-ios"),
+                .product(name: "FeedbackFeature", package: "trainerlab-ios"),
                 .product(name: "SharedModels", package: "trainerlab-ios"),
             ],
         ),

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabRootView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabRootView.swift
@@ -1,3 +1,5 @@
+import FeedbackFeature
+import Networking
 import SharedModels
 import SwiftUI
 
@@ -5,6 +7,8 @@ public struct ChatLabRootView: View {
     @StateObject private var homeStore: ChatLabHomeStore
     private let makeRunStore: (ChatSimulation) -> ChatRunStore
     private let makeToolsStore: (Int) -> ChatToolsStore
+    private let feedbackService: FeedbackServiceProtocol
+    private let feedbackHeaderProvider: FeedbackRequestHeaderProviding
     private let mediaLoader: ChatMediaLoading
     private let onExit: () -> Void
 
@@ -14,12 +18,16 @@ public struct ChatLabRootView: View {
         homeStore: ChatLabHomeStore,
         makeRunStore: @escaping (ChatSimulation) -> ChatRunStore,
         makeToolsStore: @escaping (Int) -> ChatToolsStore,
+        feedbackService: FeedbackServiceProtocol,
+        feedbackHeaderProvider: FeedbackRequestHeaderProviding,
         mediaLoader: ChatMediaLoading,
         onExit: @escaping () -> Void,
     ) {
         _homeStore = StateObject(wrappedValue: homeStore)
         self.makeRunStore = makeRunStore
         self.makeToolsStore = makeToolsStore
+        self.feedbackService = feedbackService
+        self.feedbackHeaderProvider = feedbackHeaderProvider
         self.mediaLoader = mediaLoader
         self.onExit = onExit
     }
@@ -32,6 +40,8 @@ public struct ChatLabRootView: View {
                         simulation: simulation,
                         makeRunStore: makeRunStore,
                         makeToolsStore: makeToolsStore,
+                        feedbackService: feedbackService,
+                        feedbackHeaderProvider: feedbackHeaderProvider,
                         mediaLoader: mediaLoader,
                         onBack: { selectedSimulation = nil },
                     )
@@ -59,6 +69,8 @@ private struct ChatRunScreen: View {
     let simulation: ChatSimulation
     let makeRunStore: (ChatSimulation) -> ChatRunStore
     let makeToolsStore: (Int) -> ChatToolsStore
+    let feedbackService: FeedbackServiceProtocol
+    let feedbackHeaderProvider: FeedbackRequestHeaderProviding
     let mediaLoader: ChatMediaLoading
     let onBack: () -> Void
 
@@ -69,12 +81,16 @@ private struct ChatRunScreen: View {
         simulation: ChatSimulation,
         makeRunStore: @escaping (ChatSimulation) -> ChatRunStore,
         makeToolsStore: @escaping (Int) -> ChatToolsStore,
+        feedbackService: FeedbackServiceProtocol,
+        feedbackHeaderProvider: FeedbackRequestHeaderProviding,
         mediaLoader: ChatMediaLoading,
         onBack: @escaping () -> Void,
     ) {
         self.simulation = simulation
         self.makeRunStore = makeRunStore
         self.makeToolsStore = makeToolsStore
+        self.feedbackService = feedbackService
+        self.feedbackHeaderProvider = feedbackHeaderProvider
         self.mediaLoader = mediaLoader
         self.onBack = onBack
         _runStore = StateObject(wrappedValue: makeRunStore(simulation))
@@ -85,6 +101,8 @@ private struct ChatRunScreen: View {
         ChatRunView(
             store: runStore,
             toolsStore: toolsStore,
+            feedbackService: feedbackService,
+            feedbackHeaderProvider: feedbackHeaderProvider,
             mediaLoader: mediaLoader,
             onBack: onBack,
         )

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -1,4 +1,6 @@
 import DesignSystem
+import FeedbackFeature
+import Networking
 import SharedModels
 import SwiftUI
 #if os(iOS)
@@ -10,12 +12,16 @@ import SwiftUI
 public struct ChatRunView: View {
     @ObservedObject private var store: ChatRunStore
     @ObservedObject private var toolsStore: ChatToolsStore
+    private let feedbackService: FeedbackServiceProtocol
+    private let feedbackHeaderProvider: FeedbackRequestHeaderProviding
     private let mediaLoader: ChatMediaLoading
     private let onBack: () -> Void
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.scenePhase) private var scenePhase
     @State private var showToolsSheet = false
+    @State private var activeFeedbackContext: FeedbackLaunchContext?
+    @State private var feedbackSuccessMessage: String?
     @State private var stagedOrderText = ""
     @State private var expandedToolSections = Set<ChatToolsSection>()
     @State private var lastToolLayoutMode: ChatRunLayoutMode?
@@ -26,11 +32,15 @@ public struct ChatRunView: View {
     public init(
         store: ChatRunStore,
         toolsStore: ChatToolsStore,
+        feedbackService: FeedbackServiceProtocol,
+        feedbackHeaderProvider: FeedbackRequestHeaderProviding,
         mediaLoader: ChatMediaLoading,
         onBack: @escaping () -> Void,
     ) {
         self.store = store
         self.toolsStore = toolsStore
+        self.feedbackService = feedbackService
+        self.feedbackHeaderProvider = feedbackHeaderProvider
         self.mediaLoader = mediaLoader
         self.onBack = onBack
     }
@@ -83,6 +93,32 @@ public struct ChatRunView: View {
         .modifier(ChatInlineNavigationTitleModifier())
         .modifier(ChatHideRunNavigationBarModifier())
         .modifier(ChatKeyboardStateModifier(isKeyboardPresented: $isKeyboardPresented))
+        .sheet(item: $activeFeedbackContext) { context in
+            FeedbackFormView(
+                viewModel: FeedbackViewModel(
+                    service: feedbackService,
+                    headerProvider: feedbackHeaderProvider,
+                    launchContext: context,
+                ),
+                onSubmitted: {
+                    feedbackSuccessMessage = "Feedback sent."
+                },
+            )
+        }
+        .overlay(alignment: .top) {
+            if let feedbackSuccessMessage {
+                FeedbackSuccessBanner(message: feedbackSuccessMessage)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+            }
+        }
+        .task(id: feedbackSuccessMessage) {
+            guard feedbackSuccessMessage != nil else { return }
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if !Task.isCancelled {
+                feedbackSuccessMessage = nil
+            }
+        }
     }
 
     private func padWorkspace(chromeMode: ChatRunChromeMode) -> some View {
@@ -431,6 +467,11 @@ public struct ChatRunView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
             }
+
+            Button("Send Feedback") {
+                activeFeedbackContext = feedbackLaunchContext()
+            }
+            .buttonStyle(.bordered)
         }
     }
 
@@ -780,6 +821,14 @@ public struct ChatRunView: View {
                 .frame(maxWidth: .infinity)
             }
 
+            if layoutMode != .padWorkspace {
+                Button("Send Feedback") {
+                    activeFeedbackContext = feedbackLaunchContext()
+                }
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+            }
+
             if isInStitchConversation {
                 // Currently in the Stitch debrief — show a clear indicator instead of a button.
                 Label("Stitch Debrief", systemImage: "bubble.left.and.text.bubble.right.fill")
@@ -857,6 +906,19 @@ public struct ChatRunView: View {
             .onSubmit {
                 stageCurrentOrder()
             }
+    }
+
+    private func feedbackLaunchContext() -> FeedbackLaunchContext {
+        FeedbackLaunchContext(
+            scope: .simulation,
+            sourceScreen: "chat_run",
+            simulationID: store.simulation.id,
+            conversationID: store.activeConversationID,
+            labType: .chatlab,
+            simulationDisplayName: store.simulation.patientDisplayName,
+            simulationStatus: store.simulation.status.rawValue,
+            conversationKind: activeConversation?.conversationType,
+        )
     }
 
     private var addOrderButton: some View {

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -1486,9 +1486,9 @@ private struct PatientResultRow: View {
                 Text(
                     result.displayName
                         .replacingOccurrences(of: "_", with: " ")
-                        .uppercased()
+                        .uppercased(),
                 )
-                    .font(.subheadline.weight(.semibold))
+                .font(.subheadline.weight(.semibold))
                 Spacer(minLength: 12)
                 Text(valueText)
                     .font(.headline.monospacedDigit())
@@ -1800,10 +1800,9 @@ private struct FeedbackFieldRow: View {
         field.label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "patient experience"
     }
 
-    @ViewBuilder
     private func starRatingView(rating: Int) -> some View {
         HStack(spacing: 2) {
-            ForEach(0..<5, id: \.self) { index in
+            ForEach(0 ..< 5, id: \.self) { index in
                 Image(systemName: index < rating ? "star.fill" : "star")
                     .font(.footnote)
                     .foregroundStyle(.yellow)

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -1396,9 +1396,18 @@ private struct PatientResultsRows: View {
                                 .foregroundStyle(.secondary)
                         }
 
-                        ForEach(Array(section.rows.enumerated()), id: \.offset) { _, result in
-                            PatientResultRow(result: result)
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(section.rows.enumerated()), id: \.offset) { index, result in
+                                PatientResultRow(result: result)
+
+                                if index < section.rows.count - 1 {
+                                    Divider()
+                                        .overlay(Color.secondary.opacity(0.12))
+                                }
+                            }
                         }
+                        .background(Color.secondary.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                     }
                 }
             }
@@ -1412,18 +1421,17 @@ private struct PatientResultRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(result.displayName)
+                Text(
+                    result.displayName
+                        .replacingOccurrences(of: "_", with: " ")
+                        .uppercased()
+                )
                     .font(.subheadline.weight(.semibold))
                 Spacer(minLength: 12)
                 Text(valueText)
                     .font(.headline.monospacedDigit())
                     .multilineTextAlignment(.trailing)
-            }
-
-            if !metadataLine.isEmpty {
-                Text(metadataLine)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundColor(result.flag == "abnormal" ? .red : .primary)
             }
 
             if let referenceRangeText {
@@ -1434,8 +1442,6 @@ private struct PatientResultRow: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
-        .background(Color.secondary.opacity(0.08))
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
     private var valueText: String {
@@ -1550,12 +1556,22 @@ private struct SimulationFeedbackRows: View {
                 .font(.footnote)
                 .foregroundStyle(.secondary)
         } else {
+            let fields = rows.flatMap(feedbackFields(from:))
+            let diagnosisField = fields.first { normalizedFeedbackKey(for: $0.label) == "diagnosis" }
+            let treatmentPlanField = fields.first { normalizedFeedbackKey(for: $0.label) == "treatment plan" }
+            let remainingFields = fields.filter {
+                let normalized = normalizedFeedbackKey(for: $0.label)
+                return normalized != "diagnosis" && normalized != "treatment plan"
+            }
+
             VStack(alignment: .leading, spacing: 10) {
-                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                    let fields = ChatFeedbackPresentation.fields(from: row)
+                if diagnosisField != nil || treatmentPlanField != nil {
                     VStack(alignment: .leading, spacing: 6) {
-                        ForEach(Array(fields.enumerated()), id: \.offset) { _, field in
-                            FeedbackFieldRow(field: field)
+                        if let diagnosisField {
+                            FeedbackFieldRow(field: diagnosisField)
+                        }
+                        if let treatmentPlanField {
+                            FeedbackFieldRow(field: treatmentPlanField)
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -1563,8 +1579,75 @@ private struct SimulationFeedbackRows: View {
                     .background(Color.secondary.opacity(0.08))
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }
+
+                ForEach(Array(remainingFields.enumerated()), id: \.offset) { _, field in
+                    FeedbackFieldRow(field: field)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                        .background(Color.secondary.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
             }
         }
+    }
+
+    private func feedbackFields(from row: [String: JSONValue]) -> [ChatFeedbackField] {
+        guard let rawKeyValue = row["key"] else {
+            return []
+        }
+
+        let rawKey = ChatToolValueFormatter.render(rawKeyValue)
+        let loweredRawKey = rawKey.lowercased()
+        guard !rawKey.isEmpty,
+              rawKey != "-",
+              loweredRawKey != "kind",
+              loweredRawKey != "key",
+              loweredRawKey != "db_pk"
+        else {
+            return []
+        }
+
+        let label = prettyFeedbackLabel(from: rawKey)
+        let value = row["value"] ?? .null
+
+        switch value {
+        case let .bool(boolValue):
+            return [
+                ChatFeedbackField(
+                    label: label,
+                    kind: boolValue ? .boolTrue : .boolFalse,
+                ),
+            ]
+        default:
+            let rendered = ChatToolValueFormatter.render(value)
+            guard !rendered.isEmpty,
+                  rendered != "-",
+                  rendered.lowercased() != "simulation_feedback"
+            else {
+                return []
+            }
+
+            return [
+                ChatFeedbackField(
+                    label: label,
+                    kind: .text(rendered),
+                ),
+            ]
+        }
+    }
+
+    private func prettyFeedbackLabel(from rawKey: String) -> String {
+        let stripped = rawKey
+            .replacingOccurrences(of: "hotwash_", with: "")
+            .replacingOccurrences(of: "correct_", with: "")
+
+        return ChatToolValueFormatter.friendlyLabel(for: stripped)
+    }
+
+    private func normalizedFeedbackKey(for label: String) -> String {
+        label
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
     }
 }
 
@@ -1573,49 +1656,104 @@ private struct FeedbackFieldRow: View {
 
     var body: some View {
         switch field.kind {
-        // Boolish rows: icon (for visual scanning) + "Label: Yes/No/Partial" text.
-        // VoiceOver reads the combined label so it announces the full semantic meaning.
         case .boolTrue:
-            HStack(alignment: .center, spacing: 8) {
-                Image(systemName: "checkmark.square.fill")
-                    .foregroundStyle(.green)
-                    .accessibilityHidden(true) // text below carries the full meaning
-                Text("\(field.label): Yes")
-                    .font(.footnote)
-                Spacer(minLength: 0)
-            }
-            .accessibilityLabel("\(field.label): Yes")
-        case .boolFalse:
-            HStack(alignment: .center, spacing: 8) {
-                Image(systemName: "x.square.fill")
-                    .foregroundStyle(.red)
-                    .accessibilityHidden(true)
-                Text("\(field.label): No")
-                    .font(.footnote)
-                Spacer(minLength: 0)
-            }
-            .accessibilityLabel("\(field.label): No")
-        case .partial:
-            HStack(alignment: .center, spacing: 8) {
-                Image(systemName: "exclamationmark.square.fill")
-                    .foregroundStyle(.yellow)
-                    .accessibilityHidden(true)
-                Text("\(field.label): Partial")
-                    .font(.footnote)
-                Spacer(minLength: 0)
-            }
-            .accessibilityLabel("\(field.label): Partial")
-        // Text rows: compact two-line label/value, consistent with boolish scanability.
-        case let .text(value):
-            VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(field.label)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text(value)
-                    .font(.footnote)
+                Spacer(minLength: 8)
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.green)
+                    .accessibilityHidden(true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityLabel("\(field.label): \(value)")
+            .accessibilityLabel("\(field.label): Yes")
+
+        case .boolFalse:
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(field.label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel("\(field.label): No")
+
+        case .partial:
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(field.label)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundStyle(.yellow)
+                    .accessibilityHidden(true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel("\(field.label): Partial")
+
+        case let .text(value):
+            if let rating = starRatingValue(from: value), isPatientExperienceLabel {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(field.label)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    starRatingView(rating: rating)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityLabel("\(field.label): \(rating) out of 5 stars")
+            } else if value.count > 40 || value.contains("\n") {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(field.label)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text(value)
+                        .font(.footnote)
+                        .foregroundStyle(.primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityLabel("\(field.label): \(value)")
+            } else {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(field.label)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Text(value)
+                        .font(.footnote)
+                        .multilineTextAlignment(.trailing)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityLabel("\(field.label): \(value)")
+            }
         }
+    }
+
+    private var isPatientExperienceLabel: Bool {
+        field.label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "patient experience"
+    }
+
+    @ViewBuilder
+    private func starRatingView(rating: Int) -> some View {
+        HStack(spacing: 2) {
+            ForEach(0..<5, id: \.self) { index in
+                Image(systemName: index < rating ? "star.fill" : "star")
+                    .font(.footnote)
+                    .foregroundStyle(.yellow)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
+    private func starRatingValue(from value: String) -> Int? {
+        guard let parsed = Int(value.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return nil
+        }
+        return min(max(parsed, 0), 5)
     }
 }

--- a/apps/medsim-shell-ios/Package.swift
+++ b/apps/medsim-shell-ios/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
                 .product(name: "Presets", package: "trainerlab-ios"),
                 .product(name: "RunConsole", package: "trainerlab-ios"),
                 .product(name: "Summary", package: "trainerlab-ios"),
+                .product(name: "FeedbackFeature", package: "trainerlab-ios"),
                 .product(name: "Networking", package: "trainerlab-ios"),
                 .product(name: "Realtime", package: "trainerlab-ios"),
                 .product(name: "Persistence", package: "trainerlab-ios"),

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
@@ -39,6 +39,8 @@ public final class AppShellModel: ObservableObject {
     public let accountSessionStore: AccountSessionStore
     public let billingService: AppleBillingService
     public let buildInfoStore: BuildInfoStore
+    public let feedbackService: FeedbackServiceProtocol
+    public let feedbackHeaderProvider: FeedbackRequestHeaderProviding
     public let sessionHubViewModel: SessionHubViewModel
     public let presetsViewModel: PresetsViewModel
 
@@ -78,6 +80,15 @@ public final class AppShellModel: ObservableObject {
             },
         )
         self.apiClient = apiClient
+
+        let feedbackHeaderProvider = FeedbackRequestHeaderProvider(
+            sessionID: UUID().uuidString.lowercased(),
+        )
+        self.feedbackHeaderProvider = feedbackHeaderProvider
+        feedbackService = FeedbackService(
+            apiClient: apiClient,
+            headerProvider: feedbackHeaderProvider,
+        )
 
         let trainerService = TrainerLabService(apiClient: apiClient)
         self.trainerService = trainerService

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
@@ -293,7 +293,7 @@ private struct RunConsoleScreen: View {
             onBack: onBack,
             onOpenSummary: onOpenSummary,
         )
-            .appShellOrientationLock(.iPadLandscape)
+        .appShellOrientationLock(.iPadLandscape)
     }
 }
 

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
@@ -1,6 +1,7 @@
 import Auth
 import ChatLabiOS
 import DesignSystem
+import FeedbackFeature
 import Networking
 import Presets
 import RunConsole
@@ -19,6 +20,8 @@ public struct AppShellRootView: View {
     @State private var showEnvironment = false
     @State private var showAccountBilling = false
     @State private var selectedApp: InternalApp?
+    @State private var activeFeedbackContext: FeedbackLaunchContext?
+    @State private var feedbackSuccessMessage: String?
 
     public init() {}
 
@@ -36,6 +39,8 @@ public struct AppShellRootView: View {
                             makeToolsStore: { simulationID in
                                 model.makeChatToolsStore(simulationID: simulationID)
                             },
+                            feedbackService: model.feedbackService,
+                            feedbackHeaderProvider: model.feedbackHeaderProvider,
                             mediaLoader: model.makeChatMediaLoader(),
                             onExit: {
                                 self.selectedApp = nil
@@ -67,12 +72,25 @@ public struct AppShellRootView: View {
                         onOpenAccountBilling: {
                             showAccountBilling = true
                         },
+                        onOpenFeedback: {
+                            activeFeedbackContext = FeedbackLaunchContext(
+                                scope: .general,
+                                sourceScreen: "main_menu",
+                            )
+                        },
                         onSignOut: {
                             selectedApp = nil
                             showAccountBilling = false
                             Task { await model.authViewModel.signOut() }
                         },
                     )
+                    .safeAreaInset(edge: .top) {
+                        if let feedbackSuccessMessage {
+                            FeedbackSuccessBanner(message: feedbackSuccessMessage)
+                                .padding(.horizontal, 24)
+                                .padding(.top, 12)
+                        }
+                    }
                 }
             } else {
                 AuthGateView(
@@ -99,18 +117,40 @@ public struct AppShellRootView: View {
             AccountBillingSheet(
                 accountStore: model.accountSessionStore,
                 billingService: model.billingService,
+                feedbackService: model.feedbackService,
+                feedbackHeaderProvider: model.feedbackHeaderProvider,
                 onAccountSwitched: {
                     model.resetScopedWorkspaceState()
+                },
+            )
+        }
+        .sheet(item: $activeFeedbackContext) { context in
+            FeedbackFormView(
+                viewModel: FeedbackViewModel(
+                    service: model.feedbackService,
+                    headerProvider: model.feedbackHeaderProvider,
+                    launchContext: context,
+                ),
+                onSubmitted: {
+                    feedbackSuccessMessage = "Thanks for the feedback."
                 },
             )
         }
         .task {
             await model.authViewModel.restoreSessionIfAvailable()
         }
+        .task(id: feedbackSuccessMessage) {
+            guard feedbackSuccessMessage != nil else { return }
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if !Task.isCancelled {
+                feedbackSuccessMessage = nil
+            }
+        }
         .onChange(of: model.authViewModel.isAuthenticated) { _, isAuthenticated in
             if !isAuthenticated {
                 selectedApp = nil
                 showAccountBilling = false
+                activeFeedbackContext = nil
             }
         }
     }
@@ -212,7 +252,11 @@ private struct TrainerLabWorkspace: View {
         }
         .sheet(isPresented: $showSummary) {
             if let session = selectedSession {
-                RunSummaryView(viewModel: model.makeSummaryViewModel(simulationID: session.simulationID))
+                RunSummaryView(
+                    viewModel: model.makeSummaryViewModel(simulationID: session.simulationID),
+                    feedbackService: model.feedbackService,
+                    feedbackHeaderProvider: model.feedbackHeaderProvider,
+                )
             } else {
                 Text("No session selected")
             }
@@ -242,7 +286,13 @@ private struct RunConsoleScreen: View {
     }
 
     var body: some View {
-        RunConsoleView(store: store, onBack: onBack, onOpenSummary: onOpenSummary)
+        RunConsoleView(
+            store: store,
+            feedbackService: model.feedbackService,
+            feedbackHeaderProvider: model.feedbackHeaderProvider,
+            onBack: onBack,
+            onOpenSummary: onOpenSummary,
+        )
             .appShellOrientationLock(.iPadLandscape)
     }
 }
@@ -266,6 +316,7 @@ private struct MainMenuView: View {
     let onOpenTrainerLab: () -> Void
     let onOpenChatLab: () -> Void
     let onOpenAccountBilling: () -> Void
+    let onOpenFeedback: () -> Void
     let onSignOut: () -> Void
 
     var body: some View {
@@ -324,6 +375,9 @@ private struct MainMenuView: View {
 
                 Button("Account & Billing", action: onOpenAccountBilling)
                     .buttonStyle(.borderedProminent)
+
+                Button("Send Feedback", action: onOpenFeedback)
+                    .buttonStyle(.bordered)
 
                 if let accessMessage, !accessMessage.isEmpty {
                     Text(accessMessage)
@@ -387,9 +441,13 @@ private struct MainMenuView: View {
 private struct AccountBillingSheet: View {
     @ObservedObject var accountStore: AccountSessionStore
     @ObservedObject var billingService: AppleBillingService
+    let feedbackService: FeedbackServiceProtocol
+    let feedbackHeaderProvider: FeedbackRequestHeaderProviding
     let onAccountSwitched: () -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @State private var activeFeedbackContext: FeedbackLaunchContext?
+    @State private var feedbackSuccessMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -511,6 +569,15 @@ private struct AccountBillingSheet: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+
+                Section("Support") {
+                    Button("Send Feedback") {
+                        activeFeedbackContext = FeedbackLaunchContext(
+                            scope: .general,
+                            sourceScreen: "account_billing",
+                        )
+                    }
+                }
             }
             .navigationTitle("Account & Billing")
             .toolbar {
@@ -520,9 +587,35 @@ private struct AccountBillingSheet: View {
                     }
                 }
             }
+            .safeAreaInset(edge: .top) {
+                if let feedbackSuccessMessage {
+                    FeedbackSuccessBanner(message: feedbackSuccessMessage)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 8)
+                }
+            }
         }
         .task {
             await billingService.loadProductsIfNeeded()
+        }
+        .sheet(item: $activeFeedbackContext) { context in
+            FeedbackFormView(
+                viewModel: FeedbackViewModel(
+                    service: feedbackService,
+                    headerProvider: feedbackHeaderProvider,
+                    launchContext: context,
+                ),
+                onSubmitted: {
+                    feedbackSuccessMessage = "Thanks for the feedback."
+                },
+            )
+        }
+        .task(id: feedbackSuccessMessage) {
+            guard feedbackSuccessMessage != nil else { return }
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if !Task.isCancelled {
+                feedbackSuccessMessage = nil
+            }
         }
     }
 }

--- a/apps/trainerlab-ios/Package.swift
+++ b/apps/trainerlab-ios/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .library(name: "Presets", targets: ["Presets"]),
         .library(name: "RunConsole", targets: ["RunConsole"]),
         .library(name: "Summary", targets: ["Summary"]),
+        .library(name: "FeedbackFeature", targets: ["FeedbackFeature"]),
         .library(name: "Networking", targets: ["Networking"]),
         .library(name: "Realtime", targets: ["Realtime"]),
         .library(name: "Persistence", targets: ["Persistence"]),
@@ -56,6 +57,8 @@ let package = Package(
                 "BuildInfoService.swift",
                 "DecodingDiagnostics.swift",
                 "EnvironmentStore.swift",
+                "FeedbackModels.swift",
+                "FeedbackService.swift",
                 "MutableBaseURLProvider.swift",
                 "TrainerLabService.swift",
             ],
@@ -100,6 +103,7 @@ let package = Package(
                 "SharedModels",
                 "Sessions",
                 "DesignSystem",
+                "FeedbackFeature",
             ],
         ),
         .target(
@@ -108,6 +112,15 @@ let package = Package(
                 "SharedModels",
                 "Networking",
                 "DesignSystem",
+                "FeedbackFeature",
+            ],
+        ),
+        .target(
+            name: "FeedbackFeature",
+            dependencies: [
+                "Networking",
+                "DesignSystem",
+                "SharedModels",
             ],
         ),
         .testTarget(
@@ -137,6 +150,10 @@ let package = Package(
         .testTarget(
             name: "SummaryTests",
             dependencies: ["Summary", "Networking", "SharedModels"],
+        ),
+        .testTarget(
+            name: "FeedbackFeatureTests",
+            dependencies: ["FeedbackFeature", "Networking", "SharedModels"],
         ),
         .testTarget(
             name: "AuthTests",

--- a/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackFormView.swift
+++ b/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackFormView.swift
@@ -1,0 +1,188 @@
+import DesignSystem
+import Networking
+import SwiftUI
+
+public struct FeedbackFormView: View {
+    @ObservedObject private var viewModel: FeedbackViewModel
+    private let onSubmitted: @MainActor () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var focusedField: Field?
+
+    private enum Field: Hashable {
+        case title
+        case body
+    }
+
+    public init(
+        viewModel: FeedbackViewModel,
+        onSubmitted: @escaping @MainActor () -> Void,
+    ) {
+        self.viewModel = viewModel
+        self.onSubmitted = onSubmitted
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Form {
+                if let error = viewModel.presentableError {
+                    Section {
+                        InlineAppErrorView(error: error, actionLabel: "Retry")
+                            .font(.footnote)
+                    }
+                }
+
+                Section("Category") {
+                    Picker("Category", selection: $viewModel.selectedCategory) {
+                        ForEach(viewModel.categories, id: \.self) { category in
+                            Text(category.title).tag(category)
+                        }
+                    }
+                    .accessibilityIdentifier("feedback-category-picker")
+
+                    Text(viewModel.selectedCategory.description)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !viewModel.launchContext.attachedContextLines.isEmpty {
+                    Section("Attached Context") {
+                        ForEach(viewModel.launchContext.attachedContextLines, id: \.self) { line in
+                            Text(line)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section("Details") {
+                    TextField("Optional title", text: $viewModel.title)
+                        .focused($focusedField, equals: .title)
+                        .submitLabel(.next)
+                        .onSubmit {
+                            focusedField = .body
+                        }
+                        .accessibilityIdentifier("feedback-title-field")
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Description")
+                            .font(.subheadline.weight(.semibold))
+
+                        TextEditor(text: $viewModel.body)
+                            .frame(minHeight: 180)
+                            .padding(8)
+                            .scrollContentBackground(.hidden)
+                            .background(Color.secondary.opacity(0.08))
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .focused($focusedField, equals: .body)
+                            .accessibilityIdentifier("feedback-body-field")
+                            .onChange(of: viewModel.body) { _, _ in
+                                viewModel.clearSubmissionError()
+                                viewModel.clearValidationIfNeeded()
+                            }
+
+                        if let bodyValidationMessage = viewModel.bodyValidationMessage {
+                            Text(bodyValidationMessage)
+                                .font(.footnote)
+                                .foregroundStyle(TrainerLabTheme.danger)
+                        } else {
+                            Text("Tell us what happened, what you expected, or what would help.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                Section("Rating") {
+                    FeedbackRatingPicker(rating: $viewModel.rating)
+                }
+
+                Section("Follow-Up") {
+                    Toggle("Allow the team to follow up with you", isOn: $viewModel.allowFollowUp)
+                }
+            }
+            .navigationTitle("Send Feedback")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task {
+                            let didSubmit = await viewModel.submit()
+                            if didSubmit {
+                                onSubmitted()
+                                dismiss()
+                            }
+                        }
+                    } label: {
+                        if viewModel.isSubmitting {
+                            ProgressView()
+                        } else {
+                            Text("Send")
+                        }
+                    }
+                    .disabled(!viewModel.canSubmit)
+                    .accessibilityIdentifier("feedback-submit-button")
+                }
+            }
+        }
+        .task {
+            await viewModel.loadCategoriesIfNeeded()
+            if viewModel.body.isEmpty {
+                focusedField = .body
+            }
+        }
+    }
+}
+
+private struct FeedbackRatingPicker: View {
+    @Binding var rating: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                ForEach(1 ... 5, id: \.self) { value in
+                    Button {
+                        rating = value
+                    } label: {
+                        Image(systemName: iconName(for: value))
+                            .font(.title3)
+                            .foregroundStyle(.yellow)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Rate \(value) out of 5")
+                    .accessibilityAddTraits(rating == value ? .isSelected : [])
+                }
+
+                Spacer(minLength: 12)
+
+                Button("Clear") {
+                    rating = nil
+                }
+                .buttonStyle(.bordered)
+                .disabled(rating == nil)
+                .accessibilityLabel("Clear rating")
+            }
+
+            Text(ratingDescription)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var ratingDescription: String {
+        guard let rating else {
+            return "Rating is optional."
+        }
+        return "\(rating) out of 5 selected."
+    }
+
+    private func iconName(for value: Int) -> String {
+        guard let rating else {
+            return "star"
+        }
+        return value <= rating ? "star.fill" : "star"
+    }
+}

--- a/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackLaunchContext.swift
+++ b/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackLaunchContext.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Networking
+import SharedModels
+
+public enum FeedbackScope: String, Sendable {
+    case general
+    case simulation
+}
+
+public enum FeedbackLabType: String, Sendable {
+    case chatlab
+    case trainerlab
+}
+
+public struct FeedbackLaunchContext: Identifiable, Hashable, Sendable {
+    public let id: UUID
+    public let scope: FeedbackScope
+    public let sourceScreen: String
+    public let simulationID: Int?
+    public let conversationID: Int?
+    public let labType: FeedbackLabType?
+    public let simulationDisplayName: String?
+    public let simulationStatus: String?
+    public let conversationKind: String?
+
+    public init(
+        id: UUID = UUID(),
+        scope: FeedbackScope,
+        sourceScreen: String,
+        simulationID: Int? = nil,
+        conversationID: Int? = nil,
+        labType: FeedbackLabType? = nil,
+        simulationDisplayName: String? = nil,
+        simulationStatus: String? = nil,
+        conversationKind: String? = nil,
+    ) {
+        self.id = id
+        self.scope = scope
+        self.sourceScreen = sourceScreen
+        self.simulationID = simulationID
+        self.conversationID = conversationID
+        self.labType = labType
+        self.simulationDisplayName = simulationDisplayName
+        self.simulationStatus = simulationStatus
+        self.conversationKind = conversationKind
+    }
+
+    public var defaultCategory: FeedbackCategory {
+        switch scope {
+        case .general:
+            .other
+        case .simulation:
+            .simulationContent
+        }
+    }
+
+    public var attachedContextLines: [String] {
+        var lines: [String] = []
+        if let simulationID {
+            if let simulationDisplayName, !simulationDisplayName.isEmpty {
+                lines.append("\(simulationDisplayName) (Simulation #\(simulationID))")
+            } else {
+                lines.append("Simulation #\(simulationID)")
+            }
+        }
+        if let conversationID {
+            lines.append("Conversation #\(conversationID)")
+        }
+        if let labType {
+            lines.append(labType.rawValue.capitalized)
+        }
+        if let simulationStatus, !simulationStatus.isEmpty {
+            lines.append("Status: \(simulationStatus)")
+        }
+        return lines
+    }
+
+    public func requestContext(appVersion: String) -> [String: JSONValue] {
+        var context: [String: JSONValue] = [
+            "source_screen": .string(sourceScreen),
+            "submission_scope": .string(scope.rawValue),
+            "app_version": .string(appVersion),
+        ]
+
+        if let labType {
+            context["lab_type"] = .string(labType.rawValue)
+        }
+        if let conversationKind, !conversationKind.isEmpty {
+            context["active_conversation_kind"] = .string(conversationKind)
+        }
+        if let simulationStatus, !simulationStatus.isEmpty {
+            context["simulation_status"] = .string(simulationStatus)
+        }
+        if let simulationDisplayName, !simulationDisplayName.isEmpty {
+            context["simulation_name"] = .string(simulationDisplayName)
+        }
+        return context
+    }
+}

--- a/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackSuccessBanner.swift
+++ b/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackSuccessBanner.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+public struct FeedbackSuccessBanner: View {
+    private let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+
+    public var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+
+            Text(message)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.primary)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.green.opacity(0.28), lineWidth: 1),
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .shadow(color: Color.black.opacity(0.08), radius: 10, y: 4)
+    }
+}

--- a/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackViewModel.swift
+++ b/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackViewModel.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Networking
+import SharedModels
+
+@MainActor
+public final class FeedbackViewModel: ObservableObject {
+    @Published public private(set) var categories: [FeedbackCategory] = FeedbackCategory.allCases
+    @Published public var selectedCategory: FeedbackCategory
+    @Published public var title = ""
+    @Published public var body = ""
+    @Published public var rating: Int?
+    @Published public var allowFollowUp = false
+    @Published public private(set) var isLoadingCategories = false
+    @Published public private(set) var isSubmitting = false
+    @Published public private(set) var presentableError: PresentableAppError?
+    @Published public private(set) var bodyValidationMessage: String?
+    @Published public private(set) var didSubmitSuccessfully = false
+
+    public let simulationID: Int?
+    public let conversationID: Int?
+    public let launchContext: FeedbackLaunchContext
+
+    private let service: FeedbackServiceProtocol
+    private let headerProvider: FeedbackRequestHeaderProviding
+    private var hasLoadedCategories = false
+
+    public init(
+        service: FeedbackServiceProtocol,
+        headerProvider: FeedbackRequestHeaderProviding,
+        launchContext: FeedbackLaunchContext,
+    ) {
+        self.service = service
+        self.headerProvider = headerProvider
+        self.launchContext = launchContext
+        selectedCategory = launchContext.defaultCategory
+        simulationID = launchContext.simulationID
+        conversationID = launchContext.conversationID
+    }
+
+    public var trimmedBody: String {
+        body.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var canSubmit: Bool {
+        !trimmedBody.isEmpty && !isSubmitting
+    }
+
+    public func loadCategoriesIfNeeded() async {
+        guard !hasLoadedCategories, !isLoadingCategories else { return }
+        isLoadingCategories = true
+        defer {
+            isLoadingCategories = false
+            hasLoadedCategories = true
+        }
+
+        do {
+            let fetched = try await service.fetchFeedbackCategories().map(\.value)
+            let uniqueCategories = fetched.reduce(into: [FeedbackCategory]()) { result, category in
+                if result.contains(category) == false {
+                    result.append(category)
+                }
+            }
+            if !uniqueCategories.isEmpty {
+                categories = uniqueCategories
+                if categories.contains(selectedCategory) == false {
+                    selectedCategory = launchContext.defaultCategory
+                }
+            }
+        } catch {
+            categories = FeedbackCategory.allCases
+        }
+    }
+
+    public func clearSubmissionError() {
+        presentableError = nil
+    }
+
+    public func clearValidationIfNeeded() {
+        if trimmedBody.isEmpty {
+            bodyValidationMessage = "Please enter a description."
+        } else {
+            bodyValidationMessage = nil
+        }
+    }
+
+    public func makeCreateRequest() -> FeedbackCreateRequest? {
+        let body = trimmedBody
+        guard !body.isEmpty else {
+            return nil
+        }
+
+        let title = trimmedTitle
+
+        return FeedbackCreateRequest(
+            category: selectedCategory,
+            title: title.isEmpty ? nil : title,
+            body: body,
+            simulationID: simulationID,
+            conversationID: conversationID,
+            rating: rating,
+            allowFollowUp: allowFollowUp,
+            context: launchContext.requestContext(appVersion: headerProvider.appVersionHeaderValue),
+        )
+    }
+
+    @discardableResult
+    public func submit() async -> Bool {
+        bodyValidationMessage = nil
+        presentableError = nil
+        didSubmitSuccessfully = false
+
+        guard let request = makeCreateRequest() else {
+            bodyValidationMessage = "Please enter a description."
+            return false
+        }
+        guard !isSubmitting else { return false }
+
+        isSubmitting = true
+        defer { isSubmitting = false }
+
+        do {
+            _ = try await service.submitFeedback(request)
+            didSubmitSuccessfully = true
+            clearDraft()
+            return true
+        } catch {
+            presentableError = AppErrorPresenter.present(error)
+            return false
+        }
+    }
+
+    private func clearDraft() {
+        title = ""
+        body = ""
+        rating = nil
+        allowFollowUp = false
+    }
+}

--- a/apps/trainerlab-ios/Sources/Networking/APIClient.swift
+++ b/apps/trainerlab-ios/Sources/Networking/APIClient.swift
@@ -245,6 +245,8 @@ public enum FeedbackAPI {
             method: .post,
             body: body,
             headers: headers,
+            requiresAuth: true,
+            requiresAccountContext: false,
         )
     }
 }

--- a/apps/trainerlab-ios/Sources/Networking/APIClient.swift
+++ b/apps/trainerlab-ios/Sources/Networking/APIClient.swift
@@ -230,6 +230,25 @@ public enum SystemAPI {
     }
 }
 
+public enum FeedbackAPI {
+    public static func categories() -> Endpoint {
+        Endpoint(
+            path: "/api/v1/feedback/categories/",
+            requiresAuth: false,
+            requiresAccountContext: false,
+        )
+    }
+
+    public static func create(body: Data, headers: [String: String]) -> Endpoint {
+        Endpoint(
+            path: "/api/v1/feedback/",
+            method: .post,
+            body: body,
+            headers: headers,
+        )
+    }
+}
+
 public enum TrainerLabAPI {
     public static func accessMe() -> Endpoint {
         Endpoint(path: "/api/v1/trainerlab/access/me/")

--- a/apps/trainerlab-ios/Sources/Networking/FeedbackModels.swift
+++ b/apps/trainerlab-ios/Sources/Networking/FeedbackModels.swift
@@ -1,0 +1,184 @@
+import Foundation
+import SharedModels
+
+public enum FeedbackCategory: String, Codable, CaseIterable, Sendable {
+    case bugReport = "bug_report"
+    case uxIssue = "ux_issue"
+    case simulationContent = "simulation_content"
+    case featureRequest = "feature_request"
+    case other
+
+    public var title: String {
+        switch self {
+        case .bugReport:
+            "Bug Report"
+        case .uxIssue:
+            "UX Issue"
+        case .simulationContent:
+            "Simulation Content"
+        case .featureRequest:
+            "Feature Request"
+        case .other:
+            "Other"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .bugReport:
+            "Something in the app is broken or behaving unexpectedly."
+        case .uxIssue:
+            "The experience is confusing, awkward, or hard to use."
+        case .simulationContent:
+            "The simulation scenario, realism, or content needs improvement."
+        case .featureRequest:
+            "There’s a capability you’d like to add."
+        case .other:
+            "General feedback that doesn’t fit the other categories."
+        }
+    }
+}
+
+public struct FeedbackCategoryDTO: Codable, Equatable, Sendable {
+    public let value: FeedbackCategory
+    public let label: String
+
+    public init(value: FeedbackCategory, label: String? = nil) {
+        self.value = value
+        self.label = label ?? value.title
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case value
+        case label
+        case category
+        case name
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let singleValue = try? decoder.singleValueContainer(),
+           let rawValue = try? singleValue.decode(String.self),
+           let category = FeedbackCategory(rawValue: rawValue)
+        {
+            value = category
+            label = category.title
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawValue =
+            try container.decodeIfPresent(String.self, forKey: .value)
+                ?? container.decodeIfPresent(String.self, forKey: .category)
+                ?? ""
+        guard let category = FeedbackCategory(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .value,
+                in: container,
+                debugDescription: "Unsupported feedback category: \(rawValue)",
+            )
+        }
+        value = category
+        label =
+            try container.decodeIfPresent(String.self, forKey: .label)
+                ?? container.decodeIfPresent(String.self, forKey: .name)
+                ?? category.title
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(value, forKey: .value)
+        try container.encode(label, forKey: .label)
+    }
+}
+
+public struct FeedbackCreateRequest: Codable, Equatable, Sendable {
+    public let category: FeedbackCategory
+    public let title: String?
+    public let body: String
+    public let simulationID: Int?
+    public let conversationID: Int?
+    public let rating: Int?
+    public let allowFollowUp: Bool?
+    public let context: [String: JSONValue]?
+
+    public init(
+        category: FeedbackCategory,
+        title: String? = nil,
+        body: String,
+        simulationID: Int? = nil,
+        conversationID: Int? = nil,
+        rating: Int? = nil,
+        allowFollowUp: Bool? = nil,
+        context: [String: JSONValue]? = nil,
+    ) {
+        self.category = category
+        self.title = title
+        self.body = body
+        self.simulationID = simulationID
+        self.conversationID = conversationID
+        self.rating = rating
+        self.allowFollowUp = allowFollowUp
+        self.context = context
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case category
+        case title
+        case body
+        case simulationID = "simulation_id"
+        case conversationID = "conversation_id"
+        case rating
+        case allowFollowUp = "allow_follow_up"
+        case context
+    }
+}
+
+public struct FeedbackResponse: Codable, Identifiable, Equatable, Sendable {
+    public let id: Int
+    public let category: FeedbackCategory
+    public let title: String?
+    public let body: String
+    public let simulationID: Int?
+    public let conversationID: Int?
+    public let rating: Int?
+    public let allowFollowUp: Bool?
+    public let context: [String: JSONValue]?
+    public let createdAt: Date?
+
+    public init(
+        id: Int,
+        category: FeedbackCategory,
+        title: String?,
+        body: String,
+        simulationID: Int?,
+        conversationID: Int?,
+        rating: Int?,
+        allowFollowUp: Bool?,
+        context: [String: JSONValue]?,
+        createdAt: Date?,
+    ) {
+        self.id = id
+        self.category = category
+        self.title = title
+        self.body = body
+        self.simulationID = simulationID
+        self.conversationID = conversationID
+        self.rating = rating
+        self.allowFollowUp = allowFollowUp
+        self.context = context
+        self.createdAt = createdAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case category
+        case title
+        case body
+        case simulationID = "simulation_id"
+        case conversationID = "conversation_id"
+        case rating
+        case allowFollowUp = "allow_follow_up"
+        case context
+        case createdAt = "created_at"
+    }
+}

--- a/apps/trainerlab-ios/Sources/Networking/FeedbackService.swift
+++ b/apps/trainerlab-ios/Sources/Networking/FeedbackService.swift
@@ -1,0 +1,123 @@
+import Foundation
+#if canImport(UIKit)
+    import UIKit
+#endif
+
+public protocol FeedbackRequestHeaderProviding: Sendable {
+    var appVersionHeaderValue: String { get }
+    var sessionIDHeaderValue: String { get }
+    func requestHeaders() -> [String: String]
+}
+
+public struct FeedbackRequestHeaderProvider: FeedbackRequestHeaderProviding, Equatable, Sendable {
+    public let appVersionHeaderValue: String
+    public let sessionIDHeaderValue: String
+    public let osVersionHeaderValue: String
+    public let deviceModelHeaderValue: String
+
+    public init(
+        sessionID: String,
+        appVersion: String? = nil,
+        osVersion: String? = nil,
+        deviceModel: String? = nil,
+    ) {
+        appVersionHeaderValue = appVersion ?? Self.resolveAppVersion(bundle: .main)
+        sessionIDHeaderValue = sessionID
+        osVersionHeaderValue = osVersion ?? Self.resolveOSVersion()
+        deviceModelHeaderValue = deviceModel ?? Self.resolveDeviceModel()
+    }
+
+    public func requestHeaders() -> [String: String] {
+        [
+            "X-Platform": "ios",
+            "X-App-Version": appVersionHeaderValue,
+            "X-OS-Version": osVersionHeaderValue,
+            "X-Device-Model": deviceModelHeaderValue,
+            "X-Session-ID": sessionIDHeaderValue,
+        ]
+    }
+
+    public static func resolveAppVersion(bundle: Bundle) -> String {
+        let version = normalized(bundle.infoDictionary?["CFBundleShortVersionString"] as? String)
+        let build = normalized(bundle.infoDictionary?["CFBundleVersion"] as? String)
+
+        switch (version, build) {
+        case let (version?, build?) where version != build:
+            return "\(version) (\(build))"
+        case let (version?, _):
+            return version
+        case let (_, build?):
+            return build
+        default:
+            return "unknown"
+        }
+    }
+
+    public static func resolveOSVersion() -> String {
+        #if canImport(UIKit)
+            return UIDevice.current.systemVersion
+        #else
+            return ProcessInfo.processInfo.operatingSystemVersionString
+        #endif
+    }
+
+    public static func resolveDeviceModel() -> String {
+        #if canImport(UIKit)
+            let identifier = deviceIdentifier()
+            return identifier.isEmpty ? UIDevice.current.model : identifier
+        #else
+            return ProcessInfo.processInfo.hostName
+        #endif
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    #if canImport(UIKit)
+        private static func deviceIdentifier() -> String {
+            var systemInfo = utsname()
+            uname(&systemInfo)
+            return withUnsafePointer(to: &systemInfo.machine) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: 1) { machinePointer in
+                    String(cString: machinePointer)
+                }
+            }
+        }
+    #endif
+}
+
+public protocol FeedbackServiceProtocol: Sendable {
+    func fetchFeedbackCategories() async throws -> [FeedbackCategoryDTO]
+    func submitFeedback(_ request: FeedbackCreateRequest) async throws -> FeedbackResponse
+}
+
+public struct FeedbackService: FeedbackServiceProtocol, Sendable {
+    private let apiClient: APIClientProtocol
+    private let headerProvider: FeedbackRequestHeaderProviding
+    private let encoder: JSONEncoder
+
+    public init(
+        apiClient: APIClientProtocol,
+        headerProvider: FeedbackRequestHeaderProviding,
+    ) {
+        self.apiClient = apiClient
+        self.headerProvider = headerProvider
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        self.encoder = encoder
+    }
+
+    public func fetchFeedbackCategories() async throws -> [FeedbackCategoryDTO] {
+        try await apiClient.request(FeedbackAPI.categories(), as: [FeedbackCategoryDTO].self)
+    }
+
+    public func submitFeedback(_ request: FeedbackCreateRequest) async throws -> FeedbackResponse {
+        let body = try encoder.encode(request)
+        return try await apiClient.request(
+            FeedbackAPI.create(body: body, headers: headerProvider.requestHeaders()),
+            as: FeedbackResponse.self,
+        )
+    }
+}

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -92,6 +92,7 @@ enum RunConsoleQuickAction: String, CaseIterable, Hashable, Identifiable {
     case intervention
     case event
     case annotation
+    case sendFeedback
     case steer
     case tickAI
     case tickVitals
@@ -108,6 +109,8 @@ enum RunConsoleQuickAction: String, CaseIterable, Hashable, Identifiable {
             "Event"
         case .annotation:
             "Annotation"
+        case .sendFeedback:
+            "Send Feedback"
         case .steer:
             "Steer"
         case .tickAI:
@@ -123,6 +126,8 @@ enum RunConsoleQuickAction: String, CaseIterable, Hashable, Identifiable {
             "plus.app"
         case .annotation:
             "note.text.badge.plus"
+        case .sendFeedback:
+            "bubble.left.and.text.bubble.right"
         case .steer:
             "wand.and.sparkles"
         case .tickAI:

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -1,10 +1,14 @@
 import DesignSystem
+import FeedbackFeature
+import Networking
 import Sessions
 import SharedModels
 import SwiftUI
 
 public struct RunConsoleView: View {
     @ObservedObject private var store: RunSessionStore
+    private let feedbackService: FeedbackServiceProtocol
+    private let feedbackHeaderProvider: FeedbackRequestHeaderProviding
     private let onBack: () -> Void
     private let onOpenSummary: () -> Void
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -14,6 +18,8 @@ public struct RunConsoleView: View {
     @State private var showEventSheet = false
     @State private var showSteerSheet = false
     @State private var showAnnotationSheet = false
+    @State private var activeFeedbackContext: FeedbackLaunchContext?
+    @State private var feedbackSuccessMessage: String?
 
     @State private var quickActionInjury: InjuryAnnotation?
 
@@ -62,10 +68,14 @@ public struct RunConsoleView: View {
 
     public init(
         store: RunSessionStore,
+        feedbackService: FeedbackServiceProtocol,
+        feedbackHeaderProvider: FeedbackRequestHeaderProviding,
         onBack: @escaping () -> Void,
         onOpenSummary: @escaping () -> Void,
     ) {
         self.store = store
+        self.feedbackService = feedbackService
+        self.feedbackHeaderProvider = feedbackHeaderProvider
         self.onBack = onBack
         self.onOpenSummary = onOpenSummary
     }
@@ -152,6 +162,32 @@ public struct RunConsoleView: View {
         .onChange(of: store.state.terminalCard) { _, newValue in
             if newValue != nil {
                 terminalCardDismissed = false
+            }
+        }
+        .sheet(item: $activeFeedbackContext) { context in
+            FeedbackFormView(
+                viewModel: FeedbackViewModel(
+                    service: feedbackService,
+                    headerProvider: feedbackHeaderProvider,
+                    launchContext: context,
+                ),
+                onSubmitted: {
+                    feedbackSuccessMessage = "Feedback sent."
+                },
+            )
+        }
+        .overlay(alignment: .top) {
+            if let feedbackSuccessMessage {
+                FeedbackSuccessBanner(message: feedbackSuccessMessage)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+            }
+        }
+        .task(id: feedbackSuccessMessage) {
+            guard feedbackSuccessMessage != nil else { return }
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if !Task.isCancelled {
+                feedbackSuccessMessage = nil
             }
         }
     }
@@ -2215,6 +2251,8 @@ public struct RunConsoleView: View {
                 showEventSheet = true
             case .annotation:
                 showAnnotationSheet = true
+            case .sendFeedback:
+                activeFeedbackContext = feedbackLaunchContext()
             case .steer:
                 showSteerSheet = true
             case .tickAI:
@@ -2416,6 +2454,17 @@ public struct RunConsoleView: View {
     private func isPendingInterventionControl(_ control: RunConsoleControlItem) -> Bool {
         guard case .quick(.intervention) = control else { return false }
         return store.hasPendingInterventions
+    }
+
+    private func feedbackLaunchContext() -> FeedbackLaunchContext {
+        FeedbackLaunchContext(
+            scope: .simulation,
+            sourceScreen: "trainer_run_console",
+            simulationID: store.state.session?.simulationID,
+            labType: .trainerlab,
+            simulationDisplayName: store.state.session.map { "Simulation #\($0.simulationID)" },
+            simulationStatus: store.state.session?.status.rawValue,
+        )
     }
 }
 

--- a/apps/trainerlab-ios/Sources/Summary/RunSummaryView.swift
+++ b/apps/trainerlab-ios/Sources/Summary/RunSummaryView.swift
@@ -1,16 +1,28 @@
 import DesignSystem
+import FeedbackFeature
+import Networking
 import SharedModels
 import SwiftUI
 
 public struct RunSummaryView: View {
     @ObservedObject private var viewModel: RunSummaryViewModel
+    private let feedbackService: FeedbackServiceProtocol?
+    private let feedbackHeaderProvider: FeedbackRequestHeaderProviding?
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var expandedSections = Set<RunSummarySection>()
     @State private var lastLayoutMode: RunSummaryLayoutMode?
+    @State private var activeFeedbackContext: FeedbackLaunchContext?
+    @State private var feedbackSuccessMessage: String?
 
-    public init(viewModel: RunSummaryViewModel) {
+    public init(
+        viewModel: RunSummaryViewModel,
+        feedbackService: FeedbackServiceProtocol? = nil,
+        feedbackHeaderProvider: FeedbackRequestHeaderProviding? = nil,
+    ) {
         self.viewModel = viewModel
+        self.feedbackService = feedbackService
+        self.feedbackHeaderProvider = feedbackHeaderProvider
     }
 
     public var body: some View {
@@ -22,8 +34,19 @@ public struct RunSummaryView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: layoutMode == .pad ? 18 : 14) {
-                    Text("Run Summary")
-                        .font(layoutMode == .pad ? .largeTitle.bold() : .title.bold())
+                    HStack(alignment: .top, spacing: 12) {
+                        Text("Run Summary")
+                            .font(layoutMode == .pad ? .largeTitle.bold() : .title.bold())
+
+                        Spacer(minLength: 12)
+
+                        if feedbackService != nil, feedbackHeaderProvider != nil {
+                            Button("Send Feedback") {
+                                activeFeedbackContext = feedbackLaunchContext()
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
 
                     if viewModel.isLoading {
                         ProgressView()
@@ -77,6 +100,45 @@ public struct RunSummaryView: View {
         .task {
             await viewModel.load()
         }
+        .sheet(item: $activeFeedbackContext) { context in
+            if let feedbackService, let feedbackHeaderProvider {
+                FeedbackFormView(
+                    viewModel: FeedbackViewModel(
+                        service: feedbackService,
+                        headerProvider: feedbackHeaderProvider,
+                        launchContext: context,
+                    ),
+                    onSubmitted: {
+                        feedbackSuccessMessage = "Feedback sent."
+                    },
+                )
+            }
+        }
+        .overlay(alignment: .top) {
+            if let feedbackSuccessMessage {
+                FeedbackSuccessBanner(message: feedbackSuccessMessage)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+            }
+        }
+        .task(id: feedbackSuccessMessage) {
+            guard feedbackSuccessMessage != nil else { return }
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if !Task.isCancelled {
+                feedbackSuccessMessage = nil
+            }
+        }
+    }
+
+    private func feedbackLaunchContext() -> FeedbackLaunchContext {
+        FeedbackLaunchContext(
+            scope: .simulation,
+            sourceScreen: "trainer_run_summary",
+            simulationID: viewModel.simulationID,
+            labType: .trainerlab,
+            simulationDisplayName: "Simulation #\(viewModel.simulationID)",
+            simulationStatus: viewModel.summary?.status,
+        )
     }
 
     private func summaryMetrics(_ summary: RunSummary, layoutMode: RunSummaryLayoutMode) -> some View {

--- a/apps/trainerlab-ios/Sources/Summary/RunSummaryViewModel.swift
+++ b/apps/trainerlab-ios/Sources/Summary/RunSummaryViewModel.swift
@@ -12,7 +12,7 @@ public final class RunSummaryViewModel: ObservableObject {
     @Published public private(set) var notReadyMessage: String?
 
     private let service: TrainerLabServiceProtocol
-    private let simulationID: Int
+    public let simulationID: Int
 
     public init(service: TrainerLabServiceProtocol, simulationID: Int) {
         self.service = service

--- a/apps/trainerlab-ios/Tests/FeedbackFeatureTests/FeedbackViewModelTests.swift
+++ b/apps/trainerlab-ios/Tests/FeedbackFeatureTests/FeedbackViewModelTests.swift
@@ -1,0 +1,182 @@
+import FeedbackFeature
+import Networking
+import SharedModels
+@testable import FeedbackFeature
+import XCTest
+
+private enum MockFeedbackError: Error {
+    case unused
+}
+
+private struct MockFeedbackHeaderProvider: FeedbackRequestHeaderProviding {
+    var appVersionHeaderValue: String = "1.2.3 (45)"
+    var sessionIDHeaderValue: String = "session-123"
+
+    func requestHeaders() -> [String: String] {
+        [
+            "X-Platform": "ios",
+            "X-App-Version": appVersionHeaderValue,
+            "X-OS-Version": "18.0",
+            "X-Device-Model": "iPhone17,1",
+            "X-Session-ID": sessionIDHeaderValue,
+        ]
+    }
+}
+
+@MainActor
+private final class MockFeedbackService: FeedbackServiceProtocol, @unchecked Sendable {
+    var categoriesResult: Result<[FeedbackCategoryDTO], Error> = .failure(MockFeedbackError.unused)
+    var submitResult: Result<FeedbackResponse, Error> = .failure(MockFeedbackError.unused)
+    var submittedRequests: [FeedbackCreateRequest] = []
+
+    func fetchFeedbackCategories() async throws -> [FeedbackCategoryDTO] {
+        try categoriesResult.get()
+    }
+
+    func submitFeedback(_ request: FeedbackCreateRequest) async throws -> FeedbackResponse {
+        submittedRequests.append(request)
+        return try submitResult.get()
+    }
+}
+
+@MainActor
+final class FeedbackViewModelTests: XCTestCase {
+    func testSubmitIsBlockedWhenTrimmedBodyIsEmpty() async {
+        let service = MockFeedbackService()
+        let viewModel = FeedbackViewModel(
+            service: service,
+            headerProvider: MockFeedbackHeaderProvider(),
+            launchContext: FeedbackLaunchContext(scope: .general, sourceScreen: "main_menu"),
+        )
+        viewModel.body = "   \n"
+
+        let didSubmit = await viewModel.submit()
+
+        XCTAssertFalse(didSubmit)
+        XCTAssertEqual(viewModel.bodyValidationMessage, "Please enter a description.")
+        XCTAssertTrue(service.submittedRequests.isEmpty)
+    }
+
+    func testSubmitIncludesInheritedSimulationAndConversationIDsAndTrimsContent() async {
+        let service = MockFeedbackService()
+        service.submitResult = .success(
+            FeedbackResponse(
+                id: 1,
+                category: .simulationContent,
+                title: "Great",
+                body: "Trimmed body",
+                simulationID: 77,
+                conversationID: 15,
+                rating: 5,
+                allowFollowUp: true,
+                context: nil,
+                createdAt: nil,
+            )
+        )
+        let viewModel = FeedbackViewModel(
+            service: service,
+            headerProvider: MockFeedbackHeaderProvider(),
+            launchContext: FeedbackLaunchContext(
+                scope: .simulation,
+                sourceScreen: "chat_run",
+                simulationID: 77,
+                conversationID: 15,
+                labType: .chatlab,
+                simulationDisplayName: "Jordan Alvarez",
+                simulationStatus: "in_progress",
+                conversationKind: "patient",
+            ),
+        )
+        viewModel.title = "  Great  "
+        viewModel.body = "  Trimmed body  "
+        viewModel.rating = 5
+        viewModel.allowFollowUp = true
+
+        let didSubmit = await viewModel.submit()
+
+        XCTAssertTrue(didSubmit)
+        XCTAssertEqual(service.submittedRequests.count, 1)
+        XCTAssertEqual(service.submittedRequests[0].simulationID, 77)
+        XCTAssertEqual(service.submittedRequests[0].conversationID, 15)
+        XCTAssertEqual(service.submittedRequests[0].title, "Great")
+        XCTAssertEqual(service.submittedRequests[0].body, "Trimmed body")
+        XCTAssertEqual(service.submittedRequests[0].context?["source_screen"], .string("chat_run"))
+        XCTAssertEqual(service.submittedRequests[0].context?["submission_scope"], .string("simulation"))
+        XCTAssertEqual(service.submittedRequests[0].context?["lab_type"], .string("chatlab"))
+    }
+
+    func testFailedSubmitPreservesFormContents() async {
+        let service = MockFeedbackService()
+        service.submitResult = .failure(APIClientError.http(statusCode: 500, detail: "Boom", correlationID: nil))
+        let viewModel = FeedbackViewModel(
+            service: service,
+            headerProvider: MockFeedbackHeaderProvider(),
+            launchContext: FeedbackLaunchContext(scope: .general, sourceScreen: "main_menu"),
+        )
+        viewModel.selectedCategory = .featureRequest
+        viewModel.title = "Keep title"
+        viewModel.body = "Keep body"
+        viewModel.rating = 3
+        viewModel.allowFollowUp = true
+
+        let didSubmit = await viewModel.submit()
+
+        XCTAssertFalse(didSubmit)
+        XCTAssertEqual(viewModel.selectedCategory, .featureRequest)
+        XCTAssertEqual(viewModel.title, "Keep title")
+        XCTAssertEqual(viewModel.body, "Keep body")
+        XCTAssertEqual(viewModel.rating, 3)
+        XCTAssertTrue(viewModel.allowFollowUp)
+        XCTAssertNotNil(viewModel.presentableError)
+    }
+
+    func testCategoriesFallbackToLocalEnumWhenFetchFails() async {
+        let service = MockFeedbackService()
+        service.categoriesResult = .failure(APIClientError.http(statusCode: 503, detail: "Nope", correlationID: nil))
+        let viewModel = FeedbackViewModel(
+            service: service,
+            headerProvider: MockFeedbackHeaderProvider(),
+            launchContext: FeedbackLaunchContext(scope: .general, sourceScreen: "main_menu"),
+        )
+
+        await viewModel.loadCategoriesIfNeeded()
+
+        XCTAssertEqual(viewModel.categories, FeedbackCategory.allCases)
+    }
+
+    func testSuccessfulSubmitClearsDraftAndMarksSuccess() async {
+        let service = MockFeedbackService()
+        service.submitResult = .success(
+            FeedbackResponse(
+                id: 2,
+                category: .other,
+                title: nil,
+                body: "Thanks",
+                simulationID: nil,
+                conversationID: nil,
+                rating: nil,
+                allowFollowUp: false,
+                context: nil,
+                createdAt: nil,
+            )
+        )
+        let viewModel = FeedbackViewModel(
+            service: service,
+            headerProvider: MockFeedbackHeaderProvider(),
+            launchContext: FeedbackLaunchContext(scope: .general, sourceScreen: "main_menu"),
+        )
+        viewModel.title = "Title"
+        viewModel.body = "Body"
+        viewModel.rating = 2
+        viewModel.allowFollowUp = true
+
+        let didSubmit = await viewModel.submit()
+
+        XCTAssertTrue(didSubmit)
+        XCTAssertTrue(viewModel.didSubmitSuccessfully)
+        XCTAssertEqual(viewModel.title, "")
+        XCTAssertEqual(viewModel.body, "")
+        XCTAssertNil(viewModel.rating)
+        XCTAssertFalse(viewModel.allowFollowUp)
+    }
+}

--- a/apps/trainerlab-ios/Tests/FeedbackFeatureTests/FeedbackViewModelTests.swift
+++ b/apps/trainerlab-ios/Tests/FeedbackFeatureTests/FeedbackViewModelTests.swift
@@ -1,7 +1,6 @@
-import FeedbackFeature
+@testable import FeedbackFeature
 import Networking
 import SharedModels
-@testable import FeedbackFeature
 import XCTest
 
 private enum MockFeedbackError: Error {
@@ -71,7 +70,7 @@ final class FeedbackViewModelTests: XCTestCase {
                 allowFollowUp: true,
                 context: nil,
                 createdAt: nil,
-            )
+            ),
         )
         let viewModel = FeedbackViewModel(
             service: service,
@@ -158,7 +157,7 @@ final class FeedbackViewModelTests: XCTestCase {
                 allowFollowUp: false,
                 context: nil,
                 createdAt: nil,
-            )
+            ),
         )
         let viewModel = FeedbackViewModel(
             service: service,

--- a/apps/trainerlab-ios/Tests/NetworkingTests/FeedbackNetworkingTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/FeedbackNetworkingTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+import Networking
+import Persistence
+import SharedModels
+import XCTest
+
+private final class FeedbackMockTokenProvider: AuthTokenProvider, @unchecked Sendable {
+    private var stored: AuthTokens?
+
+    init(tokens: AuthTokens?) {
+        stored = tokens
+    }
+
+    func loadTokens() -> AuthTokens? {
+        stored
+    }
+
+    func saveTokens(_ tokens: AuthTokens) {
+        stored = tokens
+    }
+
+    func clearTokens() {
+        stored = nil
+    }
+}
+
+private final class FeedbackURLProtocolMock: URLProtocol {
+    nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            XCTFail("Missing request handler")
+            return
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+final class FeedbackNetworkingTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        FeedbackURLProtocolMock.requestHandler = nil
+    }
+
+    func testFeedbackCategoryRoundTripsCodable() throws {
+        for category in FeedbackCategory.allCases {
+            let data = try JSONEncoder().encode(category)
+            let decoded = try JSONDecoder().decode(FeedbackCategory.self, from: data)
+            XCTAssertEqual(decoded, category)
+        }
+    }
+
+    func testFeedbackCreateRequestEncodesExpectedKeysAndOmitsNilOptionals() throws {
+        let request = FeedbackCreateRequest(
+            category: .featureRequest,
+            title: "Wish list",
+            body: "Please add this.",
+            simulationID: 42,
+            conversationID: 7,
+            rating: 5,
+            allowFollowUp: true,
+            context: [
+                "source_screen": .string("settings"),
+                "submission_scope": .string("general"),
+            ],
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertEqual(object["category"] as? String, "feature_request")
+        XCTAssertEqual(object["title"] as? String, "Wish list")
+        XCTAssertEqual(object["body"] as? String, "Please add this.")
+        XCTAssertEqual(object["simulation_id"] as? Int, 42)
+        XCTAssertEqual(object["conversation_id"] as? Int, 7)
+        XCTAssertEqual(object["rating"] as? Int, 5)
+        XCTAssertEqual(object["allow_follow_up"] as? Bool, true)
+        XCTAssertNotNil(object["context"])
+
+        let sparse = FeedbackCreateRequest(category: .other, body: "Plain")
+        let sparseData = try JSONEncoder().encode(sparse)
+        let sparseObject = try XCTUnwrap(JSONSerialization.jsonObject(with: sparseData) as? [String: Any])
+        XCTAssertNil(sparseObject["title"])
+        XCTAssertNil(sparseObject["simulation_id"])
+        XCTAssertNil(sparseObject["conversation_id"])
+        XCTAssertNil(sparseObject["rating"])
+        XCTAssertNil(sparseObject["allow_follow_up"])
+        XCTAssertNil(sparseObject["context"])
+    }
+
+    func testFeedbackAPIUsesExpectedPathsAndFlags() {
+        let categories = FeedbackAPI.categories()
+        XCTAssertEqual(categories.path, "/api/v1/feedback/categories/")
+        XCTAssertFalse(categories.requiresAuth)
+        XCTAssertFalse(categories.requiresAccountContext)
+
+        let create = FeedbackAPI.create(body: Data("{}".utf8), headers: ["X-Platform": "ios"])
+        XCTAssertEqual(create.path, "/api/v1/feedback/")
+        XCTAssertEqual(create.method, .post)
+        XCTAssertTrue(create.requiresAuth)
+        XCTAssertTrue(create.requiresAccountContext)
+        XCTAssertEqual(create.headers["X-Platform"], "ios")
+    }
+
+    func testFeedbackRequestHeaderProviderIncludesRequiredHeaders() {
+        let provider = FeedbackRequestHeaderProvider(
+            sessionID: "session-123",
+            appVersion: "1.2.3 (45)",
+            osVersion: "18.0",
+            deviceModel: "iPhone17,1",
+        )
+
+        let headers = provider.requestHeaders()
+
+        XCTAssertEqual(headers["X-Platform"], "ios")
+        XCTAssertEqual(headers["X-App-Version"], "1.2.3 (45)")
+        XCTAssertEqual(headers["X-OS-Version"], "18.0")
+        XCTAssertEqual(headers["X-Device-Model"], "iPhone17,1")
+        XCTAssertEqual(headers["X-Session-ID"], "session-123")
+    }
+
+    func testFeedbackServiceFetchCategoriesHitsExpectedEndpoint() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FeedbackURLProtocolMock.self]
+        let session = URLSession(configuration: configuration)
+
+        FeedbackURLProtocolMock.requestHandler = { request in
+            XCTAssertEqual(self.normalizedPath(request.url?.path), "/api/v1/feedback/categories")
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+            let body = Data(#"[{"value":"bug_report","label":"Bug Report"}]"#.utf8)
+            return (
+                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                body
+            )
+        }
+
+        let client = APIClient(
+            baseURLProvider: { URL(string: "https://example.com")! },
+            tokenProvider: FeedbackMockTokenProvider(tokens: nil),
+            session: session,
+        )
+        let service = FeedbackService(
+            apiClient: client,
+            headerProvider: FeedbackRequestHeaderProvider(
+                sessionID: "session-1",
+                appVersion: "1.0",
+                osVersion: "18.0",
+                deviceModel: "iPhone",
+            ),
+        )
+
+        let categories = try await service.fetchFeedbackCategories()
+        XCTAssertEqual(categories, [FeedbackCategoryDTO(value: .bugReport, label: "Bug Report")])
+    }
+
+    func testFeedbackServiceSubmitHitsEndpointWithMetadataHeaders() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FeedbackURLProtocolMock.self]
+        let session = URLSession(configuration: configuration)
+
+        FeedbackURLProtocolMock.requestHandler = { request in
+            XCTAssertEqual(self.normalizedPath(request.url?.path), "/api/v1/feedback")
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Platform"), "ios")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-App-Version"), "1.2.3 (45)")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-OS-Version"), "18.0")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Device-Model"), "iPhone17,1")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-Session-ID"), "session-123")
+
+            let bodyData = try XCTUnwrap(self.requestBody(from: request))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            XCTAssertEqual(object["simulation_id"] as? Int, 9)
+            XCTAssertEqual(object["conversation_id"] as? Int, 3)
+            XCTAssertEqual(object["body"] as? String, "Helpful feedback")
+
+            let responseData = Data(
+                #"{"id":11,"category":"simulation_content","title":"Realism","body":"Helpful feedback","simulation_id":9,"conversation_id":3,"rating":4,"allow_follow_up":true,"created_at":"2026-04-19T12:00:00Z"}"#.utf8
+            )
+            return (
+                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                responseData
+            )
+        }
+
+        let client = APIClient(
+            baseURLProvider: { URL(string: "https://example.com")! },
+            tokenProvider: FeedbackMockTokenProvider(
+                tokens: AuthTokens(accessToken: "token-1", refreshToken: "refresh-1", expiresIn: 3600, tokenType: "Bearer")
+            ),
+            session: session,
+        )
+        let service = FeedbackService(
+            apiClient: client,
+            headerProvider: FeedbackRequestHeaderProvider(
+                sessionID: "session-123",
+                appVersion: "1.2.3 (45)",
+                osVersion: "18.0",
+                deviceModel: "iPhone17,1",
+            ),
+        )
+
+        let response = try await service.submitFeedback(
+            FeedbackCreateRequest(
+                category: .simulationContent,
+                title: "Realism",
+                body: "Helpful feedback",
+                simulationID: 9,
+                conversationID: 3,
+                rating: 4,
+                allowFollowUp: true,
+            )
+        )
+
+        XCTAssertEqual(response.id, 11)
+        XCTAssertEqual(response.category, FeedbackCategory.simulationContent)
+        XCTAssertEqual(response.simulationID, 9)
+        XCTAssertEqual(response.conversationID, 3)
+    }
+
+    private func normalizedPath(_ path: String?) -> String? {
+        guard let path else { return nil }
+        guard path.count > 1 else { return path }
+        return path.hasSuffix("/") ? String(path.dropLast()) : path
+    }
+
+    private func requestBody(from request: URLRequest) -> Data? {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return nil
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        var data = Data()
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read < 0 {
+                return nil
+            }
+            if read == 0 {
+                break
+            }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/apps/trainerlab-ios/Tests/NetworkingTests/FeedbackNetworkingTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/FeedbackNetworkingTests.swift
@@ -155,9 +155,9 @@ final class FeedbackNetworkingTests: XCTestCase {
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
             let body = Data(#"[{"value":"bug_report","label":"Bug Report"}]"#.utf8)
-            return (
-                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!,
-                body
+            return try (
+                HTTPURLResponse(url: XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                body,
             )
         }
 
@@ -203,18 +203,18 @@ final class FeedbackNetworkingTests: XCTestCase {
             XCTAssertEqual(object["body"] as? String, "Helpful feedback")
 
             let responseData = Data(
-                #"{"id":11,"category":"simulation_content","title":"Realism","body":"Helpful feedback","simulation_id":9,"conversation_id":3,"rating":4,"allow_follow_up":true,"created_at":"2026-04-19T12:00:00Z"}"#.utf8
+                #"{"id":11,"category":"simulation_content","title":"Realism","body":"Helpful feedback","simulation_id":9,"conversation_id":3,"rating":4,"allow_follow_up":true,"created_at":"2026-04-19T12:00:00Z"}"#.utf8,
             )
-            return (
-                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!,
-                responseData
+            return try (
+                HTTPURLResponse(url: XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!,
+                responseData,
             )
         }
 
         let client = APIClient(
             baseURLProvider: { URL(string: "https://example.com")! },
             tokenProvider: FeedbackMockTokenProvider(
-                tokens: AuthTokens(accessToken: "token-1", refreshToken: "refresh-1", expiresIn: 3600, tokenType: "Bearer")
+                tokens: AuthTokens(accessToken: "token-1", refreshToken: "refresh-1", expiresIn: 3600, tokenType: "Bearer"),
             ),
             accountContextProvider: FeedbackStaticAccountContextProvider(accountUUID: "acct-123"),
             session: session,
@@ -238,7 +238,7 @@ final class FeedbackNetworkingTests: XCTestCase {
                 conversationID: 3,
                 rating: 4,
                 allowFollowUp: true,
-            )
+            ),
         )
 
         XCTAssertEqual(response.id, 11)

--- a/apps/trainerlab-ios/Tests/NetworkingTests/FeedbackNetworkingTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/FeedbackNetworkingTests.swift
@@ -24,6 +24,14 @@ private final class FeedbackMockTokenProvider: AuthTokenProvider, @unchecked Sen
     }
 }
 
+private struct FeedbackStaticAccountContextProvider: AccountContextProvider {
+    let accountUUID: String?
+
+    func selectedAccountUUID() async -> String? {
+        accountUUID
+    }
+}
+
 private final class FeedbackURLProtocolMock: URLProtocol {
     nonisolated(unsafe) static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
@@ -116,7 +124,7 @@ final class FeedbackNetworkingTests: XCTestCase {
         XCTAssertEqual(create.path, "/api/v1/feedback/")
         XCTAssertEqual(create.method, .post)
         XCTAssertTrue(create.requiresAuth)
-        XCTAssertTrue(create.requiresAccountContext)
+        XCTAssertFalse(create.requiresAccountContext)
         XCTAssertEqual(create.headers["X-Platform"], "ios")
     }
 
@@ -181,6 +189,7 @@ final class FeedbackNetworkingTests: XCTestCase {
             XCTAssertEqual(self.normalizedPath(request.url?.path), "/api/v1/feedback")
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-1")
+            XCTAssertNil(request.value(forHTTPHeaderField: "X-Account-UUID"))
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-Platform"), "ios")
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-App-Version"), "1.2.3 (45)")
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-OS-Version"), "18.0")
@@ -197,7 +206,7 @@ final class FeedbackNetworkingTests: XCTestCase {
                 #"{"id":11,"category":"simulation_content","title":"Realism","body":"Helpful feedback","simulation_id":9,"conversation_id":3,"rating":4,"allow_follow_up":true,"created_at":"2026-04-19T12:00:00Z"}"#.utf8
             )
             return (
-                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 200, httpVersion: nil, headerFields: nil)!,
+                HTTPURLResponse(url: try XCTUnwrap(request.url), statusCode: 201, httpVersion: nil, headerFields: nil)!,
                 responseData
             )
         }
@@ -207,6 +216,7 @@ final class FeedbackNetworkingTests: XCTestCase {
             tokenProvider: FeedbackMockTokenProvider(
                 tokens: AuthTokens(accessToken: "token-1", refreshToken: "refresh-1", expiresIn: 3600, tokenType: "Bearer")
             ),
+            accountContextProvider: FeedbackStaticAccountContextProvider(accountUUID: "acct-123"),
             session: session,
         )
         let service = FeedbackService(

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -173,11 +173,11 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         XCTAssertEqual(sessionControls.map(\.group), [.session, .session, .session, .session])
         XCTAssertEqual(
             RunConsoleControlsCatalog.quickControls.map(\.title),
-            ["Intervention", "Event", "Annotation", "Steer", "Tick AI", "Tick Vitals"],
+            ["Intervention", "Event", "Annotation", "Send Feedback", "Steer", "Tick AI", "Tick Vitals"],
         )
         XCTAssertEqual(
             RunConsoleControlsCatalog.quickControls.map(\.systemImage),
-            ["plus.app", "plus.app", "note.text.badge.plus", "wand.and.sparkles", "timer", "heart.text.square"],
+            ["plus.app", "plus.app", "note.text.badge.plus", "bubble.left.and.text.bubble.right", "wand.and.sparkles", "timer", "heart.text.square"],
         )
     }
 


### PR DESCRIPTION
## Summary
- Add feedback DTOs, routes, service support, and launch metadata headers in `Networking`
- Introduce a shared `FeedbackFeature` sheet with category loading, validation, success state, and retry-friendly error handling
- Wire general feedback from AppShell and simulation-scoped feedback from ChatLab, TrainerLab console, and run summary
- Add focused networking and view-model tests for encoding, headers, submission, and fallback behavior

## Testing
- `swift build --package-path apps/trainerlab-ios`
- `swift build --package-path apps/chatlab-ios`
- `swift build --package-path apps/medsim-shell-ios`
- `swift test --package-path apps/trainerlab-ios --filter FeedbackNetworkingTests`