### PR TITLE
feat(ui): adopt Liquid Glass across core surfaces

### DIFF
--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeView.swift
@@ -96,18 +96,21 @@ public struct ChatLabHomeView: View {
                     Button("Search") {
                         Task { await store.search() }
                     }
-                    .buttonStyle(.bordered)
+                    .trainerGlassButtonStyle()
 
                     Button("New Simulation") {
                         showCreateSheet = true
                     }
-                    .buttonStyle(.borderedProminent)
+                    .trainerGlassButtonStyle(prominent: true)
                 }
                 .frame(minWidth: 180)
             }
             .padding(20)
-            .background(chatHomeSystemBackgroundColor())
-            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .trainerGlassSurface(
+                role: .setupCard,
+                cornerRadius: 20,
+                tint: Color.accentColor.opacity(0.06),
+            )
             .shadow(color: Color.primary.opacity(0.04), radius: 18, y: 8)
 
         case .phone:

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -169,34 +169,74 @@ public struct ChatRunView: View {
                 // so content scrolls behind the translucent overlays (Messages-style).
                 messageTimeline(layoutMode: layoutMode, chromeMode: chromeMode)
                     .safeAreaInset(edge: .top, spacing: 0) {
-                        VStack(spacing: 0) {
-                            overlayHeader(layoutMode: layoutMode)
-                            if chromeMode == .standard {
-                                compactFailureBanners
+                        compactGlassChrome(cornerRadius: 24, tint: Color.blue.opacity(0.05)) {
+                            VStack(spacing: 0) {
+                                overlayHeader(layoutMode: layoutMode)
+                                if chromeMode == .standard {
+                                    compactFailureBanners
+                                }
+                                if store.conversations.count > 1 {
+                                    conversationTabs(layoutMode: layoutMode)
+                                        .padding(.top, 4)
+                                        .padding(.bottom, 4)
+                                }
+                                Divider()
+                                    .overlay(Color.secondary.opacity(0.18))
                             }
-                            if store.conversations.count > 1 {
-                                conversationTabs(layoutMode: layoutMode)
-                                    .padding(.top, 4)
-                                    .padding(.bottom, 4)
-                            }
-                            Divider()
-                                .overlay(Color.secondary.opacity(0.18))
                         }
-                        .background(.ultraThinMaterial)
+                        .padding(.horizontal, 8)
+                        .padding(.top, 4)
                     }
                     .safeAreaInset(edge: .bottom, spacing: 0) {
-                        VStack(spacing: 6) {
-                            awaitingReplyWarning(horizontalPadding: horizontalInset(for: layoutMode))
-                            typingIndicator(horizontalPadding: horizontalInset(for: layoutMode))
-                            composer(layoutMode: layoutMode)
+                        compactGlassChrome(cornerRadius: 24, tint: Color.blue.opacity(0.05)) {
+                            VStack(spacing: 6) {
+                                awaitingReplyWarning(horizontalPadding: horizontalInset(for: layoutMode))
+                                typingIndicator(horizontalPadding: horizontalInset(for: layoutMode))
+                                composer(layoutMode: layoutMode)
+                            }
+                            .padding(.horizontal, horizontalInset(for: layoutMode))
+                            .padding(.top, 8)
+                            .padding(.bottom, 8)
                         }
-                        .padding(.horizontal, horizontalInset(for: layoutMode))
-                        .padding(.top, 8)
-                        .padding(.bottom, 8)
-                        .background(.ultraThinMaterial)
+                        .padding(.horizontal, 8)
+                        .padding(.bottom, 4)
                     }
             }
         }
+    }
+
+    @ViewBuilder
+    private func compactGlassChrome<Content: View>(
+        cornerRadius: CGFloat,
+        tint: Color?,
+        @ViewBuilder content: () -> Content,
+    ) -> some View {
+        #if os(iOS)
+            if #available(iOS 26.0, *) {
+                GlassEffectContainer(spacing: 18) {
+                    content()
+                        .trainerGlassSurface(
+                            role: .floatingOverlay,
+                            cornerRadius: cornerRadius,
+                            tint: tint,
+                        )
+                }
+            } else {
+                content()
+                    .trainerGlassSurface(
+                        role: .floatingOverlay,
+                        cornerRadius: cornerRadius,
+                        tint: tint,
+                    )
+            }
+        #else
+            content()
+                .trainerGlassSurface(
+                    role: .floatingOverlay,
+                    cornerRadius: cornerRadius,
+                    tint: tint,
+                )
+        #endif
     }
 
     @ViewBuilder
@@ -421,7 +461,7 @@ public struct ChatRunView: View {
         Button(action: onBack) {
             Label("Back", systemImage: "chevron.left")
         }
-        .buttonStyle(.bordered)
+        .trainerGlassButtonStyle()
     }
 
     private var patientIdentityHeader: some View {
@@ -462,7 +502,7 @@ public struct ChatRunView: View {
                 Button("End Simulation") {
                     store.endSimulation()
                 }
-                .buttonStyle(.borderedProminent)
+                .trainerGlassButtonStyle(prominent: true)
                 .tint(.red)
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
@@ -471,7 +511,7 @@ public struct ChatRunView: View {
             Button("Send Feedback") {
                 activeFeedbackContext = feedbackLaunchContext()
             }
-            .buttonStyle(.bordered)
+            .trainerGlassButtonStyle()
         }
     }
 

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -188,28 +188,35 @@ public struct ChatRunView: View {
                         .padding(.top, 4)
                     }
                     .safeAreaInset(edge: .bottom, spacing: 0) {
-                        compactGlassChrome(cornerRadius: 24, tint: Color.blue.opacity(0.05)) {
-                            VStack(spacing: 6) {
-                                awaitingReplyWarning(horizontalPadding: horizontalInset(for: layoutMode))
-                                typingIndicator(horizontalPadding: horizontalInset(for: layoutMode))
-                                composer(layoutMode: layoutMode)
+                        ZStack {
+                            Rectangle()
+                                .fill(.ultraThinMaterial)
+                                .opacity(0.35)
+                                .ignoresSafeArea(edges: .bottom)
+
+                            compactGlassChrome(cornerRadius: 24, tint: Color.blue.opacity(0.05)) {
+                                VStack(spacing: 6) {
+                                    awaitingReplyWarning(horizontalPadding: horizontalInset(for: layoutMode))
+                                    typingIndicator(horizontalPadding: horizontalInset(for: layoutMode))
+                                    composer(layoutMode: layoutMode)
+                                }
+                                .padding(.horizontal, horizontalInset(for: layoutMode))
+                                .padding(.top, 8)
+                                .padding(.bottom, 8)
                             }
-                            .padding(.horizontal, horizontalInset(for: layoutMode))
-                            .padding(.top, 8)
-                            .padding(.bottom, 8)
+                            .padding(.horizontal, 8)
+                            .padding(.bottom, 4)
                         }
-                        .padding(.horizontal, 8)
-                        .padding(.bottom, 4)
                     }
             }
         }
     }
 
     @ViewBuilder
-    private func compactGlassChrome<Content: View>(
+    private func compactGlassChrome(
         cornerRadius: CGFloat,
         tint: Color?,
-        @ViewBuilder content: () -> Content,
+        @ViewBuilder content: () -> some View,
     ) -> some View {
         #if os(iOS)
             if #available(iOS 26.0, *) {

--- a/apps/medsim-shell-ios/Package.swift
+++ b/apps/medsim-shell-ios/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
                 .product(name: "RunConsole", package: "trainerlab-ios"),
                 .product(name: "Summary", package: "trainerlab-ios"),
                 .product(name: "FeedbackFeature", package: "trainerlab-ios"),
+                .product(name: "DesignSystem", package: "trainerlab-ios"),
                 .product(name: "Networking", package: "trainerlab-ios"),
                 .product(name: "Realtime", package: "trainerlab-ios"),
                 .product(name: "Persistence", package: "trainerlab-ios"),

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellRootView.swift
@@ -345,8 +345,11 @@ private struct MainMenuView: View {
                 }
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
-                .background(Color.secondary.opacity(0.08))
-                .clipShape(Capsule())
+                .trainerGlassSurface(
+                    role: .chip,
+                    cornerRadius: 999,
+                    tint: TrainerLabTheme.accentBlue.opacity(0.08),
+                )
 
                 VStack(spacing: 12) {
                     menuButton(
@@ -374,10 +377,10 @@ private struct MainMenuView: View {
                 .padding(.top, 8)
 
                 Button("Account & Billing", action: onOpenAccountBilling)
-                    .buttonStyle(.borderedProminent)
+                    .trainerGlassButtonStyle(prominent: true)
 
                 Button("Send Feedback", action: onOpenFeedback)
-                    .buttonStyle(.bordered)
+                    .trainerGlassButtonStyle()
 
                 if let accessMessage, !accessMessage.isEmpty {
                     Text(accessMessage)
@@ -387,7 +390,7 @@ private struct MainMenuView: View {
                 }
 
                 Button("Sign Out", action: onSignOut)
-                    .buttonStyle(.bordered)
+                    .trainerGlassButtonStyle()
 
                 Spacer()
             }
@@ -405,8 +408,11 @@ private struct MainMenuView: View {
                 Image(systemName: content.systemImage)
                     .font(.title2.weight(.semibold))
                     .frame(width: 42, height: 42)
-                    .background(TrainerLabTheme.accentBlue.opacity(0.12))
-                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .trainerGlassSurface(
+                        role: .chip,
+                        cornerRadius: 12,
+                        tint: TrainerLabTheme.accentBlue.opacity(0.16),
+                    )
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(content.title)
@@ -429,8 +435,12 @@ private struct MainMenuView: View {
             }
             .padding(16)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.secondary.opacity(0.08))
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .trainerGlassSurface(
+                role: .setupCard,
+                cornerRadius: 18,
+                interactive: content.isEnabled,
+                tint: TrainerLabTheme.accentBlue.opacity(content.isEnabled ? 0.08 : 0.03),
+            )
         }
         .buttonStyle(.plain)
         .disabled(!content.isEnabled)

--- a/apps/trainerlab-ios/Sources/DesignSystem/Theme.swift
+++ b/apps/trainerlab-ios/Sources/DesignSystem/Theme.swift
@@ -45,14 +45,185 @@ public enum TrainerLabTheme {
     public static let avpuUnalert = Color.primary
 }
 
+public enum TrainerLabSurfaceRole: Equatable {
+    case setupCard
+    case tacticalPanel
+    case floatingOverlay
+    case chip
+
+    var fallbackBackground: Color {
+        switch self {
+        case .setupCard:
+            TrainerLabTheme.setupSurface
+        case .tacticalPanel:
+            TrainerLabTheme.tacticalSurfaceElevated
+        case .floatingOverlay:
+            TrainerLabTheme.setupSurface.opacity(0.86)
+        case .chip:
+            Color.secondary.opacity(0.08)
+        }
+    }
+
+    var strokeColor: Color {
+        switch self {
+        case .setupCard:
+            Color.primary.opacity(0.08)
+        case .tacticalPanel:
+            TrainerLabTheme.tacticalBorder
+        case .floatingOverlay:
+            Color.primary.opacity(0.10)
+        case .chip:
+            Color.primary.opacity(0.07)
+        }
+    }
+}
+
 public extension View {
-    func trainerCardStyle(background: Color = TrainerLabTheme.tacticalSurface) -> some View {
-        padding(12)
-            .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    func trainerGlassSurface(
+        role: TrainerLabSurfaceRole,
+        cornerRadius: CGFloat = 14,
+        interactive: Bool = false,
+        tint: Color? = nil,
+    ) -> some View {
+        modifier(
+            TrainerLabGlassSurfaceModifier(
+                role: role,
+                cornerRadius: cornerRadius,
+                interactive: interactive,
+                tint: tint,
+            ),
+        )
+    }
+
+    func trainerCardStyle(
+        background: Color = TrainerLabTheme.tacticalSurface,
+        glassRole: TrainerLabSurfaceRole? = nil,
+        cornerRadius: CGFloat = 14,
+        interactive: Bool = false,
+        tint: Color? = nil,
+    ) -> some View {
+        modifier(
+            TrainerLabCardStyleModifier(
+                background: background,
+                glassRole: glassRole,
+                cornerRadius: cornerRadius,
+                interactive: interactive,
+                tint: tint,
+            ),
+        )
+    }
+
+    @ViewBuilder
+    func trainerGlassButtonStyle(prominent: Bool = false) -> some View {
+        #if os(iOS)
+            if #available(iOS 26.0, *) {
+                if prominent {
+                    buttonStyle(.glassProminent)
+                } else {
+                    buttonStyle(.glass)
+                }
+            } else if prominent {
+                buttonStyle(.borderedProminent)
+            } else {
+                buttonStyle(.bordered)
+            }
+        #else
+            if prominent {
+                buttonStyle(.borderedProminent)
+            } else {
+                buttonStyle(.bordered)
+            }
+        #endif
+    }
+}
+
+private struct TrainerLabCardStyleModifier: ViewModifier {
+    let background: Color
+    let glassRole: TrainerLabSurfaceRole?
+    let cornerRadius: CGFloat
+    let interactive: Bool
+    let tint: Color?
+
+    func body(content: Content) -> some View {
+        let paddedContent = content.padding(12)
+
+        if let glassRole {
+            paddedContent
+                .trainerGlassSurface(
+                    role: glassRole,
+                    cornerRadius: cornerRadius,
+                    interactive: interactive,
+                    tint: tint,
+                )
+        } else {
+            paddedContent
+                .background(background)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
+                )
+        }
+    }
+}
+
+private struct TrainerLabGlassSurfaceModifier: ViewModifier {
+    let role: TrainerLabSurfaceRole
+    let cornerRadius: CGFloat
+    let interactive: Bool
+    let tint: Color?
+
+    func body(content: Content) -> some View {
+        glassSurface(content)
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(role.strokeColor, lineWidth: 1),
             )
     }
+
+    @ViewBuilder
+    private func glassSurface(_ content: Content) -> some View {
+        #if os(iOS)
+            if #available(iOS 26.0, *) {
+                content
+                    .glassEffect(
+                        glassConfiguration,
+                        in: .rect(cornerRadius: cornerRadius),
+                    )
+            } else {
+                fallbackSurface(content)
+            }
+        #else
+            fallbackSurface(content)
+        #endif
+    }
+
+    private func fallbackSurface(_ content: Content) -> some View {
+        content
+            .background(fallbackBackground)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    }
+
+    private var fallbackBackground: AnyShapeStyle {
+        switch role {
+        case .floatingOverlay:
+            return AnyShapeStyle(.regularMaterial)
+        default:
+            return AnyShapeStyle(role.fallbackBackground)
+        }
+    }
+
+    #if os(iOS)
+        @available(iOS 26.0, *)
+        private var glassConfiguration: Glass {
+            var glass = Glass.regular
+            if let tint {
+                glass = glass.tint(tint)
+            }
+            if interactive {
+                glass = glass.interactive()
+            }
+            return glass
+        }
+    #endif
 }

--- a/apps/trainerlab-ios/Sources/DesignSystem/Theme.swift
+++ b/apps/trainerlab-ios/Sources/DesignSystem/Theme.swift
@@ -207,9 +207,9 @@ private struct TrainerLabGlassSurfaceModifier: ViewModifier {
     private var fallbackBackground: AnyShapeStyle {
         switch role {
         case .floatingOverlay:
-            return AnyShapeStyle(.regularMaterial)
+            AnyShapeStyle(.regularMaterial)
         default:
-            return AnyShapeStyle(role.fallbackBackground)
+            AnyShapeStyle(role.fallbackBackground)
         }
     }
 

--- a/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackSuccessBanner.swift
+++ b/apps/trainerlab-ios/Sources/FeedbackFeature/FeedbackSuccessBanner.swift
@@ -1,3 +1,4 @@
+import DesignSystem
 import SwiftUI
 
 public struct FeedbackSuccessBanner: View {
@@ -20,12 +21,11 @@ public struct FeedbackSuccessBanner: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-        .background(.regularMaterial)
-        .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.green.opacity(0.28), lineWidth: 1),
+        .trainerGlassSurface(
+            role: .floatingOverlay,
+            cornerRadius: 14,
+            tint: Color.green.opacity(0.14),
         )
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .shadow(color: Color.black.opacity(0.08), radius: 10, y: 4)
     }
 }

--- a/apps/trainerlab-ios/Sources/Presets/PresetsLibraryView.swift
+++ b/apps/trainerlab-ios/Sources/Presets/PresetsLibraryView.swift
@@ -139,7 +139,7 @@ public struct PresetsLibraryView: View {
                 Button("Refresh") {
                     Task { await viewModel.loadPresets() }
                 }
-                .buttonStyle(.bordered)
+                .trainerGlassButtonStyle()
             }
 
             if showRefreshCard {
@@ -175,8 +175,7 @@ public struct PresetsLibraryView: View {
                     }
                     .padding(14)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(TrainerLabTheme.setupSurface)
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .presetSidebarSurface(isSelected: true)
                 }
                 .buttonStyle(.plain)
 
@@ -199,12 +198,7 @@ public struct PresetsLibraryView: View {
                         }
                         .padding(14)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(selectedPresetID == preset.id ? TrainerLabTheme.setupSurface : TrainerLabTheme.setupSurface.opacity(0.55))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .stroke(selectedPresetID == preset.id ? TrainerLabTheme.accentBlue : Color.clear, lineWidth: 2),
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        .presetSidebarSurface(isSelected: selectedPresetID == preset.id)
                     }
                     .buttonStyle(.plain)
                 }
@@ -383,7 +377,11 @@ public struct PresetsLibraryView: View {
             }
         }
         .padding(18)
-        .trainerCardStyle(background: TrainerLabTheme.setupSurface)
+        .trainerCardStyle(
+            background: TrainerLabTheme.setupSurface,
+            glassRole: .setupCard,
+            tint: TrainerLabTheme.accentBlue.opacity(0.05),
+        )
     }
 
     private func shareManager(preset: ScenarioInstruction, layoutMode _: PresetsLayoutMode) -> some View {
@@ -433,7 +431,7 @@ public struct PresetsLibraryView: View {
             }
         }
         .padding(18)
-        .trainerCardStyle(background: TrainerLabTheme.setupSurface)
+        .trainerCardStyle(background: TrainerLabTheme.setupSurface, glassRole: .setupCard)
     }
 
     private func presetShareSheet(preset: ScenarioInstruction) -> some View {
@@ -546,6 +544,27 @@ public struct PresetsLibraryView: View {
             } else {
                 resetDraftForNewPreset()
             }
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func presetSidebarSurface(isSelected: Bool) -> some View {
+        if isSelected {
+            trainerGlassSurface(
+                role: .setupCard,
+                cornerRadius: 16,
+                interactive: true,
+                tint: TrainerLabTheme.accentBlue.opacity(0.08),
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(TrainerLabTheme.accentBlue, lineWidth: 2),
+            )
+        } else {
+            background(TrainerLabTheme.setupSurface.opacity(0.55))
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         }
     }
 }

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -361,8 +361,11 @@ public struct RunConsoleView: View {
             }
         }
         .padding(10)
-        .background(TrainerLabTheme.tacticalSurfaceElevated)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .trainerGlassSurface(
+            role: .tacticalPanel,
+            cornerRadius: 12,
+            tint: TrainerLabTheme.accentBlue.opacity(0.05),
+        )
     }
 
     private func compactCommandPanel(
@@ -382,6 +385,7 @@ public struct RunConsoleView: View {
             RunConsoleCardModifier(
                 background: TrainerLabTheme.tacticalSurfaceElevated,
                 padding: compactMetrics.cardPadding,
+                glassRole: .tacticalPanel,
             ),
         )
     }
@@ -1519,7 +1523,7 @@ public struct RunConsoleView: View {
                     Button("Retry Simulation") {
                         store.retryInitialSimulation()
                     }
-                    .buttonStyle(.borderedProminent)
+                    .trainerGlassButtonStyle(prominent: true)
                     .frame(maxWidth: .infinity)
                 } else if card.status == .failed {
                     Text("Retry unavailable for this failure.")
@@ -1531,12 +1535,15 @@ public struct RunConsoleView: View {
                 Button("View Run Summary") {
                     onOpenSummary()
                 }
-                .buttonStyle(.borderedProminent)
+                .trainerGlassButtonStyle(prominent: true)
                 .frame(maxWidth: .infinity)
             }
             .padding(18)
-            .background(TrainerLabTheme.tacticalSurfaceElevated)
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .trainerGlassSurface(
+                role: .tacticalPanel,
+                cornerRadius: 18,
+                tint: terminalCardColor(card.status).opacity(0.12),
+            )
             .overlay(
                 RoundedRectangle(cornerRadius: 18, style: .continuous)
                     .stroke(terminalCardColor(card.status).opacity(0.4), lineWidth: 1),
@@ -2361,13 +2368,13 @@ public struct RunConsoleView: View {
 
         if case .exit = control {
             button
-                .buttonStyle(.bordered)
+                .trainerGlassButtonStyle()
                 .controlSize(compact ? compactMetrics.buttonControlSize : .regular)
                 .disabled(!controlEnabled(control))
                 .accessibilityLabel(control.title)
         } else {
             button
-                .buttonStyle(.borderedProminent)
+                .trainerGlassButtonStyle(prominent: true)
                 .controlSize(compact ? compactMetrics.buttonControlSize : .regular)
                 .disabled(!controlEnabled(control))
                 .accessibilityLabel(control.title)
@@ -2394,7 +2401,7 @@ public struct RunConsoleView: View {
                 .frame(maxWidth: .infinity)
                 .frame(minHeight: compactMetrics.buttonMinHeight)
         }
-        .buttonStyle(.borderedProminent)
+        .trainerGlassButtonStyle(prominent: true)
         .controlSize(compactMetrics.buttonControlSize)
     }
 
@@ -2715,16 +2722,27 @@ private struct InjuryQuickActionSheet: View {
 private struct RunConsoleCardModifier: ViewModifier {
     let background: Color
     let padding: CGFloat
+    var glassRole: TrainerLabSurfaceRole? = nil
 
     func body(content: Content) -> some View {
-        content
-            .padding(padding)
-            .background(background)
-            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
-            )
+        let paddedContent = content.padding(padding)
+
+        if let glassRole {
+            paddedContent
+                .trainerGlassSurface(
+                    role: glassRole,
+                    cornerRadius: 14,
+                    tint: TrainerLabTheme.accentBlue.opacity(0.05),
+                )
+        } else {
+            paddedContent
+                .background(background)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(TrainerLabTheme.tacticalBorder, lineWidth: 1),
+                )
+        }
     }
 }
 

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -2722,7 +2722,7 @@ private struct InjuryQuickActionSheet: View {
 private struct RunConsoleCardModifier: ViewModifier {
     let background: Color
     let padding: CGFloat
-    var glassRole: TrainerLabSurfaceRole? = nil
+    var glassRole: TrainerLabSurfaceRole?
 
     func body(content: Content) -> some View {
         let paddedContent = content.padding(padding)

--- a/apps/trainerlab-ios/Sources/Sessions/SessionHubView.swift
+++ b/apps/trainerlab-ios/Sources/Sessions/SessionHubView.swift
@@ -82,15 +82,19 @@ public struct SessionHubView: View {
 
                 HStack(spacing: 12) {
                     Button("Presets Library", action: onOpenPresets)
-                        .buttonStyle(.bordered)
+                        .trainerGlassButtonStyle()
                     Button("Create Session") {
                         Task { await viewModel.createSession() }
                     }
-                    .buttonStyle(.borderedProminent)
+                    .trainerGlassButtonStyle(prominent: true)
                 }
             }
             .padding(20)
-            .trainerCardStyle(background: TrainerLabTheme.setupSurface)
+            .trainerCardStyle(
+                background: TrainerLabTheme.setupSurface,
+                glassRole: .setupCard,
+                tint: TrainerLabTheme.accentBlue.opacity(0.06),
+            )
 
         case .phone:
             VStack(alignment: .leading, spacing: 10) {

--- a/apps/trainerlab-ios/Sources/Summary/RunSummaryView.swift
+++ b/apps/trainerlab-ios/Sources/Summary/RunSummaryView.swift
@@ -44,7 +44,7 @@ public struct RunSummaryView: View {
                             Button("Send Feedback") {
                                 activeFeedbackContext = feedbackLaunchContext()
                             }
-                            .buttonStyle(.bordered)
+                            .trainerGlassButtonStyle()
                         }
                     }
 
@@ -166,7 +166,11 @@ public struct RunSummaryView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(14)
-                .trainerCardStyle(background: TrainerLabTheme.setupSurface)
+                .trainerCardStyle(
+                    background: TrainerLabTheme.setupSurface,
+                    glassRole: .setupCard,
+                    tint: item.tint.opacity(0.08),
+                )
             }
         }
     }
@@ -198,7 +202,7 @@ public struct RunSummaryView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .trainerCardStyle(background: TrainerLabTheme.setupSurface)
+        .trainerCardStyle(background: TrainerLabTheme.setupSurface, glassRole: .setupCard)
     }
 
     private func sectionCard(
@@ -225,7 +229,7 @@ public struct RunSummaryView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .trainerCardStyle(background: TrainerLabTheme.setupSurface)
+        .trainerCardStyle(background: TrainerLabTheme.setupSurface, glassRole: .setupCard)
     }
 
     private func timelineContent(_ summary: RunSummary) -> some View {


### PR DESCRIPTION
## Summary
- Add a shared DesignSystem Liquid Glass layer with availability-aware fallbacks and reusable glass button/surface helpers.
- Apply glass selectively to high-value chrome and launch surfaces in AppShell, ChatLab, SessionHub, Presets, Summary, Feedback, and RunConsole.
- Keep dense tactical/data surfaces opaque to preserve scanning clarity and contrast.

## Testing
- `swift build --package-path apps/trainerlab-ios`
- `swift build --package-path apps/chatlab-ios`
- `xcodebuild build -project MedSim.xcodeproj -scheme MedSim -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5),OS=26.4.1'`