### PR TITLE
fix(trainerlab-ios): restore accordion/diagram rendering, recommendation acceptance, and target-problem collapse

### DIFF
--- a/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
@@ -319,8 +319,8 @@ struct InterventionMenuContext {
         }
     }
 
-    // Returns all candidate intervention-type tokens for a recommendation, deduped and
-    // order-preserved, with the dictionary-resolved type first.
+    /// Returns all candidate intervention-type tokens for a recommendation, deduped and
+    /// order-preserved, with the dictionary-resolved type first.
     static func recommendationCandidateTypes(
         for recommendation: RecommendedInterventionItem,
         dictionary: [InterventionGroup],
@@ -348,8 +348,8 @@ struct InterventionMenuContext {
         return result
     }
 
-    // Returns true only when an already-submitted intervention matches this specific
-    // recommendation by type AND target problem — not merely by target problem alone.
+    /// Returns true only when an already-submitted intervention matches this specific
+    /// recommendation by type AND target problem — not merely by target problem alone.
     static func isRecommendationAccepted(
         _ recommendation: RecommendedInterventionItem,
         dictionary: [InterventionGroup],

--- a/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
@@ -176,6 +176,7 @@ struct RecommendedInterventionAction: Identifiable, Equatable {
     let validationStatus: String?
     let siteSummary: String?
     let disabledReason: String?
+    let isAccepted: Bool
     let prefill: InterventionComposerPrefill
 
     var id: Int {
@@ -241,6 +242,12 @@ struct InterventionMenuContext {
             let disabledReason = accessInventory.disabledReason(for: group)
                 ?? (prefill.siteCode == nil && (availableSitesByType[group.interventionType] ?? group.sites).count > 1 ? "Choose site in edit" : nil)
 
+            let isAccepted = Self.isRecommendationAccepted(
+                recommendation,
+                interventionType: interventionType,
+                interventions: interventions,
+            )
+
             return RecommendedInterventionAction(
                 recommendationID: recommendation.recommendationID,
                 title: recommendation.title,
@@ -253,6 +260,7 @@ struct InterventionMenuContext {
                     dictionary: dictionary,
                 ),
                 disabledReason: disabledReason,
+                isAccepted: isAccepted,
                 prefill: prefill,
             )
         }
@@ -292,7 +300,7 @@ struct InterventionMenuContext {
         )
     }
 
-    private static func recommendedInterventionType(
+    static func recommendedInterventionType(
         for recommendation: RecommendedInterventionItem,
         dictionary: [InterventionGroup],
     ) -> String? {
@@ -308,6 +316,19 @@ struct InterventionMenuContext {
 
         return candidates.first { candidate in
             dictionary.contains(where: { $0.interventionType == candidate })
+        }
+    }
+
+    // Returns true only when an already-submitted intervention matches this specific
+    // recommendation by type AND target problem — not merely by target problem alone.
+    static func isRecommendationAccepted(
+        _ recommendation: RecommendedInterventionItem,
+        interventionType: String,
+        interventions: [InterventionAnnotation],
+    ) -> Bool {
+        interventions.contains { intervention in
+            intervention.interventionType == interventionType
+                && intervention.targetProblemID == recommendation.targetProblemID
         }
     }
 
@@ -493,35 +514,66 @@ struct InterventionComposerSheet: View {
 
     private var targetProblemSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Target Problem")
-                .font(.caption.bold())
-                .foregroundStyle(.secondary)
-
             Button {
-                draft.selectedTargetProblemID = nil
-                draft.activeSection = .type
+                draft.activeSection = draft.activeSection == .target ? .type : .target
             } label: {
-                selectionRow(
-                    title: "General intervention",
-                    subtitle: "Not tied to a single problem",
-                    selected: draft.selectedTargetProblemID == nil,
-                )
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Target Problem")
+                            .font(.caption.bold())
+                            .foregroundStyle(.secondary)
+                        if draft.activeSection != .target {
+                            if let id = draft.selectedTargetProblemID,
+                               let problem = problems.first(where: { $0.problemID == id })
+                            {
+                                Text(problem.label)
+                                    .font(.caption)
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(1)
+                            } else {
+                                Text("General intervention")
+                                    .font(.caption)
+                                    .foregroundStyle(.primary)
+                            }
+                        }
+                    }
+                    Spacer()
+                    Image(systemName: draft.activeSection == .target ? "chevron.up" : "chevron.down")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
-            ForEach(problems) { problem in
+            if draft.activeSection == .target {
                 Button {
-                    draft.selectedTargetProblemID = problem.problemID
+                    draft.selectedTargetProblemID = nil
                     draft.activeSection = .type
-                    refreshDefaultsForCurrentType()
                 } label: {
                     selectionRow(
-                        title: problem.label,
-                        subtitle: problem.status.rawValue.capitalized,
-                        selected: draft.selectedTargetProblemID == problem.problemID,
+                        title: "General intervention",
+                        subtitle: "Not tied to a single problem",
+                        selected: draft.selectedTargetProblemID == nil,
                     )
                 }
                 .buttonStyle(.plain)
+
+                ForEach(problems) { problem in
+                    Button {
+                        draft.selectedTargetProblemID = problem.problemID
+                        draft.activeSection = .type
+                        refreshDefaultsForCurrentType()
+                    } label: {
+                        selectionRow(
+                            title: problem.label,
+                            subtitle: problem.status.rawValue.capitalized,
+                            selected: draft.selectedTargetProblemID == problem.problemID,
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
         .padding(12)
@@ -541,9 +593,16 @@ struct InterventionComposerSheet: View {
                         action: { submit(action) },
                         label: {
                             VStack(alignment: .leading, spacing: 4) {
-                                Text(action.title)
-                                    .font(.subheadline.weight(.semibold))
-                                    .foregroundStyle(.primary)
+                                HStack(spacing: 6) {
+                                    Text(action.title)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(.primary)
+                                    if action.isAccepted {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .font(.caption.weight(.semibold))
+                                            .foregroundStyle(TrainerLabTheme.success)
+                                    }
+                                }
                                 if let subtitle = action.subtitle, !subtitle.isEmpty {
                                     Text(subtitle)
                                         .font(.caption)
@@ -558,15 +617,15 @@ struct InterventionComposerSheet: View {
                                     Text(disabledReason)
                                         .font(.caption2)
                                         .foregroundStyle(TrainerLabTheme.warning)
-                                } else if let validationStatus = action.validationStatus {
-                                    Text(SimulationEventRegistry.humanizedLabel(validationStatus))
+                                } else if action.isAccepted {
+                                    Text("Applied")
                                         .font(.caption2)
-                                        .foregroundStyle(.secondary)
+                                        .foregroundStyle(TrainerLabTheme.success)
                                 }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(10)
-                            .background(Color.white.opacity(0.04))
+                            .background(action.isAccepted ? TrainerLabTheme.success.opacity(0.07) : Color.white.opacity(0.04))
                             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                         },
                     )

--- a/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/InterventionComposer.swift
@@ -244,7 +244,7 @@ struct InterventionMenuContext {
 
             let isAccepted = Self.isRecommendationAccepted(
                 recommendation,
-                interventionType: interventionType,
+                dictionary: dictionary,
                 interventions: interventions,
             )
 
@@ -319,15 +319,45 @@ struct InterventionMenuContext {
         }
     }
 
+    // Returns all candidate intervention-type tokens for a recommendation, deduped and
+    // order-preserved, with the dictionary-resolved type first.
+    static func recommendationCandidateTypes(
+        for recommendation: RecommendedInterventionItem,
+        dictionary: [InterventionGroup],
+    ) -> [String] {
+        let rawCandidates = [
+            recommendation.normalizedKind,
+            recommendation.kind,
+            recommendation.normalizedCode,
+            recommendation.code,
+        ].compactMap { candidate -> String? in
+            guard let candidate, !candidate.isEmpty else { return nil }
+            return candidate
+        }
+        var seen = Set<String>()
+        var result: [String] = []
+        if let resolved = rawCandidates.first(where: { candidate in
+            dictionary.contains(where: { $0.interventionType == candidate })
+        }) {
+            result.append(resolved)
+            seen.insert(resolved)
+        }
+        for candidate in rawCandidates where seen.insert(candidate).inserted {
+            result.append(candidate)
+        }
+        return result
+    }
+
     // Returns true only when an already-submitted intervention matches this specific
     // recommendation by type AND target problem — not merely by target problem alone.
     static func isRecommendationAccepted(
         _ recommendation: RecommendedInterventionItem,
-        interventionType: String,
+        dictionary: [InterventionGroup],
         interventions: [InterventionAnnotation],
     ) -> Bool {
-        interventions.contains { intervention in
-            intervention.interventionType == interventionType
+        let candidates = recommendationCandidateTypes(for: recommendation, dictionary: dictionary)
+        return interventions.contains { intervention in
+            candidates.contains(intervention.interventionType)
                 && intervention.targetProblemID == recommendation.targetProblemID
         }
     }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -583,6 +583,7 @@ struct PatientDiagramPanel: View {
     let problems: [ProblemAnnotation]
     let recommendations: [RecommendedInterventionItem]
     let pulses: [PulseAnnotation]
+    let dictionary: [InterventionGroup]
     let pendingInterventionProblemIDs: Set<Int>
     let canMutate: Bool
     let layoutMode: RunConsoleLayoutMode
@@ -882,7 +883,7 @@ struct PatientDiagramPanel: View {
     }
 
     private func recommendationCard(_ recommendation: RecommendedInterventionItem) -> some View {
-        let accepted = isRecommendationAccepted(recommendation)
+        let accepted = InterventionMenuContext.isRecommendationAccepted(recommendation, dictionary: dictionary, interventions: interventions)
         return VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .top, spacing: 8) {
                 Text(recommendation.title)
@@ -923,20 +924,6 @@ struct PatientDiagramPanel: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(accepted ? TrainerLabTheme.success.opacity(0.07) : Color.white.opacity(0.05))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-    }
-
-    private func isRecommendationAccepted(_ recommendation: RecommendedInterventionItem) -> Bool {
-        let candidates = [
-            recommendation.normalizedKind,
-            recommendation.kind,
-            recommendation.normalizedCode,
-            recommendation.code,
-        ].compactMap { $0?.isEmpty == false ? $0 : nil }
-
-        return interventions.contains { intervention in
-            candidates.contains(intervention.interventionType)
-                && intervention.targetProblemID == recommendation.targetProblemID
-        }
     }
 
     // MARK: - Body Diagram

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -487,7 +487,7 @@ enum PatientDiagramSelection: Equatable {
     case pulse(PulseAnnotation)
 }
 
-private struct PatientPaneAccordionState: Equatable {
+struct PatientPaneAccordionState: Equatable {
     var pinnedDiagram = false
     var openSection: PatientPaneSection = .diagram
 
@@ -535,14 +535,27 @@ private struct PatientPaneAccordionState: Equatable {
         if pinnedDiagram {
             // The diagram header stays inert while pinned; only the pin button changes pin state.
             guard section != .diagram else { return }
-            if openSection != section {
+            if openSection == section {
+                // Tapping the active secondary section collapses it and unpins the diagram.
+                pinnedDiagram = false
+                openSection = .diagram
+            } else {
                 openSection = section
             }
             return
         }
 
-        if openSection != section {
+        if openSection == section {
+            // Tapping the already-open section collapses it. Diagram is the ground state.
+            if section != .diagram {
+                openSection = .diagram
+            }
+        } else {
             openSection = section
+            // Opening any secondary section auto-pins the diagram so both remain visible.
+            if section != .diagram {
+                pinnedDiagram = true
+            }
         }
     }
 
@@ -869,14 +882,19 @@ struct PatientDiagramPanel: View {
     }
 
     private func recommendationCard(_ recommendation: RecommendedInterventionItem) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
+        let accepted = isRecommendationAccepted(recommendation)
+        return VStack(alignment: .leading, spacing: 5) {
             HStack(alignment: .top, spacing: 8) {
                 Text(recommendation.title)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.primary)
                     .fixedSize(horizontal: false, vertical: true)
                 Spacer(minLength: 8)
-                if let targetProblem = linkedProblemLabel(for: recommendation) {
+                if accepted {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(TrainerLabTheme.success)
+                } else if let targetProblem = linkedProblemLabel(for: recommendation) {
                     Text(targetProblem)
                         .font(.caption2.bold())
                         .foregroundStyle(TrainerLabTheme.accentBlue)
@@ -891,7 +909,11 @@ struct PatientDiagramPanel: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            if let validationStatus = recommendation.validationStatus, !validationStatus.isEmpty {
+            if accepted {
+                Text("Applied")
+                    .font(.caption2.bold())
+                    .foregroundStyle(TrainerLabTheme.success)
+            } else if let validationStatus = recommendation.validationStatus, !validationStatus.isEmpty {
                 Text(validationStatus.replacingOccurrences(of: "_", with: " ").capitalized)
                     .font(.caption2.bold())
                     .foregroundStyle(TrainerLabTheme.warning)
@@ -899,8 +921,22 @@ struct PatientDiagramPanel: View {
         }
         .padding(layoutMode == .compact ? 8 : 10)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.white.opacity(0.05))
+        .background(accepted ? TrainerLabTheme.success.opacity(0.07) : Color.white.opacity(0.05))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    private func isRecommendationAccepted(_ recommendation: RecommendedInterventionItem) -> Bool {
+        let candidates = [
+            recommendation.normalizedKind,
+            recommendation.kind,
+            recommendation.normalizedCode,
+            recommendation.code,
+        ].compactMap { $0?.isEmpty == false ? $0 : nil }
+
+        return interventions.contains { intervention in
+            candidates.contains(intervention.interventionType)
+                && intervention.targetProblemID == recommendation.targetProblemID
+        }
     }
 
     // MARK: - Body Diagram

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -525,6 +525,7 @@ public struct RunConsoleView: View {
             problems: store.state.problemAnnotations,
             recommendations: store.state.recommendedInterventions,
             pulses: store.state.pulseAnnotations,
+            dictionary: store.interventionDictionary,
             pendingInterventionProblemIDs: store.pendingInterventionProblemIDs,
             canMutate: canMutate,
             layoutMode: layoutMode,

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -555,7 +555,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
 
         let accepted = InterventionMenuContext.isRecommendationAccepted(
             rec,
-            interventionType: "tourniquet",
+            dictionary: makeDictionary(["tourniquet"]),
             interventions: [],
         )
 
@@ -570,7 +570,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
 
         let accepted = InterventionMenuContext.isRecommendationAccepted(
             rec,
-            interventionType: "tourniquet",
+            dictionary: makeDictionary(["tourniquet"]),
             interventions: [intervention],
         )
 
@@ -586,7 +586,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
 
         let accepted = InterventionMenuContext.isRecommendationAccepted(
             rec,
-            interventionType: "tourniquet",
+            dictionary: makeDictionary(["tourniquet"]),
             interventions: [intervention],
         )
 
@@ -602,7 +602,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
 
         let accepted = InterventionMenuContext.isRecommendationAccepted(
             rec,
-            interventionType: "tourniquet",
+            dictionary: makeDictionary(["tourniquet"]),
             interventions: [intervention],
         )
 
@@ -621,12 +621,13 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         let interventions = [
             makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date()),
         ]
+        let dictionary = makeDictionary(["tourniquet", "pressure_dressing"])
 
         let tourniquetAccepted = InterventionMenuContext.isRecommendationAccepted(
-            recTourniquet, interventionType: "tourniquet", interventions: interventions,
+            recTourniquet, dictionary: dictionary, interventions: interventions,
         )
         let dressingAccepted = InterventionMenuContext.isRecommendationAccepted(
-            recDressing, interventionType: "pressure_dressing", interventions: interventions,
+            recDressing, dictionary: dictionary, interventions: interventions,
         )
 
         XCTAssertTrue(tourniquetAccepted, "Tourniquet recommendation must be accepted since a tourniquet was applied")
@@ -645,12 +646,13 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         let interventions = [
             makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date()),
         ]
+        let dictionary = makeDictionary(["tourniquet"])
 
         XCTAssertTrue(
-            InterventionMenuContext.isRecommendationAccepted(recProblem10, interventionType: "tourniquet", interventions: interventions),
+            InterventionMenuContext.isRecommendationAccepted(recProblem10, dictionary: dictionary, interventions: interventions),
         )
         XCTAssertFalse(
-            InterventionMenuContext.isRecommendationAccepted(recProblem20, interventionType: "tourniquet", interventions: interventions),
+            InterventionMenuContext.isRecommendationAccepted(recProblem20, dictionary: dictionary, interventions: interventions),
             "Recommendation for problem 20 must remain pending — intervention targeted problem 10",
         )
     }
@@ -666,11 +668,139 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         ]
 
         let accepted = InterventionMenuContext.isRecommendationAccepted(
-            rec, interventionType: "iv_access", interventions: interventions,
+            rec, dictionary: makeDictionary(["iv_access"]), interventions: interventions,
         )
 
         XCTAssertTrue(accepted, "IV access recommendation must be accepted since an iv_access intervention for the same problem exists")
     }
+
+    // MARK: - Recommendation Candidate Types (normalization)
+
+    func testRecommendationCandidateTypesDictionaryResolvedTypeComesFirst() {
+        // normalizedKind is not in the dictionary; kind is — kind must be the resolved type and come first.
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            kind: "tourniquet",
+            targetProblemID: 10,
+            normalizedKind: "tourniquet_v2",
+        )
+        let dictionary = makeDictionary(["tourniquet"])
+        let candidates = InterventionMenuContext.recommendationCandidateTypes(for: rec, dictionary: dictionary)
+        XCTAssertEqual(candidates.first, "tourniquet", "Dictionary-resolved type must be the first candidate")
+        XCTAssertTrue(candidates.contains("tourniquet_v2"), "Raw candidates must still be included after the resolved type")
+    }
+
+    func testRecommendationCandidateTypesDeduplicatesResolvedAndRaw() {
+        // normalizedKind matches the dictionary → resolved. kind is the same string → no duplicate.
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            kind: "tourniquet",
+            targetProblemID: 10,
+            normalizedKind: "tourniquet",
+        )
+        let dictionary = makeDictionary(["tourniquet"])
+        let candidates = InterventionMenuContext.recommendationCandidateTypes(for: rec, dictionary: dictionary)
+        XCTAssertEqual(candidates.filter { $0 == "tourniquet" }.count, 1, "Duplicate candidates must be collapsed to one entry")
+    }
+
+    func testRecommendationCandidateTypesEmptyWhenAllFieldsNil() {
+        let rec = RecommendedInterventionItem(recommendationID: 1, title: "Unknown")
+        let candidates = InterventionMenuContext.recommendationCandidateTypes(for: rec, dictionary: [])
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    func testRecommendationAcceptanceMatchesByNormalizedKindOnly() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            kind: nil,
+            targetProblemID: 10,
+            normalizedKind: "tourniquet",
+        )
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(rec, dictionary: makeDictionary(["tourniquet"]), interventions: [intervention]),
+            "normalizedKind-only recommendation must be accepted when a matching intervention exists",
+        )
+    }
+
+    func testRecommendationAcceptanceMatchesByKindWhenNormalizedKindAbsent() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            kind: "tourniquet",
+            targetProblemID: 10,
+            normalizedKind: nil,
+        )
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(rec, dictionary: makeDictionary(["tourniquet"]), interventions: [intervention]),
+            "kind-only recommendation must be accepted when a matching intervention exists",
+        )
+    }
+
+    func testRecommendationAcceptanceMatchesByNormalizedCodeFallback() {
+        // normalizedCode is the only populated field; it is not in the dictionary,
+        // but the submitted intervention uses that same token as its interventionType.
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            kind: nil,
+            targetProblemID: 10,
+            normalizedKind: nil,
+            normalizedCode: "tourniquet",
+        )
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(rec, dictionary: [], interventions: [intervention]),
+            "normalizedCode fallback must match when no dictionary entry exists",
+        )
+    }
+
+    func testRecommendationAcceptanceMatchesByCodeFallback() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            code: "tourniquet",
+            kind: nil,
+            targetProblemID: 10,
+            normalizedKind: nil,
+            normalizedCode: nil,
+        )
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(rec, dictionary: [], interventions: [intervention]),
+            "code-only recommendation must be accepted via raw-candidate fallback",
+        )
+    }
+
+    func testRecommendationAcceptanceMultipleCandidatesOnlyOneMatchesInterventionType() {
+        // normalizedKind is "tourniquet" (in dictionary), kind is "tourniquet_legacy" (not in dictionary).
+        // The submitted intervention uses "tourniquet". Only normalizedKind should match.
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1,
+            title: "Tourniquet",
+            kind: "tourniquet_legacy",
+            targetProblemID: 10,
+            normalizedKind: "tourniquet",
+        )
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(rec, dictionary: makeDictionary(["tourniquet"]), interventions: [intervention]),
+        )
+        // An intervention using the legacy token must also match via raw candidates.
+        let legacyIntervention = makeInterventionAnnotation(id: "int-2", type: "tourniquet_legacy", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(rec, dictionary: makeDictionary(["tourniquet"]), interventions: [legacyIntervention]),
+            "Raw candidate fallback must also accept a legacy-token intervention",
+        )
+    }
+}
+
+private func makeDictionary(_ types: [String]) -> [InterventionGroup] {
+    types.map { InterventionGroup(interventionType: $0, label: $0, sites: []) }
 }
 
 private func makeInterventionAnnotation(

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -412,12 +412,272 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("LEFT_LEG"), "Left Leg")
         XCTAssertEqual(InterventionDisplayText.normalizedSiteCode("RIGHT_CHEST"), "Right Chest")
     }
+
+    // MARK: - PatientPane Accordion
+
+    func testPatientPaneAccordionOpenSecondaryPinsDiagram() {
+        var state = PatientPaneAccordionState()
+        let sections: [PatientPaneSection] = [.diagram, .causes, .problems]
+
+        state.toggleSection(.causes, availableSections: sections)
+
+        XCTAssertTrue(state.pinnedDiagram, "Opening a secondary section should auto-pin the diagram")
+        XCTAssertEqual(state.openSection, .causes)
+        XCTAssertTrue(state.isExpanded(.diagram), "Diagram must remain visible when a secondary section opens")
+        XCTAssertTrue(state.isExpanded(.causes))
+        XCTAssertFalse(state.isExpanded(.problems))
+    }
+
+    func testPatientPaneAccordionRepeatTapCollapsesPinnedSection() {
+        var state = PatientPaneAccordionState()
+        let sections: [PatientPaneSection] = [.diagram, .causes, .problems]
+
+        state.toggleSection(.causes, availableSections: sections)
+        XCTAssertTrue(state.pinnedDiagram)
+        XCTAssertEqual(state.openSection, .causes)
+
+        state.toggleSection(.causes, availableSections: sections)
+
+        XCTAssertFalse(state.pinnedDiagram, "Tapping the active secondary section should unpin and collapse")
+        XCTAssertEqual(state.openSection, .diagram, "After collapse the diagram should be the open section")
+        XCTAssertTrue(state.isExpanded(.diagram))
+        XCTAssertFalse(state.isExpanded(.causes))
+    }
+
+    func testPatientPaneAccordionSwitchBetweenSectionsKeepsDiagramPinned() {
+        var state = PatientPaneAccordionState()
+        let sections: [PatientPaneSection] = [.diagram, .causes, .problems, .recommendations]
+
+        state.toggleSection(.causes, availableSections: sections)
+        XCTAssertTrue(state.pinnedDiagram)
+        XCTAssertEqual(state.openSection, .causes)
+
+        state.toggleSection(.problems, availableSections: sections)
+
+        XCTAssertTrue(state.pinnedDiagram, "Diagram should stay pinned when switching between secondary sections")
+        XCTAssertEqual(state.openSection, .problems)
+        XCTAssertTrue(state.isExpanded(.diagram))
+        XCTAssertFalse(state.isExpanded(.causes))
+        XCTAssertTrue(state.isExpanded(.problems))
+    }
+
+    func testPatientPaneAccordionDiagramOnlyWhenNoSecondary() {
+        var state = PatientPaneAccordionState()
+        let sections: [PatientPaneSection] = [.diagram]
+
+        // Tapping diagram when it is the only section is a no-op.
+        state.toggleSection(.diagram, availableSections: sections)
+
+        XCTAssertFalse(state.pinnedDiagram)
+        XCTAssertEqual(state.openSection, .diagram)
+        XCTAssertTrue(state.isExpanded(.diagram))
+    }
+
+    func testPatientPaneAccordionUnavailableSectionIsIgnored() {
+        var state = PatientPaneAccordionState()
+        let sections: [PatientPaneSection] = [.diagram, .causes]
+
+        // .problems is not in the available list; toggle should be a no-op.
+        state.toggleSection(.problems, availableSections: sections)
+
+        XCTAssertFalse(state.pinnedDiagram)
+        XCTAssertEqual(state.openSection, .diagram)
+    }
+
+    // MARK: - Target Problem Chooser Collapse
+
+    func testInterventionComposerDraftStartsWithTargetChooserOpen() {
+        let draft = InterventionComposerDraft(prefilledTargetProblemID: nil)
+
+        XCTAssertEqual(draft.activeSection, .target, "Draft with no prefill should start at the target-chooser step")
+        XCTAssertNil(draft.selectedTargetProblemID)
+    }
+
+    func testInterventionComposerDraftPrefilledProblemStartsAtTypeStep() {
+        let draft = InterventionComposerDraft(prefilledTargetProblemID: 42)
+
+        XCTAssertEqual(draft.activeSection, .type, "Prefilled draft should start at the type step, not the chooser")
+        XCTAssertEqual(draft.selectedTargetProblemID, 42)
+    }
+
+    func testInterventionComposerDraftSelectingProblemCollapsesChooser() {
+        var draft = InterventionComposerDraft(prefilledTargetProblemID: nil)
+        XCTAssertEqual(draft.activeSection, .target)
+
+        // Simulate selecting a target problem (same logic as the button action).
+        draft.selectedTargetProblemID = 99
+        draft.activeSection = .type
+
+        XCTAssertEqual(draft.activeSection, .type, "Chooser must collapse (activeSection advances to .type) after selection")
+        XCTAssertEqual(draft.selectedTargetProblemID, 99, "Selected problem ID must be preserved after collapse")
+    }
+
+    func testInterventionComposerDraftSelectedProblemVisibleWhenCollapsed() {
+        var draft = InterventionComposerDraft(prefilledTargetProblemID: nil)
+        draft.selectedTargetProblemID = 7
+        draft.activeSection = .type
+
+        // The summary chip should be derivable from draft state.
+        XCTAssertEqual(draft.selectedTargetProblemID, 7)
+        XCTAssertNotEqual(draft.activeSection, .target, "Chooser list must not be open after collapse")
+    }
+
+    func testInterventionComposerDraftCanReopenChooser() {
+        var draft = InterventionComposerDraft(prefilledTargetProblemID: nil)
+        draft.selectedTargetProblemID = 7
+        draft.activeSection = .type
+
+        // Simulate the header button toggling back to .target.
+        draft.activeSection = .target
+
+        XCTAssertEqual(draft.activeSection, .target, "Tapping the summary should re-open the chooser")
+        XCTAssertEqual(draft.selectedTargetProblemID, 7, "Previously selected problem should still be set while chooser is open")
+    }
+
+    func testInterventionComposerDraftGeneralSelectionCollapsesChooser() {
+        var draft = InterventionComposerDraft(prefilledTargetProblemID: nil)
+        XCTAssertEqual(draft.activeSection, .target)
+
+        // Simulate selecting "General intervention".
+        draft.selectedTargetProblemID = nil
+        draft.activeSection = .type
+
+        XCTAssertEqual(draft.activeSection, .type)
+        XCTAssertNil(draft.selectedTargetProblemID)
+    }
+
+    // MARK: - Recommendation Acceptance State
+
+    func testRecommendationAcceptanceNoInterventionsAllPending() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1, title: "Tourniquet", kind: "tourniquet", targetProblemID: 10, priority: 1,
+        )
+
+        let accepted = InterventionMenuContext.isRecommendationAccepted(
+            rec,
+            interventionType: "tourniquet",
+            interventions: [],
+        )
+
+        XCTAssertFalse(accepted)
+    }
+
+    func testRecommendationAcceptanceMatchingInterventionIsAccepted() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1, title: "Tourniquet", kind: "tourniquet", targetProblemID: 10, priority: 1,
+        )
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+
+        let accepted = InterventionMenuContext.isRecommendationAccepted(
+            rec,
+            interventionType: "tourniquet",
+            interventions: [intervention],
+        )
+
+        XCTAssertTrue(accepted)
+    }
+
+    func testRecommendationAcceptanceDifferentTypeNotAccepted() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1, title: "Tourniquet", kind: "tourniquet", targetProblemID: 10, priority: 1,
+        )
+        // An intervention for the same problem but a different type should NOT accept this recommendation.
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "pressure_dressing", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date())
+
+        let accepted = InterventionMenuContext.isRecommendationAccepted(
+            rec,
+            interventionType: "tourniquet",
+            interventions: [intervention],
+        )
+
+        XCTAssertFalse(accepted, "A different intervention type for the same problem must not mark the recommendation as accepted")
+    }
+
+    func testRecommendationAcceptanceDifferentProblemNotAccepted() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1, title: "Tourniquet", kind: "tourniquet", targetProblemID: 10, priority: 1,
+        )
+        // Same type, but targeting a different problem — should not accept.
+        let intervention = makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 99, updatedAt: Date())
+
+        let accepted = InterventionMenuContext.isRecommendationAccepted(
+            rec,
+            interventionType: "tourniquet",
+            interventions: [intervention],
+        )
+
+        XCTAssertFalse(accepted, "An intervention targeting a different problem must not mark this recommendation as accepted")
+    }
+
+    func testRecommendationAcceptanceOnePendingOneAcceptedOnSameProblem() {
+        let recTourniquet = RecommendedInterventionItem(
+            recommendationID: 1, title: "Tourniquet", kind: "tourniquet", targetProblemID: 10, priority: 1,
+        )
+        let recDressing = RecommendedInterventionItem(
+            recommendationID: 2, title: "Pressure Dressing", kind: "pressure_dressing", targetProblemID: 10, priority: 2,
+        )
+
+        // Only the tourniquet was applied.
+        let interventions = [
+            makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date()),
+        ]
+
+        let tourniquetAccepted = InterventionMenuContext.isRecommendationAccepted(
+            recTourniquet, interventionType: "tourniquet", interventions: interventions,
+        )
+        let dressingAccepted = InterventionMenuContext.isRecommendationAccepted(
+            recDressing, interventionType: "pressure_dressing", interventions: interventions,
+        )
+
+        XCTAssertTrue(tourniquetAccepted, "Tourniquet recommendation must be accepted since a tourniquet was applied")
+        XCTAssertFalse(dressingAccepted, "Pressure dressing recommendation must remain pending — only tourniquet was applied")
+    }
+
+    func testRecommendationAcceptanceTwoProblemsWithDifferentStates() {
+        let recProblem10 = RecommendedInterventionItem(
+            recommendationID: 1, title: "Tourniquet", kind: "tourniquet", targetProblemID: 10, priority: 1,
+        )
+        let recProblem20 = RecommendedInterventionItem(
+            recommendationID: 2, title: "Tourniquet", kind: "tourniquet", targetProblemID: 20, priority: 1,
+        )
+
+        // Only problem 10 was treated.
+        let interventions = [
+            makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 10, updatedAt: Date()),
+        ]
+
+        XCTAssertTrue(
+            InterventionMenuContext.isRecommendationAccepted(recProblem10, interventionType: "tourniquet", interventions: interventions),
+        )
+        XCTAssertFalse(
+            InterventionMenuContext.isRecommendationAccepted(recProblem20, interventionType: "tourniquet", interventions: interventions),
+            "Recommendation for problem 20 must remain pending — intervention targeted problem 10",
+        )
+    }
+
+    func testRecommendationAcceptanceMultipleInterventionTypesOnlyMatchCorrect() {
+        let rec = RecommendedInterventionItem(
+            recommendationID: 1, title: "IV Access", kind: "iv_access", targetProblemID: 5, priority: 1,
+        )
+        let interventions = [
+            makeInterventionAnnotation(id: "int-1", type: "tourniquet", siteCode: "LEFT_LEG", targetProblemID: 5, updatedAt: Date()),
+            makeInterventionAnnotation(id: "int-2", type: "pressure_dressing", siteCode: "LEFT_LEG", targetProblemID: 5, updatedAt: Date()),
+            makeInterventionAnnotation(id: "int-3", type: "iv_access", siteCode: "IV-RIGHT-AC", targetProblemID: 5, updatedAt: Date()),
+        ]
+
+        let accepted = InterventionMenuContext.isRecommendationAccepted(
+            rec, interventionType: "iv_access", interventions: interventions,
+        )
+
+        XCTAssertTrue(accepted, "IV access recommendation must be accepted since an iv_access intervention for the same problem exists")
+    }
 }
 
 private func makeInterventionAnnotation(
     id: String,
     type: String,
     siteCode: String,
+    targetProblemID: Int? = nil,
     updatedAt: Date,
 ) -> InterventionAnnotation {
     InterventionAnnotation(
@@ -425,6 +685,7 @@ private func makeInterventionAnnotation(
         interventionID: Int(id.split(separator: "-").last ?? "1"),
         interventionType: type,
         siteCode: siteCode,
+        targetProblemID: targetProblemID,
         side: .front,
         x: 0.4,
         y: 0.4,

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -702,7 +702,7 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         )
         let dictionary = makeDictionary(["tourniquet"])
         let candidates = InterventionMenuContext.recommendationCandidateTypes(for: rec, dictionary: dictionary)
-        XCTAssertEqual(candidates.filter { $0 == "tourniquet" }.count, 1, "Duplicate candidates must be collapsed to one entry")
+        XCTAssertEqual(candidates.count(where: { $0 == "tourniquet" }), 1, "Duplicate candidates must be collapsed to one entry")
     }
 
     func testRecommendationCandidateTypesEmptyWhenAllFieldsNil() {


### PR DESCRIPTION
Fixes four regressions introduced by the unified patient pane accordion refactor and
intervention overlay changes.

1. Accordion toggle + diagram surfacing (PatientPaneAccordionState)
   - `toggleSection` now collapses the active secondary section when tapped again,
     returning to the diagram-only ground state.
   - Opening any secondary section auto-pins the diagram so both the diagram and the
     secondary content remain visible simultaneously — restoring the pre-refactor
     behavior where causes/problems/recommendations were always visible alongside
     the body diagram.

2. Recommendation acceptance state
   - All recommendations were showing "Accepted" because the display was driven by
     `recommendation.validationStatus` from the backend, which was being set too
     broadly (accepted for any intervention on the same problem).
   - `InterventionMenuContext` now computes `isAccepted` per recommendation by
     matching the specific intervention type **and** target problem ID against the
     submitted interventions array — not merely target problem ID alone.
   - `PatientDiagramPanel.recommendationCard` does the same local match via a new
     `isRecommendationAccepted` helper, replacing raw `validationStatus` display.

3. Target problem chooser collapse (InterventionComposerSheet)
   - `targetProblemSection` now collapses immediately when the user selects a target
     problem (or "General intervention"), advancing to the type-selection step.
   - The header shows the selected problem label (or "General intervention") as a
     chip summary while collapsed, and tapping it re-opens the chooser for reselection.

4. Tests added (RunConsoleLayoutSupportTests)
   - Accordion: open pinned diagram, repeat-tap collapse, section switching, no-op guards.
   - Draft: initial state, prefill, select problem collapses chooser, selected label
     preserved after collapse, reopen, general selection.
   - Recommendation acceptance: no interventions pending, matching type accepted,
     different type not accepted, different problem not accepted, one pending + one
     accepted on same problem, two problems with different states, multiple types.

No backend follow-up required — all fixes are frontend-only using data already available
in the store's interventions/recommendations arrays.

https://claude.ai/code/session_01C4MWvMPaYekNdar22YqHoj