### PR TITLE
Patient diagram: anatomy-aware rendering, silhouettes, labels, and tests

### DIFF
--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -595,6 +595,8 @@ struct PatientDiagramPanel: View {
     @State private var selected: PatientDiagramSelection?
     @State private var accordionState = PatientPaneAccordionState()
 
+    private let displayConvention: BodyDisplayOrientationConvention = RunConsolePatientDiagramSupport.displayOrientationConvention
+
     var body: some View {
         VStack(spacing: containerSpacing) {
             accordionSections
@@ -930,9 +932,14 @@ struct PatientDiagramPanel: View {
     // MARK: - Body Diagram
 
     private var diagramArea: some View {
-        HStack(alignment: .top, spacing: 8) {
-            bodyPanel(title: "Front", side: .front)
-            bodyPanel(title: "Back", side: .back)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 8) {
+                bodyPanel(title: "Front", side: .front)
+                bodyPanel(title: "Back", side: .back)
+            }
+            if shouldShowDiagramLegend {
+                diagramLegend
+            }
         }
     }
 
@@ -945,14 +952,33 @@ struct PatientDiagramPanel: View {
                 ZStack {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .fill(TrainerLabTheme.tacticalSurface)
-                    BodyOutlineShape()
+                    bodySilhouette(for: side)
                         .stroke(Color.white.opacity(0.35), lineWidth: 1.5)
                         .padding(12)
+                    Path { path in
+                        let x = geo.size.width * 0.5
+                        path.move(to: CGPoint(x: x, y: 10))
+                        path.addLine(to: CGPoint(x: x, y: geo.size.height - 10))
+                    }
+                    .stroke(Color.white.opacity(0.14), style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+                    orientationOverlay(for: side)
                     markersOverlay(side: side, size: geo.size)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+    }
+
+    private func bodySilhouette(for side: InjuryZoneSide) -> BodySilhouetteShape {
+        BodySilhouetteShape(side: side)
+    }
+
+    private func orientationOverlay(for side: InjuryZoneSide) -> some View {
+        BodyOrientationLabels(
+            leadingText: RunConsolePatientDiagramSupport.orientationLabels(for: side).leading,
+            trailingText: RunConsolePatientDiagramSupport.orientationLabels(for: side).trailing,
+        )
+        .padding(8)
     }
 
     @ViewBuilder
@@ -991,15 +1017,14 @@ struct PatientDiagramPanel: View {
         problems: [ProblemAnnotation],
         size: CGSize,
     ) -> some View {
-        let cx = injury.x * size.width
-        let cy = injury.y * size.height
+        let center = displayPoint(x: injury.x, y: injury.y, for: injury.side, in: size)
         let colocatedInterventions = interventions.filter { isColocated($0, with: injury) }
         let colocatedProblems = problems.filter { isColocated($0, with: injury) }
 
         return ZStack {
             // Base injury marker
             Image(systemName: "x.circle.fill")
-                .font(.system(size: 16, weight: .bold))
+                .font(.system(size: 18, weight: .bold))
                 .foregroundStyle(injuryColor(for: injury))
                 .shadow(color: .black.opacity(0.4), radius: 2, x: 0, y: 1)
                 .onTapGesture {
@@ -1010,16 +1035,16 @@ struct PatientDiagramPanel: View {
             // Intervention badge stack (offset right)
             ForEach(Array(colocatedInterventions.enumerated()), id: \.element.id) { idx, intervention in
                 Image(systemName: "plus.circle.fill")
-                    .font(.system(size: 10))
+                    .font(.system(size: 11))
                     .foregroundStyle(TrainerLabTheme.accentBlue)
-                    .offset(x: 10 + CGFloat(idx) * 6, y: -6)
+                    .offset(x: 11 + CGFloat(idx) * 7, y: -8)
                     .onTapGesture { selected = .intervention(intervention) }
             }
 
             // Problem badge stack (offset below the cause marker)
             ForEach(Array(colocatedProblems.enumerated()), id: \.element.id) { idx, problem in
                 problemBadge(problem)
-                    .offset(x: CGFloat(idx) * 6, y: 12 + CGFloat(idx) * 4)
+                    .offset(x: CGFloat(idx) * 7, y: 13 + CGFloat(idx) * 5)
                     .onTapGesture {
                         if let onSelectProblem {
                             onSelectProblem(problem)
@@ -1029,7 +1054,7 @@ struct PatientDiagramPanel: View {
                     }
             }
         }
-        .position(x: cx, y: cy)
+        .position(center)
     }
 
     private func injuryColor(for injury: InjuryAnnotation) -> Color {
@@ -1043,22 +1068,20 @@ struct PatientDiagramPanel: View {
     // MARK: - Standalone Markers
 
     private func interventionMarker(_ intervention: InterventionAnnotation, size: CGSize) -> some View {
-        let cx = intervention.x * size.width
-        let cy = intervention.y * size.height
+        let center = displayPoint(x: intervention.x, y: intervention.y, for: intervention.side, in: size)
         return Image(systemName: "plus.circle.fill")
-            .font(.system(size: 14, weight: .bold))
+            .font(.system(size: 13, weight: .bold))
             .foregroundStyle(TrainerLabTheme.accentBlue)
             .shadow(color: .black.opacity(0.4), radius: 2, x: 0, y: 1)
-            .position(x: cx, y: cy)
+            .position(center)
             .onTapGesture { selected = .intervention(intervention) }
     }
 
     private func problemMarker(_ problem: ProblemAnnotation, size: CGSize) -> some View {
-        let cx = (problem.x ?? 0.5) * size.width
-        let cy = (problem.y ?? 0.5) * size.height
+        let center = displayPoint(x: problem.x ?? 0.5, y: problem.y ?? 0.5, for: problem.side ?? .front, in: size)
         return ZStack {
             Image(systemName: "circle.circle.fill")
-                .font(.system(size: 14, weight: .bold))
+                .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(problem.isUncontrolled ? TrainerLabTheme.danger : TrainerLabTheme.success)
             if problem.isUncontrolled {
                 Image(systemName: "exclamationmark.triangle.fill")
@@ -1070,7 +1093,7 @@ struct PatientDiagramPanel: View {
         .scaleEffect(problem.isUncontrolled ? 1.0 : 1.0)
         .modifier(PulsingModifier(active: problem.isUncontrolled))
         .shadow(color: problem.isUncontrolled ? TrainerLabTheme.danger.opacity(0.6) : .clear, radius: 4)
-        .position(x: cx, y: cy)
+        .position(center)
         .onTapGesture {
             if let onSelectProblem {
                 onSelectProblem(problem)
@@ -1081,13 +1104,12 @@ struct PatientDiagramPanel: View {
     }
 
     private func pulseMarker(_ pulse: PulseAnnotation, size: CGSize) -> some View {
-        let cx = pulse.x * size.width
-        let cy = pulse.y * size.height
+        let center = displayPoint(x: pulse.x, y: pulse.y, for: pulse.side, in: size)
         return Image(systemName: pulse.present ? "circle.dotted.circle" : "circle.dotted.circle.fill")
-            .font(.system(size: 12))
+            .font(.system(size: 11))
             .foregroundStyle(pulse.present ? .cyan : .gray)
             .shadow(color: .black.opacity(0.3), radius: 1, x: 0, y: 1)
-            .position(x: cx, y: cy)
+            .position(center)
             .onTapGesture { selected = .pulse(pulse) }
     }
 
@@ -1095,7 +1117,7 @@ struct PatientDiagramPanel: View {
         ZStack {
             Circle()
                 .fill(problem.isUncontrolled ? TrainerLabTheme.danger : TrainerLabTheme.success)
-                .frame(width: 12, height: 12)
+                .frame(width: 13, height: 13)
             if problem.isUncontrolled {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 7))
@@ -1108,12 +1130,22 @@ struct PatientDiagramPanel: View {
     // MARK: - Colocation Helpers
 
     private func isColocated(_ intervention: InterventionAnnotation, with injury: InjuryAnnotation) -> Bool {
-        abs(intervention.x - injury.x) < 0.05 && abs(intervention.y - injury.y) < 0.05 && intervention.side == injury.side
+        let unitSize = CGSize(width: 1, height: 1)
+        let injuryDisplay = displayPoint(x: injury.x, y: injury.y, for: injury.side, in: unitSize)
+        let interventionDisplay = displayPoint(x: intervention.x, y: intervention.y, for: intervention.side, in: unitSize)
+        return abs(interventionDisplay.x - injuryDisplay.x) < 0.05 &&
+            abs(interventionDisplay.y - injuryDisplay.y) < 0.05 &&
+            intervention.side == injury.side
     }
 
     private func isColocated(_ problem: ProblemAnnotation, with injury: InjuryAnnotation) -> Bool {
         guard let px = problem.x, let py = problem.y, let ps = problem.side else { return false }
-        return abs(px - injury.x) < 0.05 && abs(py - injury.y) < 0.05 && ps == injury.side
+        let unitSize = CGSize(width: 1, height: 1)
+        let injuryDisplay = displayPoint(x: injury.x, y: injury.y, for: injury.side, in: unitSize)
+        let problemDisplay = displayPoint(x: px, y: py, for: ps, in: unitSize)
+        return abs(problemDisplay.x - injuryDisplay.x) < 0.05 &&
+            abs(problemDisplay.y - injuryDisplay.y) < 0.05 &&
+            ps == injury.side
     }
 
     private func standaloneInterventions(from interventions: [InterventionAnnotation], injuries: [InjuryAnnotation]) -> [InterventionAnnotation] {
@@ -1136,7 +1168,7 @@ struct PatientDiagramPanel: View {
                 .font(.caption)
                 .foregroundStyle(injuryColor(for: injury))
             VStack(alignment: .leading, spacing: 1) {
-                Text("\(injury.kind.uppercased())\(injury.category.map { " (\($0.uppercased()))" } ?? "") — \(injury.locationCode)")
+                Text("\(injury.kind.uppercased())\(injury.category.map { " (\($0.uppercased()))" } ?? "") — \(anatomicalLocationLabel(for: injury) ?? injury.locationCode)")
                     .font(.caption2.bold())
                     .lineLimit(1)
                 Text(injury.label)
@@ -1188,7 +1220,11 @@ struct PatientDiagramPanel: View {
                 Text(problem.label)
                     .font(.caption2.bold())
                     .lineLimit(1)
-                if let severity = problem.severity {
+                if let anatomicalLabel = anatomicalLocationLabel(for: problem) {
+                    Text(anatomicalLabel)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                } else if let severity = problem.severity {
                     Text(severity.capitalized)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
@@ -1223,10 +1259,11 @@ struct PatientDiagramPanel: View {
     }
 
     private func interventionRow(_ intervention: InterventionAnnotation) -> some View {
-        let siteSummary = InterventionDisplayText.siteLabel(
+        let fallbackSummary = InterventionDisplayText.siteLabel(
             siteCode: intervention.siteCode,
             siteLabel: intervention.siteLabel,
         ) ?? intervention.siteCode
+        let siteSummary = anatomicalLocationLabel(for: intervention) ?? fallbackSummary
         return HStack(spacing: 6) {
             Image(systemName: "plus.circle.fill")
                 .font(.caption)
@@ -1298,7 +1335,7 @@ struct PatientDiagramPanel: View {
                     Text(injury.label)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                    Text("Location: \(injury.locationCode) · \(injury.side.rawValue.capitalized)")
+                    Text("Location: \(anatomicalLocationLabel(for: injury) ?? injury.locationCode)")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     Text("Cause Type: \(injury.kind.replacingOccurrences(of: "_", with: " ").capitalized)")
@@ -1306,13 +1343,14 @@ struct PatientDiagramPanel: View {
                 }
             case let .intervention(intervention):
                 VStack(alignment: .leading, spacing: 4) {
-                    let siteSummary = InterventionDisplayText.siteLabel(
+                    let fallbackSummary = InterventionDisplayText.siteLabel(
                         siteCode: intervention.siteCode,
                         siteLabel: intervention.siteLabel,
                     ) ?? intervention.siteCode
+                    let siteSummary = anatomicalLocationLabel(for: intervention) ?? fallbackSummary
                     Text(intervention.title)
                         .font(.caption.bold())
-                    Text("Site: \(siteSummary) · \(intervention.side.rawValue.capitalized)")
+                    Text("Site: \(siteSummary)")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     Text("Effectiveness: \(SimulationEventRegistry.humanizedLabel(intervention.effectiveness)) — \(intervention.status.capitalized)")
@@ -1349,8 +1387,8 @@ struct PatientDiagramPanel: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
-                    if problem.isAnatomic, let loc = problem.locationCode {
-                        Text("Location: \(loc)")
+                    if problem.isAnatomic {
+                        Text("Location: \(anatomicalLocationLabel(for: problem) ?? problem.locationCode ?? "Unknown")")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     } else {
@@ -1474,11 +1512,184 @@ struct PatientDiagramPanel: View {
         .controlSize(.mini)
         .tint(problem.status == status ? TrainerLabTheme.accentBlue : .secondary)
     }
+
+    private var shouldShowDiagramLegend: Bool {
+        !(layoutMode == .compact && compactMetrics.cardPadding <= 8)
+    }
+
+    private var diagramLegend: some View {
+        HStack(spacing: 10) {
+            legendItem(icon: "x.circle.fill", color: TrainerLabTheme.danger, label: "Cause/Injury")
+            legendItem(icon: "circle.circle.fill", color: TrainerLabTheme.warning, label: "Problem")
+            legendItem(icon: "plus.circle.fill", color: TrainerLabTheme.accentBlue, label: "Intervention")
+            legendItem(icon: "circle.dotted.circle", color: .cyan, label: "Pulse")
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+    }
+
+    private func legendItem(icon: String, color: Color, label: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .foregroundStyle(color)
+            Text(label)
+        }
+    }
+
+    private func displayPoint(x: Double, y: Double, for side: InjuryZoneSide, in size: CGSize) -> CGPoint {
+        RunConsolePatientDiagramSupport.displayPoint(
+            x: CGFloat(x),
+            y: CGFloat(y),
+            side: side,
+            size: size,
+            convention: displayConvention,
+        )
+    }
+
+    private func anatomicalLocationLabel(for problem: ProblemAnnotation) -> String? {
+        RunConsolePatientDiagramSupport.anatomicalLocationLabel(
+            side: problem.side,
+            zoneCode: problem.locationCode,
+        )
+    }
+
+    private func anatomicalLocationLabel(for injury: InjuryAnnotation) -> String? {
+        RunConsolePatientDiagramSupport.anatomicalLocationLabel(
+            side: injury.side,
+            zoneCode: injury.locationCode,
+        )
+    }
+
+    private func anatomicalLocationLabel(for intervention: InterventionAnnotation) -> String? {
+        RunConsolePatientDiagramSupport.anatomicalLocationLabel(
+            side: intervention.side,
+            zoneCode: intervention.siteCode,
+        )
+    }
 }
 
-// MARK: - Body Outline Shape
+enum BodyDisplayOrientationConvention {
+    case patientAnatomical
+    case viewerMirrored
+}
 
-struct BodyOutlineShape: Shape {
+enum RunConsolePatientDiagramSupport {
+    static let displayOrientationConvention: BodyDisplayOrientationConvention = .patientAnatomical
+
+    static func orientationLabels(for side: InjuryZoneSide) -> (leading: String, trailing: String) {
+        switch side {
+        case .front:
+            ("Patient Right", "Patient Left")
+        case .back:
+            ("Patient Left", "Patient Right")
+        }
+    }
+
+    // Coordinates are rendered in patient-anatomy orientation, not viewer selfie orientation.
+    // If older payloads are discovered to be viewer-mirrored, change displayOrientationConvention
+    // (or side-specific logic) instead of introducing ad hoc flips in marker views.
+    static func displayPoint(
+        x: CGFloat,
+        y: CGFloat,
+        side: InjuryZoneSide,
+        size: CGSize,
+        convention: BodyDisplayOrientationConvention = displayOrientationConvention,
+    ) -> CGPoint {
+        let normalizedX: CGFloat
+        switch convention {
+        case .patientAnatomical:
+            normalizedX = x
+        case .viewerMirrored:
+            normalizedX = side == .front ? 1 - x : x
+        }
+
+        return CGPoint(x: normalizedX * size.width, y: y * size.height)
+    }
+
+    static func anatomicalLocationLabel(side: InjuryZoneSide?, zoneCode: String?) -> String? {
+        guard let zoneCode, !zoneCode.isEmpty else { return nil }
+        let cleaned = zoneCode
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+            .uppercased()
+
+        let tokens = cleaned.split(separator: "_").map(String.init)
+        let resolvedSide = normalizedLateralityLabel(side: side, zoneCode: zoneCode)
+
+        let regionTokens = tokens.filter {
+            !["LEFT", "RIGHT", "FRONT", "BACK", "ANTERIOR", "POSTERIOR"].contains($0)
+        }
+        let region = regionTokens.isEmpty ? nil : regionTokens.map(\.capitalized).joined(separator: " ")
+
+        let plane: String?
+        if tokens.contains("POSTERIOR") || tokens.contains("BACK") || side == .back {
+            plane = "Posterior"
+        } else if tokens.contains("ANTERIOR") || tokens.contains("FRONT") {
+            plane = "Anterior"
+        } else {
+            plane = nil
+        }
+
+        var parts: [String] = []
+        if let plane { parts.append(plane) }
+        if let resolvedSide { parts.append(resolvedSide) }
+        if let region { parts.append(region) }
+
+        if parts.isEmpty {
+            return cleaned.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+        return parts.joined(separator: " ")
+    }
+
+    static func normalizedLateralityLabel(side: InjuryZoneSide?, zoneCode: String?) -> String? {
+        _ = side
+        let cleaned = zoneCode?
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+            .uppercased() ?? ""
+        let tokens = cleaned.split(separator: "_").map(String.init)
+
+        if tokens.contains("RIGHT") { return "Right" }
+        if tokens.contains("LEFT") { return "Left" }
+        return nil
+    }
+}
+
+// MARK: - Body Silhouettes
+
+private struct BodySilhouetteShape: Shape {
+    let side: InjuryZoneSide
+
+    func path(in rect: CGRect) -> Path {
+        switch side {
+        case .front:
+            AnteriorBodyShape().path(in: rect)
+        case .back:
+            PosteriorBodyShape().path(in: rect)
+        }
+    }
+}
+
+private struct BodyOrientationLabels: View {
+    let leadingText: String
+    let trailingText: String
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text(leadingText)
+                Spacer()
+                Text(trailingText)
+            }
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.secondary)
+            Spacer()
+        }
+    }
+}
+
+private struct AnteriorBodyShape: Shape {
     func path(in rect: CGRect) -> Path {
         let w = rect.width
         let h = rect.height
@@ -1496,14 +1707,14 @@ struct BodyOutlineShape: Shape {
         p.move(to: CGPoint(x: w * 0.53, y: h * 0.115))
         p.addLine(to: CGPoint(x: w * 0.53, y: h * 0.14))
 
-        // Torso
+        // Torso (anterior)
         p.move(to: CGPoint(x: w * 0.35, y: h * 0.14))
         p.addLine(to: CGPoint(x: w * 0.65, y: h * 0.14))
-        p.addQuadCurve(to: CGPoint(x: w * 0.62, y: h * 0.46), control: CGPoint(x: w * 0.68, y: h * 0.30))
+        p.addQuadCurve(to: CGPoint(x: w * 0.62, y: h * 0.47), control: CGPoint(x: w * 0.68, y: h * 0.29))
         p.addLine(to: CGPoint(x: w * 0.56, y: h * 0.48))
         p.addLine(to: CGPoint(x: w * 0.44, y: h * 0.48))
-        p.addLine(to: CGPoint(x: w * 0.38, y: h * 0.46))
-        p.addQuadCurve(to: CGPoint(x: w * 0.35, y: h * 0.14), control: CGPoint(x: w * 0.32, y: h * 0.30))
+        p.addLine(to: CGPoint(x: w * 0.38, y: h * 0.47))
+        p.addQuadCurve(to: CGPoint(x: w * 0.35, y: h * 0.14), control: CGPoint(x: w * 0.32, y: h * 0.29))
 
         // Left arm
         p.move(to: CGPoint(x: w * 0.35, y: h * 0.15))
@@ -1546,6 +1757,61 @@ struct BodyOutlineShape: Shape {
         p.addLine(to: CGPoint(x: w * 0.65, y: h * 0.95))
         p.move(to: CGPoint(x: w * 0.57, y: h * 0.92))
         p.addLine(to: CGPoint(x: w * 0.60, y: h * 0.95))
+
+        return p
+    }
+}
+
+private struct PosteriorBodyShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width
+        let h = rect.height
+        var p = Path()
+
+        let headCX = w * 0.5
+        let headCY = h * 0.08
+        let headR = min(w, h) * 0.055
+        p.addEllipse(in: CGRect(x: headCX - headR, y: headCY - headR, width: headR * 2, height: headR * 2.2))
+
+        p.move(to: CGPoint(x: w * 0.47, y: h * 0.115))
+        p.addLine(to: CGPoint(x: w * 0.47, y: h * 0.145))
+        p.move(to: CGPoint(x: w * 0.53, y: h * 0.115))
+        p.addLine(to: CGPoint(x: w * 0.53, y: h * 0.145))
+
+        // Torso (posterior): slightly broader shoulders and straighter flank to differentiate from anterior.
+        p.move(to: CGPoint(x: w * 0.33, y: h * 0.145))
+        p.addQuadCurve(to: CGPoint(x: w * 0.67, y: h * 0.145), control: CGPoint(x: w * 0.50, y: h * 0.11))
+        p.addQuadCurve(to: CGPoint(x: w * 0.60, y: h * 0.49), control: CGPoint(x: w * 0.70, y: h * 0.34))
+        p.addLine(to: CGPoint(x: w * 0.40, y: h * 0.49))
+        p.addQuadCurve(to: CGPoint(x: w * 0.33, y: h * 0.145), control: CGPoint(x: w * 0.30, y: h * 0.34))
+
+        // Arms
+        p.move(to: CGPoint(x: w * 0.33, y: h * 0.16))
+        p.addQuadCurve(to: CGPoint(x: w * 0.18, y: h * 0.34), control: CGPoint(x: w * 0.22, y: h * 0.20))
+        p.addLine(to: CGPoint(x: w * 0.15, y: h * 0.47))
+        p.move(to: CGPoint(x: w * 0.67, y: h * 0.16))
+        p.addQuadCurve(to: CGPoint(x: w * 0.82, y: h * 0.34), control: CGPoint(x: w * 0.78, y: h * 0.20))
+        p.addLine(to: CGPoint(x: w * 0.85, y: h * 0.47))
+
+        // Legs
+        p.move(to: CGPoint(x: w * 0.43, y: h * 0.49))
+        p.addLine(to: CGPoint(x: w * 0.40, y: h * 0.72))
+        p.addLine(to: CGPoint(x: w * 0.39, y: h * 0.93))
+        p.move(to: CGPoint(x: w * 0.57, y: h * 0.49))
+        p.addLine(to: CGPoint(x: w * 0.60, y: h * 0.72))
+        p.addLine(to: CGPoint(x: w * 0.61, y: h * 0.93))
+        p.move(to: CGPoint(x: w * 0.49, y: h * 0.49))
+        p.addLine(to: CGPoint(x: w * 0.46, y: h * 0.73))
+        p.addLine(to: CGPoint(x: w * 0.45, y: h * 0.92))
+        p.move(to: CGPoint(x: w * 0.51, y: h * 0.49))
+        p.addLine(to: CGPoint(x: w * 0.54, y: h * 0.73))
+        p.addLine(to: CGPoint(x: w * 0.55, y: h * 0.92))
+
+        // Heels
+        p.move(to: CGPoint(x: w * 0.39, y: h * 0.93))
+        p.addLine(to: CGPoint(x: w * 0.36, y: h * 0.96))
+        p.move(to: CGPoint(x: w * 0.61, y: h * 0.93))
+        p.addLine(to: CGPoint(x: w * 0.64, y: h * 0.96))
 
         return p
     }

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -797,6 +797,95 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
             "Raw candidate fallback must also accept a legacy-token intervention",
         )
     }
+
+    func testDisplayPointFrontRightSidedAnatomyRendersOnPatientRightPanelSide() {
+        let point = RunConsolePatientDiagramSupport.displayPoint(
+            x: 0.2,
+            y: 0.5,
+            side: .front,
+            size: CGSize(width: 200, height: 300),
+        )
+
+        XCTAssertEqual(point.x, 40, accuracy: 0.001)
+        XCTAssertEqual(point.y, 150, accuracy: 0.001)
+    }
+
+    func testDisplayPointFrontLeftSidedAnatomyRendersOnPatientLeftPanelSide() {
+        let point = RunConsolePatientDiagramSupport.displayPoint(
+            x: 0.8,
+            y: 0.4,
+            side: .front,
+            size: CGSize(width: 200, height: 300),
+        )
+
+        XCTAssertEqual(point.x, 160, accuracy: 0.001)
+        XCTAssertEqual(point.y, 120, accuracy: 0.001)
+    }
+
+    func testDisplayPointBackLateralityStaysConsistentWithConvention() {
+        let point = RunConsolePatientDiagramSupport.displayPoint(
+            x: 0.25,
+            y: 0.3,
+            side: .back,
+            size: CGSize(width: 200, height: 300),
+        )
+
+        XCTAssertEqual(point.x, 50, accuracy: 0.001)
+        XCTAssertEqual(point.y, 90, accuracy: 0.001)
+    }
+
+    func testAnatomicalLocationLabelNormalizesRepresentativeCases() {
+        XCTAssertEqual(
+            RunConsolePatientDiagramSupport.anatomicalLocationLabel(side: .front, zoneCode: "RIGHT_CHEST"),
+            "Right Chest",
+        )
+        XCTAssertEqual(
+            RunConsolePatientDiagramSupport.anatomicalLocationLabel(side: .front, zoneCode: "LEFT_FOREARM"),
+            "Left Forearm",
+        )
+        XCTAssertEqual(
+            RunConsolePatientDiagramSupport.anatomicalLocationLabel(side: .back, zoneCode: "RIGHT_CALF"),
+            "Posterior Right Calf",
+        )
+        XCTAssertEqual(
+            RunConsolePatientDiagramSupport.anatomicalLocationLabel(side: .back, zoneCode: "LEFT_SHOULDER"),
+            "Posterior Left Shoulder",
+        )
+    }
+
+    func testOrientationLabelsUsePatientLateralityForFrontView() {
+        let frontLabels = RunConsolePatientDiagramSupport.orientationLabels(for: .front)
+
+        XCTAssertEqual(frontLabels.leading, "Patient Right")
+        XCTAssertEqual(frontLabels.trailing, "Patient Left")
+    }
+
+    func testOrientationLabelsUsePatientLateralityForBackView() {
+        let backLabels = RunConsolePatientDiagramSupport.orientationLabels(for: .back)
+
+        XCTAssertEqual(backLabels.leading, "Patient Left")
+        XCTAssertEqual(backLabels.trailing, "Patient Right")
+    }
+
+    func testNormalizedLateralityLabelReadsTokenWhenAvailable() {
+        XCTAssertEqual(
+            RunConsolePatientDiagramSupport.normalizedLateralityLabel(side: .front, zoneCode: "RIGHT_CHEST"),
+            "Right",
+        )
+        XCTAssertEqual(
+            RunConsolePatientDiagramSupport.normalizedLateralityLabel(side: .back, zoneCode: "LEFT_SHOULDER"),
+            "Left",
+        )
+    }
+
+    func testNormalizedLateralityLabelDoesNotInferFromPanelSideOnly() {
+        XCTAssertNil(
+            RunConsolePatientDiagramSupport.normalizedLateralityLabel(side: .front, zoneCode: "CHEST"),
+        )
+        XCTAssertNil(
+            RunConsolePatientDiagramSupport.normalizedLateralityLabel(side: .back, zoneCode: nil),
+        )
+    }
 }
 
 private func makeDictionary(_ types: [String]) -> [InterventionGroup] {


### PR DESCRIPTION
### Motivation
- Replace ad-hoc viewer orientation assumptions and hard-coded marker math with a centralized, anatomy-aware display model to ensure markers and labels render consistently across front/back panels.
- Improve diagram readability by adding body silhouettes for anterior/posterior views, orientation labels, and a small legend when space permits.
- Surface human-friendly anatomical labels in lists and detail cards instead of raw zone tokens.

### Description
- Introduces `RunConsolePatientDiagramSupport` with `displayPoint`, `anatomicalLocationLabel`, `orientationLabels`, and `normalizedLateralityLabel`, plus a `BodyDisplayOrientationConvention` to centralize orientation behavior.  
- Replaces raw `x * size.width`/`y * size.height` calculations with `displayPoint(...)` across marker placement and colocation helpers, and adds a `displayConvention` constant to `PatientDiagramPanel`.  
- Adds anterior/posterior body silhouettes (`AnteriorBodyShape`, `PosteriorBodyShape`) and `BodySilhouetteShape`, plus `BodyOrientationLabels` and a diagram legend (`diagramLegend`) that is conditionally shown via `shouldShowDiagramLegend`.  
- Adjusts marker and badge sizes/offsets and draws a center dashed line and orientation overlay in the diagram area, plus substitutes anatomical labels in rows and detail cards where available.

### Testing
- Added unit tests in `RunConsoleLayoutSupportTests` that validate `displayPoint` coordinates, `anatomicalLocationLabel` normalization, `orientationLabels`, and `normalizedLateralityLabel`, which all passed.  
- Ran the test suite with `swift test` and confirmed `RunConsoleLayoutSupportTests` succeeded without failures.  
- Existing layout and recommendation-related tests were preserved and ran successfully as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0f84959c83339d6c8028b048d1ad)