### PR TITLE
fix(trainerlab): resolve anatomical location codes

### DIFF
--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -1156,14 +1156,20 @@ struct PatientDiagramPanel: View {
     }
 
     private func anatomicalLocationLabel(for problem: ProblemAnnotation) -> String? {
-        RunConsolePatientDiagramSupport.anatomicalLocationLabel(
+        if let displayLocation = Self.problemDisplayLocation(problem) {
+            return displayLocation
+        }
+        return RunConsolePatientDiagramSupport.anatomicalLocationLabel(
             side: problem.side,
             zoneCode: problem.locationCode,
         )
     }
 
     private func anatomicalLocationLabel(for injury: InjuryAnnotation) -> String? {
-        RunConsolePatientDiagramSupport.anatomicalLocationLabel(
+        if let knownLabel = RuntimeAnatomicalLocationDisplay.knownLabel(for: injury.locationCode) {
+            return knownLabel
+        }
+        return RunConsolePatientDiagramSupport.anatomicalLocationLabel(
             side: injury.side,
             zoneCode: injury.locationCode,
         )
@@ -1272,37 +1278,49 @@ struct PatientDiagramPanel: View {
     }
 
     static func causeDisplayLocation(_ cause: RuntimeCauseState) -> String? {
-        RuntimeLocationDisplay.locationText(
+        RuntimeAnatomicalLocationDisplay.label(
             preferredLabel: cause.anatomicalLocationLabel,
-            secondaryLabel: cause.injuryLocationLabel,
-            rawLocation: cause.anatomicalLocation,
-            fallbackRawLocation: cause.injuryLocation,
+            rawCode: cause.anatomicalLocation ?? cause.injuryLocation,
+            fallbackLabel: cause.injuryLocationLabel,
             lateralityLabel: cause.lateralityLabel,
             laterality: cause.laterality,
-            includesLateralityWhenSeparate: true,
+            includeLateralityWhenSeparate: true,
         )
     }
 
     static func problemDisplayLocation(_ problem: ProblemAnnotation) -> String? {
-        nonEmpty(problem.locationLabel)
-            ?? nonEmpty(problem.locationCode).map(InterventionDisplayText.normalizedSiteCode)
+        if let locationLabel = nonEmpty(problem.locationLabel) {
+            return locationLabel
+        }
+        if let knownLabel = RuntimeAnatomicalLocationDisplay.knownLabel(for: problem.locationCode) {
+            return knownLabel
+        }
+        return RunConsolePatientDiagramSupport.anatomicalLocationLabel(
+            side: problem.side,
+            zoneCode: problem.locationCode,
+        ) ?? RuntimeAnatomicalLocationDisplay.label(
+            preferredLabel: nil,
+            rawCode: problem.locationCode,
+        )
     }
 
     static func assessmentFindingDisplayLocation(_ finding: RuntimeAssessmentFindingState) -> String? {
-        RuntimeLocationDisplay.locationText(
+        RuntimeAnatomicalLocationDisplay.label(
             preferredLabel: finding.anatomicalLocationLabel,
-            secondaryLabel: nil,
-            rawLocation: finding.anatomicalLocation,
-            fallbackRawLocation: nil,
+            rawCode: finding.anatomicalLocation,
             lateralityLabel: finding.lateralityLabel,
             laterality: finding.laterality,
-            includesLateralityWhenSeparate: true,
+            includeLateralityWhenSeparate: true,
         )
     }
 
     static func injuryDisplayTitle(injury: InjuryAnnotation) -> String {
         let kind = humanizeLabel(injury.kind)
-        return "\(kind) — \(humanizeLabel(injury.locationCode))"
+        let location = RuntimeAnatomicalLocationDisplay.label(
+            preferredLabel: nil,
+            rawCode: injury.locationCode,
+        ) ?? humanizeLabel(injury.locationCode)
+        return "\(kind) — \(location)"
     }
 
     static func humanizeLabel(_ raw: String) -> String {

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -1280,7 +1280,8 @@ struct PatientDiagramPanel: View {
     static func causeDisplayLocation(_ cause: RuntimeCauseState) -> String? {
         RuntimeAnatomicalLocationDisplay.label(
             preferredLabel: cause.anatomicalLocationLabel,
-            rawCode: cause.anatomicalLocation ?? cause.injuryLocation,
+            rawCode: cause.anatomicalLocation,
+            fallbackRawCode: cause.injuryLocation,
             fallbackLabel: cause.injuryLocationLabel,
             lateralityLabel: cause.lateralityLabel,
             laterality: cause.laterality,

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -2094,19 +2094,20 @@ public final class RunSessionStore: ObservableObject {
         let label = eventPrimaryLabel(from: event.payload) ?? "Problem"
         let status = ProblemLifecycleState(rawValue: jsonString(event.payload["status"]) ?? "active") ?? .active
         let severity = jsonString(event.payload["severity"])
-        let locationLabel = RuntimeLocationDisplay.locationText(
-            preferredLabel: jsonString(event.payload["anatomical_location_label"]),
-            rawLocation: jsonString(event.payload["anatomical_location"]),
-            fallbackRawLocation: jsonString(event.payload["injury_location"]),
-            lateralityLabel: jsonString(event.payload["laterality_label"]),
-            laterality: jsonString(event.payload["laterality"]),
-            includesLateralityWhenSeparate: true,
-        )
         let locationCode = resolvedAnatomicLocationCode(
             primary: jsonString(event.payload["anatomical_location"]) ?? jsonString(event.payload["injury_location"]),
             fallback: jsonInt(event.payload["cause_id"]).flatMap { causeID in
                 state.causeAnnotations.first(where: { $0.causeID == causeID })?.locationCode
             },
+        )
+        let locationLabel = RuntimeAnatomicalLocationDisplay.label(
+            preferredLabel: jsonString(event.payload["anatomical_location_label"]),
+            rawCode: locationCode
+                ?? jsonString(event.payload["anatomical_location"])
+                ?? jsonString(event.payload["injury_location"]),
+            lateralityLabel: jsonString(event.payload["laterality_label"]),
+            laterality: jsonString(event.payload["laterality"]),
+            includeLateralityWhenSeparate: true,
         )
 
         let zone = locationCode.flatMap { injuryZone(for: $0) }
@@ -2630,17 +2631,19 @@ public final class RunSessionStore: ObservableObject {
         causesByID: [Int: RuntimeCauseState],
     ) -> ProblemAnnotation {
         let linkedCause = problem.causeID.flatMap { causesByID[$0] }
-        let locationLabel = RuntimeLocationDisplay.locationText(
-            preferredLabel: problem.anatomicalLocationLabel,
-            rawLocation: problem.anatomicalLocation,
-            fallbackRawLocation: linkedCause?.anatomicalLocation ?? linkedCause?.injuryLocation,
-            lateralityLabel: problem.lateralityLabel,
-            laterality: problem.laterality,
-            includesLateralityWhenSeparate: true,
-        )
         let locationCode = resolvedAnatomicLocationCode(
             primary: problem.anatomicalLocation,
             fallback: linkedCause?.anatomicalLocation ?? linkedCause?.injuryLocation,
+        )
+        let locationLabel = RuntimeAnatomicalLocationDisplay.label(
+            preferredLabel: problem.anatomicalLocationLabel,
+            rawCode: locationCode
+                ?? problem.anatomicalLocation
+                ?? linkedCause?.anatomicalLocation
+                ?? linkedCause?.injuryLocation,
+            lateralityLabel: problem.lateralityLabel,
+            laterality: problem.laterality,
+            includeLateralityWhenSeparate: true,
         )
         let zone = locationCode.flatMap(injuryZone(for:))
         let id = problem.problemID.map(String.init) ?? problem.primaryLabel

--- a/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/RunSessionStore.swift
@@ -2094,17 +2094,19 @@ public final class RunSessionStore: ObservableObject {
         let label = eventPrimaryLabel(from: event.payload) ?? "Problem"
         let status = ProblemLifecycleState(rawValue: jsonString(event.payload["status"]) ?? "active") ?? .active
         let severity = jsonString(event.payload["severity"])
+        let rawAnatomicalLocation = jsonString(event.payload["anatomical_location"])
+        let rawInjuryLocation = jsonString(event.payload["injury_location"])
         let locationCode = resolvedAnatomicLocationCode(
-            primary: jsonString(event.payload["anatomical_location"]) ?? jsonString(event.payload["injury_location"]),
+            primary: rawAnatomicalLocation ?? rawInjuryLocation,
             fallback: jsonInt(event.payload["cause_id"]).flatMap { causeID in
                 state.causeAnnotations.first(where: { $0.causeID == causeID })?.locationCode
             },
         )
         let locationLabel = RuntimeAnatomicalLocationDisplay.label(
             preferredLabel: jsonString(event.payload["anatomical_location_label"]),
-            rawCode: locationCode
-                ?? jsonString(event.payload["anatomical_location"])
-                ?? jsonString(event.payload["injury_location"]),
+            rawCode: rawAnatomicalLocation ?? locationCode,
+            fallbackRawCode: rawInjuryLocation ?? locationCode,
+            fallbackLabel: jsonString(event.payload["injury_location_label"]),
             lateralityLabel: jsonString(event.payload["laterality_label"]),
             laterality: jsonString(event.payload["laterality"]),
             includeLateralityWhenSeparate: true,
@@ -2637,10 +2639,11 @@ public final class RunSessionStore: ObservableObject {
         )
         let locationLabel = RuntimeAnatomicalLocationDisplay.label(
             preferredLabel: problem.anatomicalLocationLabel,
-            rawCode: locationCode
-                ?? problem.anatomicalLocation
+            rawCode: problem.anatomicalLocation,
+            fallbackRawCode: linkedCause?.injuryLocation
                 ?? linkedCause?.anatomicalLocation
-                ?? linkedCause?.injuryLocation,
+                ?? locationCode,
+            fallbackLabel: linkedCause?.injuryLocationLabel,
             lateralityLabel: problem.lateralityLabel,
             laterality: problem.laterality,
             includeLateralityWhenSeparate: true,

--- a/apps/trainerlab-ios/Sources/SharedModels/RuntimeState.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/RuntimeState.swift
@@ -333,6 +333,77 @@ public enum RuntimeLocationDisplay {
     }
 }
 
+public enum RuntimeAnatomicalLocationDisplay {
+    private static let injuryLocationLabels: [String: String] = [
+        "HLA": "Left Anterior Head",
+        "HRA": "Right Anterior Head",
+        "HLP": "Left Posterior Head",
+        "HRP": "Right Posterior Head",
+        "NLA": "Left Anterior Neck",
+        "NRA": "Right Anterior Neck",
+        "NLP": "Left Posterior Neck",
+        "NRP": "Right Posterior Neck",
+        "LUA": "Left Upper Arm",
+        "LLA": "Left Lower Arm",
+        "LHA": "Left Hand",
+        "RUA": "Right Upper Arm",
+        "RLA": "Right Lower Arm",
+        "RHA": "Right Hand",
+        "TLA": "Left Anterior Chest",
+        "TRA": "Right Anterior Chest",
+        "TLP": "Left Posterior Chest",
+        "TRP": "Right Posterior Chest",
+        "ALA": "Left Anterior Abdomen",
+        "ARA": "Right Anterior Abdomen",
+        "ALP": "Left Posterior Abdomen",
+        "ARP": "Right Posterior Abdomen",
+        "LUL": "Left Upper Leg",
+        "LLL": "Left Lower Leg",
+        "LFT": "Left Foot",
+        "RUL": "Right Upper Leg",
+        "RLL": "Right Lower Leg",
+        "RFT": "Right Foot",
+        "JLX": "Left Junctional Axilla",
+        "JRX": "Right Junctional Axilla",
+        "JLI": "Left Junctional Inguinal",
+        "JRI": "Right Junctional Inguinal",
+        "JLN": "Left Junctional Neck",
+        "JRN": "Right Junctional Neck",
+    ]
+
+    public static func knownLabel(for rawCode: String?) -> String? {
+        guard let raw = RuntimeLocationDisplay.nonEmpty(rawCode) else { return nil }
+        return injuryLocationLabels[raw.uppercased()]
+    }
+
+    public static func label(
+        preferredLabel: String?,
+        rawCode: String?,
+        fallbackLabel: String? = nil,
+        lateralityLabel: String? = nil,
+        laterality: String? = nil,
+        includeLateralityWhenSeparate: Bool = false,
+    ) -> String? {
+        let raw = RuntimeLocationDisplay.nonEmpty(rawCode)
+        let resolved = RuntimeLocationDisplay.nonEmpty(preferredLabel)
+            ?? knownLabel(for: raw)
+            ?? RuntimeLocationDisplay.nonEmpty(fallbackLabel)
+            ?? raw.map(RuntimeLocationDisplay.humanizeLabel)
+
+        let side = RuntimeLocationDisplay.lateralityText(label: lateralityLabel, raw: laterality)
+
+        guard let resolved else { return side }
+        guard
+            includeLateralityWhenSeparate,
+            let side,
+            !RuntimeLocationDisplay.locationContainsLaterality(resolved, side)
+        else {
+            return resolved
+        }
+        return "\(side) \(resolved)"
+    }
+}
+
 public struct RecommendedInterventionItem: Identifiable, Equatable, Sendable {
     public let recommendationID: Int
     public let title: String

--- a/apps/trainerlab-ios/Sources/SharedModels/RuntimeState.swift
+++ b/apps/trainerlab-ios/Sources/SharedModels/RuntimeState.swift
@@ -379,16 +379,20 @@ public enum RuntimeAnatomicalLocationDisplay {
     public static func label(
         preferredLabel: String?,
         rawCode: String?,
+        fallbackRawCode: String? = nil,
         fallbackLabel: String? = nil,
         lateralityLabel: String? = nil,
         laterality: String? = nil,
         includeLateralityWhenSeparate: Bool = false,
     ) -> String? {
         let raw = RuntimeLocationDisplay.nonEmpty(rawCode)
+        let fallbackRaw = RuntimeLocationDisplay.nonEmpty(fallbackRawCode)
         let resolved = RuntimeLocationDisplay.nonEmpty(preferredLabel)
             ?? knownLabel(for: raw)
             ?? RuntimeLocationDisplay.nonEmpty(fallbackLabel)
+            ?? knownLabel(for: fallbackRaw)
             ?? raw.map(RuntimeLocationDisplay.humanizeLabel)
+            ?? fallbackRaw.map(RuntimeLocationDisplay.humanizeLabel)
 
         let side = RuntimeLocationDisplay.lateralityText(label: lateralityLabel, raw: laterality)
 

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -482,6 +482,13 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
     }
 
     @MainActor
+    func testCauseDisplayTitleMapsAnatomicalCodeWithoutBackendLabel() {
+        let cause = makeRuntimeCause(causeID: 11, kind: "gunshot", location: "LLL")
+
+        XCTAssertEqual(PatientDiagramPanel.causeDisplayTitle(cause: cause), "Gunshot — Left Lower Leg")
+    }
+
+    @MainActor
     func testCauseDisplayTitleFallsBackWhenBackendLocationLabelIsEmpty() {
         let cause = makeRuntimeCause(
             causeID: 11,
@@ -535,6 +542,37 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
 
         XCTAssertEqual(PatientDiagramPanel.problemDisplayLocation(problem), "Left Lower Leg")
         XCTAssertEqual(problem.locationCode, "LLL")
+    }
+
+    @MainActor
+    func testProblemDisplayLocationMapsAnatomicalCodeWithoutLocationLabel() {
+        let problem = ProblemAnnotation(
+            id: "problem-1",
+            problemID: 41,
+            title: "Massive hemorrhage",
+            isAnatomic: true,
+            locationCode: "LLL",
+            locationLabel: nil,
+            status: .active,
+        )
+
+        XCTAssertEqual(PatientDiagramPanel.problemDisplayLocation(problem), "Left Lower Leg")
+    }
+
+    @MainActor
+    func testInjuryDisplayTitleMapsAnatomicalCodeWithoutHumanizingRawCode() {
+        let injury = InjuryAnnotation(
+            id: "injury-1",
+            locationCode: "LLL",
+            side: .front,
+            x: 0.42,
+            y: 0.74,
+            kind: "gunshot",
+            summary: "Gunshot wound",
+            status: .active,
+        )
+
+        XCTAssertEqual(PatientDiagramPanel.injuryDisplayTitle(injury: injury), "Gunshot — Left Lower Leg")
     }
 
     @MainActor

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -489,6 +489,18 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
     }
 
     @MainActor
+    func testCauseDisplayTitleUsesInjuryLocationCodeWhenAnatomicalLocationIsCoarse() {
+        let cause = makeRuntimeCause(
+            causeID: 11,
+            kind: "gunshot",
+            location: "leg",
+            injuryLocation: "LLL",
+        )
+
+        XCTAssertEqual(PatientDiagramPanel.causeDisplayTitle(cause: cause), "Gunshot — Left Lower Leg")
+    }
+
+    @MainActor
     func testCauseDisplayTitleFallsBackWhenBackendLocationLabelIsEmpty() {
         let cause = makeRuntimeCause(
             causeID: 11,
@@ -1041,6 +1053,8 @@ private func makeRuntimeCause(
     kind: String,
     location: String,
     locationLabel: String? = nil,
+    injuryLocation: String? = nil,
+    injuryLocationLabel: String? = nil,
     laterality: String? = nil,
     lateralityLabel: String? = nil,
 ) -> RuntimeCauseState {
@@ -1051,6 +1065,12 @@ private func makeRuntimeCause(
     ]
     if let locationLabel {
         fields.append("\"anatomical_location_label\": \"\(locationLabel)\"")
+    }
+    if let injuryLocation {
+        fields.append("\"injury_location\": \"\(injuryLocation)\"")
+    }
+    if let injuryLocationLabel {
+        fields.append("\"injury_location_label\": \"\(injuryLocationLabel)\"")
     }
     if let laterality {
         fields.append("\"laterality\": \"\(laterality)\"")

--- a/apps/trainerlab-ios/Tests/SharedModelsTests/RuntimePayloadLabelDecodingTests.swift
+++ b/apps/trainerlab-ios/Tests/SharedModelsTests/RuntimePayloadLabelDecodingTests.swift
@@ -74,6 +74,51 @@ final class RuntimePayloadLabelDecodingTests: XCTestCase {
         )
     }
 
+    func testRuntimeAnatomicalLocationDisplayMapsKnownInjuryCodes() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(preferredLabel: nil, rawCode: "LLL"),
+            "Left Lower Leg",
+        )
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(preferredLabel: nil, rawCode: "TLA"),
+            "Left Anterior Chest",
+        )
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(preferredLabel: nil, rawCode: "JRN"),
+            "Right Junctional Neck",
+        )
+    }
+
+    func testRuntimeAnatomicalLocationDisplayNormalizesRawCodes() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(preferredLabel: nil, rawCode: "  lll  "),
+            "Left Lower Leg",
+        )
+    }
+
+    func testRuntimeAnatomicalLocationDisplayPrefersBackendLabel() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(
+                preferredLabel: "Provider Supplied Location",
+                rawCode: "LLL",
+            ),
+            "Provider Supplied Location",
+        )
+    }
+
+    func testRuntimeAnatomicalLocationDisplayDoesNotDuplicateLaterality() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(
+                preferredLabel: nil,
+                rawCode: "LLL",
+                lateralityLabel: "Left",
+                laterality: "left",
+                includeLateralityWhenSeparate: true,
+            ),
+            "Left Lower Leg",
+        )
+    }
+
     func testRuntimeProblemStateDecodesAnatomyAndLateralityLabels() throws {
         let json = """
         {

--- a/apps/trainerlab-ios/Tests/SharedModelsTests/RuntimePayloadLabelDecodingTests.swift
+++ b/apps/trainerlab-ios/Tests/SharedModelsTests/RuntimePayloadLabelDecodingTests.swift
@@ -119,6 +119,40 @@ final class RuntimePayloadLabelDecodingTests: XCTestCase {
         )
     }
 
+    func testRuntimeAnatomicalLocationDisplayUsesFallbackKnownCodeBeforeHumanizingRawLocation() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(
+                preferredLabel: nil,
+                rawCode: "leg",
+                fallbackRawCode: "LLL",
+            ),
+            "Left Lower Leg",
+        )
+    }
+
+    func testRuntimeAnatomicalLocationDisplayPrefersBackendLabelOverFallbackKnownCode() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(
+                preferredLabel: "Provider Supplied Leg",
+                rawCode: "leg",
+                fallbackRawCode: "LLL",
+            ),
+            "Provider Supplied Leg",
+        )
+    }
+
+    func testRuntimeAnatomicalLocationDisplayUsesFallbackLabelBeforeFallbackKnownCode() {
+        XCTAssertEqual(
+            RuntimeAnatomicalLocationDisplay.label(
+                preferredLabel: nil,
+                rawCode: "leg",
+                fallbackRawCode: "LLL",
+                fallbackLabel: "Backend Injury Location",
+            ),
+            "Backend Injury Location",
+        )
+    }
+
     func testRuntimeProblemStateDecodesAnatomyAndLateralityLabels() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary
- Add a shared anatomical location resolver for TrainerLab injury codes.
- Route PatientDiagramPanel injury/problem/cause display through the shared resolver so codes like `LLL` render as `Left Lower Leg` instead of generic title-cased text.
- Update session projection so live and snapshot problem annotations preserve backend labels and resolve raw anatomical codes consistently.
- Add regression coverage for known codes, normalization, and the PatientDiagramPanel fallback paths.

## Testing
- `swift test --package-path apps/trainerlab-ios --filter SharedModelsTests`
- `swift test --package-path apps/trainerlab-ios --filter RunConsoleLayoutSupportTests`