### PR TITLE
feat(chatlab): hydrate modifiers from backend config API

### DIFF
--- a/MedSim/MedSimApp.swift
+++ b/MedSim/MedSimApp.swift
@@ -493,8 +493,22 @@ private struct ReadmeDemoChatService: ChatLabServiceProtocol {
         fatalError("Readme demo does not call submitLabOrders().")
     }
 
-    func listModifierGroups(groups _: [String]?) async throws -> [ModifierGroup] {
-        []
+    func listModifierGroups(labType _: String) async throws -> [ModifierGroup] {
+        [
+            ModifierGroup(
+                key: "clinical_scenario",
+                label: "Clinical Scenario",
+                description: "Type of clinical encounter",
+                selection: ModifierSelectionConfig(mode: .single, required: false),
+                modifiers: [
+                    ModifierOption(
+                        key: "respiratory",
+                        label: "Respiratory",
+                        description: "Respiratory issue",
+                    ),
+                ],
+            ),
+        ]
     }
 
     func getGuardState(simulationID _: Int) async throws -> GuardStateDTO {

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
@@ -627,13 +627,51 @@ public struct ChatLabOrdersResponse: Codable, Sendable, Equatable {
     }
 }
 
+public enum ModifierSelectionMode: String, Codable, Sendable, Equatable {
+    case single
+    case multiple
+}
+
+public struct ModifierSelectionConfig: Codable, Sendable, Equatable {
+    public let mode: ModifierSelectionMode
+    public let required: Bool
+
+    public init(mode: ModifierSelectionMode, required: Bool) {
+        self.mode = mode
+        self.required = required
+    }
+}
+
 public struct ModifierGroup: Codable, Sendable, Equatable {
-    public let group: String
+    public let key: String
+    public let label: String
     public let description: String
+    public let selection: ModifierSelectionConfig
     public let modifiers: [ModifierOption]
+
+    public init(
+        key: String,
+        label: String,
+        description: String,
+        selection: ModifierSelectionConfig,
+        modifiers: [ModifierOption],
+    ) {
+        self.key = key
+        self.label = label
+        self.description = description
+        self.selection = selection
+        self.modifiers = modifiers
+    }
 }
 
 public struct ModifierOption: Codable, Sendable, Equatable {
     public let key: String
+    public let label: String
     public let description: String
+
+    public init(key: String, label: String, description: String) {
+        self.key = key
+        self.label = label
+        self.description = description
+    }
 }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeStore.swift
@@ -12,7 +12,10 @@ public final class ChatLabHomeStore: ObservableObject {
     @Published public var searchQuery = ""
     @Published public var includeMessageSearch = false
     @Published public private(set) var modifierGroups: [ModifierGroup] = []
-    @Published public var selectedModifiers = Set<String>()
+    @Published public private(set) var isLoadingModifierGroups = false
+    @Published public private(set) var modifierLoadError: PresentableAppError?
+    @Published public private(set) var modifierValidationErrors: [String] = []
+    @Published public var selectedModifiersByGroup: [String: Set<String>] = [:]
 
     private let service: ChatLabServiceProtocol
     private var nextCursor: String?
@@ -25,6 +28,10 @@ public final class ChatLabHomeStore: ObservableObject {
 
     public var errorMessage: String? {
         presentableError?.message
+    }
+
+    public var selectedModifiers: Set<String> {
+        Set(flattenSelectedModifierKeys())
     }
 
     deinit {
@@ -97,35 +104,85 @@ public final class ChatLabHomeStore: ObservableObject {
         await loadInitial()
     }
 
-    public func loadModifierGroups() async {
+    public func loadModifierGroups(labType: String = "chatlab") async {
+        isLoadingModifierGroups = true
+        modifierLoadError = nil
+        defer { isLoadingModifierGroups = false }
+
         do {
-            modifierGroups = try await service.listModifierGroups(groups: ["ClinicalScenario", "ClinicalDuration"])
+            modifierGroups = try await service.listModifierGroups(labType: labType)
+            pruneStaleSelectedModifiers()
         } catch {
-            presentableError = AppErrorPresenter.present(error)
+            modifierLoadError = AppErrorPresenter.present(error)
         }
     }
 
-    public func toggleModifier(_ modifier: String) {
-        if selectedModifiers.contains(modifier) {
-            selectedModifiers.remove(modifier)
+    public func selectSingleModifier(_ modifier: String?, in group: ModifierGroup) {
+        modifierValidationErrors = []
+        if let modifier, !modifier.isEmpty {
+            selectedModifiersByGroup[group.key] = [modifier]
         } else {
-            selectedModifiers.insert(modifier)
+            selectedModifiersByGroup[group.key] = []
         }
+    }
+
+    public func toggleMultipleModifier(_ modifier: String, in group: ModifierGroup) {
+        modifierValidationErrors = []
+        var selected = selectedModifiersByGroup[group.key] ?? []
+        if selected.contains(modifier) {
+            selected.remove(modifier)
+        } else {
+            selected.insert(modifier)
+        }
+        selectedModifiersByGroup[group.key] = selected
+    }
+
+    public func isModifierSelected(_ modifier: String, in group: ModifierGroup) -> Bool {
+        selectedModifiersByGroup[group.key]?.contains(modifier) ?? false
+    }
+
+    public func singleSelection(in group: ModifierGroup) -> String? {
+        let selected = selectedModifiersByGroup[group.key] ?? []
+        return group.modifiers.first { selected.contains($0.key) }?.key
+    }
+
+    public func flattenSelectedModifierKeys() -> [String] {
+        Self.flattenSelectedModifierKeys(groups: modifierGroups, selected: selectedModifiersByGroup)
+    }
+
+    public func validateModifierSelections() -> [String] {
+        Self.validateModifierSelections(groups: modifierGroups, selected: selectedModifiersByGroup)
     }
 
     public func quickCreateSimulation() async -> ChatSimulation? {
         isCreating = true
         presentableError = nil
+        modifierValidationErrors = []
         defer { isCreating = false }
+
+        let validationErrors = validateModifierSelections()
+        guard validationErrors.isEmpty else {
+            modifierValidationErrors = validationErrors
+            return nil
+        }
 
         do {
             let created = try await service.quickCreateSimulation(
-                request: ChatQuickCreateRequest(modifiers: selectedModifiers.sorted()),
+                request: ChatQuickCreateRequest(modifiers: flattenSelectedModifierKeys()),
             )
             simulations.insert(created, at: 0)
             return created
         } catch {
-            presentableError = AppErrorPresenter.present(error)
+            if Self.isInvalidModifierSelectionError(error) {
+                presentableError = PresentableAppError(
+                    title: "Invalid Modifier Selection",
+                    message: "Invalid modifier selection. Refresh and try again.",
+                    statusCode: 400,
+                    recoveryActionLabel: "Retry",
+                )
+            } else {
+                presentableError = AppErrorPresenter.present(error)
+            }
             return nil
         }
     }
@@ -144,5 +201,83 @@ public final class ChatLabHomeStore: ObservableObject {
     public func stopAutoRefresh() {
         autoRefreshTask?.cancel()
         autoRefreshTask = nil
+    }
+
+    private func pruneStaleSelectedModifiers() {
+        selectedModifiersByGroup = Self.prunedSelections(groups: modifierGroups, selected: selectedModifiersByGroup)
+    }
+
+    private static func prunedSelections(
+        groups: [ModifierGroup],
+        selected: [String: Set<String>],
+    ) -> [String: Set<String>] {
+        var pruned: [String: Set<String>] = [:]
+
+        for group in groups {
+            let selectedForGroup = selected[group.key] ?? []
+            let validSelected = group.modifiers
+                .map(\.key)
+                .filter { selectedForGroup.contains($0) }
+
+            switch group.selection.mode {
+            case .single:
+                if let first = validSelected.first {
+                    pruned[group.key] = [first]
+                }
+            case .multiple:
+                if !validSelected.isEmpty {
+                    pruned[group.key] = Set(validSelected)
+                }
+            }
+        }
+
+        return pruned
+    }
+
+    private static func flattenSelectedModifierKeys(
+        groups: [ModifierGroup],
+        selected: [String: Set<String>],
+    ) -> [String] {
+        var keys: [String] = []
+
+        for group in groups {
+            let selectedForGroup = selected[group.key] ?? []
+            keys.append(contentsOf: group.modifiers.map(\.key).filter { selectedForGroup.contains($0) })
+        }
+
+        return keys
+    }
+
+    private static func validateModifierSelections(
+        groups: [ModifierGroup],
+        selected: [String: Set<String>],
+    ) -> [String] {
+        var errors: [String] = []
+
+        for group in groups {
+            let selectedCount = selected[group.key]?.count ?? 0
+
+            if group.selection.required {
+                switch group.selection.mode {
+                case .single where selectedCount == 0:
+                    errors.append("\(group.label) is required.")
+                case .multiple where selectedCount == 0:
+                    errors.append("\(group.label) requires at least one selection.")
+                default:
+                    break
+                }
+            }
+
+            if group.selection.mode == .single, selectedCount > 1 {
+                errors.append("\(group.label) allows only one selection.")
+            }
+        }
+
+        return errors
+    }
+
+    private static func isInvalidModifierSelectionError(_ error: Error) -> Bool {
+        guard let apiError = error as? APIClientError else { return false }
+        return apiError.statusCode == 400
     }
 }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeStore.swift
@@ -13,6 +13,7 @@ public final class ChatLabHomeStore: ObservableObject {
     @Published public var includeMessageSearch = false
     @Published public private(set) var modifierGroups: [ModifierGroup] = []
     @Published public private(set) var isLoadingModifierGroups = false
+    @Published public private(set) var hasLoadedModifierGroups = false
     @Published public private(set) var modifierLoadError: PresentableAppError?
     @Published public private(set) var modifierValidationErrors: [String] = []
     @Published public var selectedModifiersByGroup: [String: Set<String>] = [:]
@@ -32,6 +33,13 @@ public final class ChatLabHomeStore: ObservableObject {
 
     public var selectedModifiers: Set<String> {
         Set(flattenSelectedModifierKeys())
+    }
+
+    public var canCreateSimulation: Bool {
+        !isCreating &&
+            hasLoadedModifierGroups &&
+            !isLoadingModifierGroups &&
+            modifierLoadError == nil
     }
 
     deinit {
@@ -111,8 +119,10 @@ public final class ChatLabHomeStore: ObservableObject {
 
         do {
             modifierGroups = try await service.listModifierGroups(labType: labType)
+            hasLoadedModifierGroups = true
             pruneStaleSelectedModifiers()
         } catch {
+            hasLoadedModifierGroups = false
             modifierLoadError = AppErrorPresenter.present(error)
         }
     }
@@ -159,6 +169,25 @@ public final class ChatLabHomeStore: ObservableObject {
         presentableError = nil
         modifierValidationErrors = []
         defer { isCreating = false }
+
+        guard !isLoadingModifierGroups else {
+            modifierValidationErrors = ["Modifiers are still loading."]
+            return nil
+        }
+
+        guard modifierLoadError == nil else {
+            presentableError = PresentableAppError(
+                title: "Modifiers Unavailable",
+                message: "Refresh modifiers and try again.",
+                recoveryActionLabel: "Retry",
+            )
+            return nil
+        }
+
+        guard hasLoadedModifierGroups else {
+            modifierValidationErrors = ["Modifiers are still loading."]
+            return nil
+        }
 
         let validationErrors = validateModifierSelections()
         guard validationErrors.isEmpty else {

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeView.swift
@@ -399,6 +399,7 @@ private struct ChatCreateSimulationSheet: View {
                                 }
                             }
                         }
+                        .disabled(!store.canCreateSimulation || creating)
                     }
                 }
             }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabHomeView.swift
@@ -48,6 +48,7 @@ public struct ChatLabHomeView: View {
             }
             .refreshable {
                 await store.refresh()
+                await store.loadModifierGroups()
             }
             .background(Color.secondary.opacity(0.04).ignoresSafeArea())
             .navigationTitle("ChatLab")
@@ -360,26 +361,22 @@ private struct ChatCreateSimulationSheet: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Selected Modifiers") {
-                    if store.modifierGroups.isEmpty {
-                        Text("No modifiers available.")
-                            .foregroundStyle(.secondary)
+                if let error = store.presentableError {
+                    Section {
+                        InlineAppErrorView(error: error)
                     }
                 }
 
-                ForEach(store.modifierGroups, id: \.group) { group in
-                    Section(group.group) {
-                        ForEach(group.modifiers, id: \.key) { modifier in
-                            Toggle(
-                                modifier.description,
-                                isOn: Binding(
-                                    get: { store.selectedModifiers.contains(modifier.key) },
-                                    set: { _ in store.toggleModifier(modifier.key) },
-                                ),
-                            )
+                if !store.modifierValidationErrors.isEmpty {
+                    Section("Selection Required") {
+                        ForEach(store.modifierValidationErrors, id: \.self) { error in
+                            Text(error)
+                                .foregroundStyle(.red)
                         }
                     }
                 }
+
+                modifierContent
             }
             .frame(maxWidth: layoutMode == .pad ? 680 : .infinity)
             .navigationTitle("New Chat Simulation")
@@ -404,6 +401,144 @@ private struct ChatCreateSimulationSheet: View {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var modifierContent: some View {
+        if store.isLoadingModifierGroups {
+            Section("Modifiers") {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Loading modifiers...")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } else if let error = store.modifierLoadError {
+            Section("Modifiers") {
+                InlineAppErrorView(error: error, actionLabel: "Retry") {
+                    Task { await store.loadModifierGroups() }
+                }
+            }
+        } else if store.modifierGroups.isEmpty {
+            Section("Modifiers") {
+                Text("No modifiers available.")
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            ForEach(store.modifierGroups, id: \.key) { group in
+                Section {
+                    if !group.description.isEmpty {
+                        Text(group.description)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    switch group.selection.mode {
+                    case .single:
+                        if group.selection.required == false {
+                            ModifierSingleOptionRow(
+                                title: "No preference",
+                                subtitle: nil,
+                                isSelected: store.singleSelection(in: group) == nil,
+                            ) {
+                                store.selectSingleModifier(nil, in: group)
+                            }
+                        }
+
+                        ForEach(group.modifiers, id: \.key) { modifier in
+                            ModifierSingleOptionRow(
+                                title: modifier.label,
+                                subtitle: modifier.description,
+                                isSelected: store.singleSelection(in: group) == modifier.key,
+                            ) {
+                                store.selectSingleModifier(modifier.key, in: group)
+                            }
+                        }
+
+                    case .multiple:
+                        ForEach(group.modifiers, id: \.key) { modifier in
+                            ModifierMultipleOptionRow(
+                                title: modifier.label,
+                                subtitle: modifier.description,
+                                isSelected: store.isModifierSelected(modifier.key, in: group),
+                            ) {
+                                store.toggleMultipleModifier(modifier.key, in: group)
+                            }
+                        }
+                    }
+                } header: {
+                    Text(group.label)
+                }
+            }
+        }
+    }
+}
+
+private struct ModifierSingleOptionRow: View {
+    let title: String
+    let subtitle: String?
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .imageScale(.large)
+                    .frame(width: 24)
+
+                ModifierOptionText(title: title, subtitle: subtitle)
+
+                Spacer(minLength: 8)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}
+
+private struct ModifierMultipleOptionRow: View {
+    let title: String
+    let subtitle: String?
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .imageScale(.large)
+                    .frame(width: 24)
+
+                ModifierOptionText(title: title, subtitle: subtitle)
+
+                Spacer(minLength: 8)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}
+
+private struct ModifierOptionText: View {
+    let title: String
+    let subtitle: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .foregroundStyle(.primary)
+
+            if let subtitle, !subtitle.isEmpty {
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
         }
     }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabService.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabService.swift
@@ -42,7 +42,7 @@ public protocol ChatLabServiceProtocol: Sendable {
     func getGuardState(simulationID: Int) async throws -> GuardStateDTO
     func sendHeartbeat(simulationID: Int) async throws -> GuardStateDTO
 
-    func listModifierGroups(groups: [String]?) async throws -> [ModifierGroup]
+    func listModifierGroups(labType: String) async throws -> [ModifierGroup]
 }
 
 public final class ChatLabService: ChatLabServiceProtocol, @unchecked Sendable {
@@ -221,9 +221,9 @@ public final class ChatLabService: ChatLabServiceProtocol, @unchecked Sendable {
         try await apiClient.request(ChatLabAPI.heartbeat(simulationID: simulationID), as: GuardStateDTO.self)
     }
 
-    public func listModifierGroups(groups: [String]? = nil) async throws -> [ModifierGroup] {
+    public func listModifierGroups(labType: String = "chatlab") async throws -> [ModifierGroup] {
         try await apiClient.request(
-            ChatLabAPI.listModifierGroups(groups: groups),
+            ChatLabAPI.listModifierGroups(labType: labType),
             as: [ModifierGroup].self,
         )
     }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabContractTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabContractTests.swift
@@ -176,6 +176,38 @@ final class ChatLabContractTests: XCTestCase {
         XCTAssertTrue(response.hasMore)
     }
 
+    func testModifierGroupDecodesBackendCatalogShape() throws {
+        let json = """
+        [
+          {
+            "key": "clinical_scenario",
+            "label": "Clinical Scenario",
+            "description": "Type of clinical encounter",
+            "selection": {
+              "mode": "single",
+              "required": false
+            },
+            "modifiers": [
+              {
+                "key": "musculoskeletal",
+                "label": "Musculoskeletal",
+                "description": "Musculoskeletal injury or issue scenario"
+              }
+            ]
+          }
+        ]
+        """
+
+        let groups = try JSONDecoder().decode([ModifierGroup].self, from: Data(json.utf8))
+
+        XCTAssertEqual(groups.first?.key, "clinical_scenario")
+        XCTAssertEqual(groups.first?.label, "Clinical Scenario")
+        XCTAssertEqual(groups.first?.selection.mode, .single)
+        XCTAssertEqual(groups.first?.selection.required, false)
+        XCTAssertEqual(groups.first?.modifiers.first?.key, "musculoskeletal")
+        XCTAssertEqual(groups.first?.modifiers.first?.label, "Musculoskeletal")
+    }
+
     func testRealtimeHelpersUseWebSocketOnlyRoutesAndLastEventIDQuery() async throws {
         let api = ChatRecordingAPIClient()
         let service = ChatLabService(apiClient: api)
@@ -198,5 +230,20 @@ final class ChatLabContractTests: XCTestCase {
             api.capturedEndpoints.last?.query.first(where: { $0.name == "last_event_id" })?.value,
             "evt-22",
         )
+    }
+
+    func testListModifierGroupsUsesLabTypeQuery() async throws {
+        let api = ChatRecordingAPIClient()
+        let service = ChatLabService(apiClient: api)
+
+        do {
+            _ = try await service.listModifierGroups(labType: "chatlab")
+            XCTFail("Expected intercepted error")
+        } catch {
+            XCTAssertTrue(error is ChatRecordingError)
+        }
+
+        XCTAssertEqual(api.capturedEndpoints.last?.path, "/api/v1/config/modifier-groups/")
+        XCTAssertEqual(api.capturedEndpoints.last?.query, [URLQueryItem(name: "lab_type", value: "chatlab")])
     }
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabHomeStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabHomeStoreTests.swift
@@ -15,6 +15,7 @@ private final class StubChatLabService: ChatLabServiceProtocol, @unchecked Senda
     var quickCreateRequests: [ChatQuickCreateRequest] = []
     var listModifierGroupsResult: Result<[ModifierGroup], Error> = .failure(StubError.sentinel)
     var listModifierGroupsCallCount = 0
+    var listModifierGroupsDelay: UInt64 = 0
     var requestedLabTypes: [String] = []
 
     func listSimulations(limit _: Int, cursor _: String?, status _: String?, query _: String?, searchMessages _: Bool) async throws -> PaginatedResponse<ChatSimulation> {
@@ -109,6 +110,9 @@ private final class StubChatLabService: ChatLabServiceProtocol, @unchecked Senda
     func listModifierGroups(labType: String) async throws -> [ModifierGroup] {
         listModifierGroupsCallCount += 1
         requestedLabTypes.append(labType)
+        if listModifierGroupsDelay > 0 {
+            try? await Task.sleep(nanoseconds: listModifierGroupsDelay)
+        }
         return try listModifierGroupsResult.get()
     }
 }
@@ -192,6 +196,8 @@ final class ChatLabHomeStoreTests: XCTestCase {
         XCTAssertEqual(service.requestedLabTypes, ["chatlab"])
         XCTAssertEqual(store.modifierGroups.first?.key, "clinical_scenario")
         XCTAssertNil(store.modifierLoadError)
+        XCTAssertTrue(store.hasLoadedModifierGroups)
+        XCTAssertTrue(store.canCreateSimulation)
     }
 
     func testOptionalSingleSelectDefaultsToNoPreferenceAndFlattensNoKey() async {
@@ -329,6 +335,57 @@ final class ChatLabHomeStoreTests: XCTestCase {
         XCTAssertNil(created)
         XCTAssertEqual(store.presentableError?.message, "Invalid modifier selection. Refresh and try again.")
         XCTAssertFalse(store.presentableError?.message.contains("nonexistent") ?? true)
+    }
+
+    func testQuickCreateBeforeModifierHydrationDoesNotCallService() async {
+        let service = StubChatLabService()
+        service.quickCreateResult = .success(makeSimulation(id: 77))
+        let store = ChatLabHomeStore(service: service)
+
+        let created = await store.quickCreateSimulation()
+
+        XCTAssertNil(created)
+        XCTAssertEqual(service.quickCreateRequests.count, 0)
+        XCTAssertEqual(store.modifierValidationErrors, ["Modifiers are still loading."])
+        XCTAssertFalse(store.canCreateSimulation)
+    }
+
+    func testQuickCreateWhileModifierGroupsAreLoadingDoesNotCallService() async {
+        let service = StubChatLabService()
+        service.listModifierGroupsDelay = 200_000_000
+        service.listModifierGroupsResult = .success([makeModifierGroup()])
+        service.quickCreateResult = .success(makeSimulation(id: 78))
+        let store = ChatLabHomeStore(service: service)
+
+        let loadTask = Task { await store.loadModifierGroups() }
+        while store.isLoadingModifierGroups == false {
+            await Task.yield()
+        }
+
+        let created = await store.quickCreateSimulation()
+        await loadTask.value
+
+        XCTAssertNil(created)
+        XCTAssertEqual(service.quickCreateRequests.count, 0)
+        XCTAssertEqual(store.modifierValidationErrors, ["Modifiers are still loading."])
+    }
+
+    func testQuickCreateAfterModifierLoadFailureDoesNotCallService() async {
+        let service = StubChatLabService()
+        service.listModifierGroupsResult = .failure(
+            APIClientError.http(statusCode: 500, detail: "catalog invalid", correlationID: nil),
+        )
+        service.quickCreateResult = .success(makeSimulation(id: 79))
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+        let created = await store.quickCreateSimulation()
+
+        XCTAssertNil(created)
+        XCTAssertEqual(service.quickCreateRequests.count, 0)
+        XCTAssertEqual(store.presentableError?.title, "Modifiers Unavailable")
+        XCTAssertEqual(store.presentableError?.message, "Refresh modifiers and try again.")
+        XCTAssertFalse(store.canCreateSimulation)
     }
 }
 

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabHomeStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatLabHomeStoreTests.swift
@@ -11,6 +11,11 @@ private final class StubChatLabService: ChatLabServiceProtocol, @unchecked Senda
     )
     var listSimulationsCallCount = 0
     var listSimulationsDelay: UInt64 = 0
+    var quickCreateResult: Result<ChatSimulation, Error> = .failure(StubError.sentinel)
+    var quickCreateRequests: [ChatQuickCreateRequest] = []
+    var listModifierGroupsResult: Result<[ModifierGroup], Error> = .failure(StubError.sentinel)
+    var listModifierGroupsCallCount = 0
+    var requestedLabTypes: [String] = []
 
     func listSimulations(limit _: Int, cursor _: String?, status _: String?, query _: String?, searchMessages _: Bool) async throws -> PaginatedResponse<ChatSimulation> {
         listSimulationsCallCount += 1
@@ -20,8 +25,9 @@ private final class StubChatLabService: ChatLabServiceProtocol, @unchecked Senda
         return try listSimulationsResult.get()
     }
 
-    func quickCreateSimulation(request _: ChatQuickCreateRequest) async throws -> ChatSimulation {
-        throw StubError.sentinel
+    func quickCreateSimulation(request: ChatQuickCreateRequest) async throws -> ChatSimulation {
+        quickCreateRequests.append(request)
+        return try quickCreateResult.get()
     }
 
     func getSimulation(simulationID _: Int) async throws -> ChatSimulation {
@@ -100,8 +106,10 @@ private final class StubChatLabService: ChatLabServiceProtocol, @unchecked Senda
         throw StubError.sentinel
     }
 
-    func listModifierGroups(groups _: [String]?) async throws -> [ModifierGroup] {
-        throw StubError.sentinel
+    func listModifierGroups(labType: String) async throws -> [ModifierGroup] {
+        listModifierGroupsCallCount += 1
+        requestedLabTypes.append(labType)
+        return try listModifierGroupsResult.get()
     }
 }
 
@@ -172,6 +180,156 @@ final class ChatLabHomeStoreTests: XCTestCase {
 
         XCTAssertEqual(service.listSimulationsCallCount, 2)
     }
+
+    func testLoadModifierGroups_fetchesChatLabCatalog() async {
+        let service = StubChatLabService()
+        service.listModifierGroupsResult = .success([makeModifierGroup()])
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+
+        XCTAssertEqual(service.listModifierGroupsCallCount, 1)
+        XCTAssertEqual(service.requestedLabTypes, ["chatlab"])
+        XCTAssertEqual(store.modifierGroups.first?.key, "clinical_scenario")
+        XCTAssertNil(store.modifierLoadError)
+    }
+
+    func testOptionalSingleSelectDefaultsToNoPreferenceAndFlattensNoKey() async {
+        let service = StubChatLabService()
+        let group = makeModifierGroup(required: false)
+        service.listModifierGroupsResult = .success([group])
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+
+        XCTAssertNil(store.singleSelection(in: group))
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), [])
+
+        store.selectSingleModifier("musculoskeletal", in: group)
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), ["musculoskeletal"])
+
+        store.selectSingleModifier(nil, in: group)
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), [])
+    }
+
+    func testRequiredSingleSelectValidationBlocksUntilSelected() async {
+        let service = StubChatLabService()
+        let group = makeModifierGroup(required: true)
+        service.listModifierGroupsResult = .success([group])
+        service.quickCreateResult = .success(makeSimulation(id: 41))
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+        let blocked = await store.quickCreateSimulation()
+
+        XCTAssertNil(blocked)
+        XCTAssertEqual(store.modifierValidationErrors, ["Clinical Scenario is required."])
+        XCTAssertEqual(service.quickCreateRequests.count, 0)
+
+        store.selectSingleModifier("musculoskeletal", in: group)
+        let created = await store.quickCreateSimulation()
+
+        XCTAssertEqual(created?.id, 41)
+        XCTAssertEqual(service.quickCreateRequests.first?.modifiers, ["musculoskeletal"])
+    }
+
+    func testMultipleSelectAllowsMultipleKeysAndValidatesRequiredGroup() async {
+        let service = StubChatLabService()
+        let group = makeModifierGroup(
+            key: "injuries",
+            label: "Injuries",
+            mode: .multiple,
+            required: true,
+            modifiers: [
+                ModifierOption(key: "hemorrhage", label: "Hemorrhage", description: "Bleeding"),
+                ModifierOption(key: "fracture", label: "Fracture", description: "Broken bone"),
+            ],
+        )
+        service.listModifierGroupsResult = .success([group])
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+        XCTAssertEqual(store.validateModifierSelections(), ["Injuries requires at least one selection."])
+
+        store.toggleMultipleModifier("hemorrhage", in: group)
+        store.toggleMultipleModifier("fracture", in: group)
+
+        XCTAssertEqual(store.validateModifierSelections(), [])
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), ["hemorrhage", "fracture"])
+    }
+
+    func testFlattenSelectedKeysUsesBackendGroupOrder() async {
+        let service = StubChatLabService()
+        let scenario = makeModifierGroup()
+        let duration = makeModifierGroup(
+            key: "clinical_duration",
+            label: "Clinical Duration",
+            modifiers: [
+                ModifierOption(key: "acute", label: "Acute", description: "New concern"),
+                ModifierOption(key: "chronic", label: "Chronic", description: "Long concern"),
+            ],
+        )
+        service.listModifierGroupsResult = .success([scenario, duration])
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+        store.selectSingleModifier("acute", in: duration)
+        store.selectSingleModifier("musculoskeletal", in: scenario)
+
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), ["musculoskeletal", "acute"])
+    }
+
+    func testRefreshModifierGroupsDropsStaleSelectedKeys() async {
+        let service = StubChatLabService()
+        let original = makeModifierGroup()
+        service.listModifierGroupsResult = .success([original])
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+        store.selectSingleModifier("musculoskeletal", in: original)
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), ["musculoskeletal"])
+
+        service.listModifierGroupsResult = .success([
+            makeModifierGroup(
+                modifiers: [ModifierOption(key: "respiratory", label: "Respiratory", description: "Respiratory issue")],
+            ),
+        ])
+        await store.loadModifierGroups()
+
+        XCTAssertEqual(store.flattenSelectedModifierKeys(), [])
+    }
+
+    func testModifierLoadFailureSetsRecoverableModifierErrorOnly() async {
+        let service = StubChatLabService()
+        service.listModifierGroupsResult = .failure(
+            APIClientError.http(statusCode: 500, detail: "raw backend exception", correlationID: nil),
+        )
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+
+        XCTAssertNotNil(store.modifierLoadError)
+        XCTAssertNil(store.presentableError)
+        XCTAssertFalse(store.modifierLoadError?.message.contains("raw backend exception") ?? true)
+    }
+
+    func testQuickCreateMapsHTTP400ToGenericInvalidModifierMessage() async {
+        let service = StubChatLabService()
+        let group = makeModifierGroup()
+        service.listModifierGroupsResult = .success([group])
+        service.quickCreateResult = .failure(
+            APIClientError.http(statusCode: 400, detail: "Unknown modifier key nonexistent", correlationID: nil),
+        )
+        let store = ChatLabHomeStore(service: service)
+
+        await store.loadModifierGroups()
+        store.selectSingleModifier("musculoskeletal", in: group)
+        let created = await store.quickCreateSimulation()
+
+        XCTAssertNil(created)
+        XCTAssertEqual(store.presentableError?.message, "Invalid modifier selection. Refresh and try again.")
+        XCTAssertFalse(store.presentableError?.message.contains("nonexistent") ?? true)
+    }
 }
 
 private func makeSimulation(id: Int) -> ChatSimulation {
@@ -191,5 +349,32 @@ private func makeSimulation(id: Int) -> ChatSimulation {
         terminalAt: nil,
         retryable: nil,
         latestEventID: nil,
+    )
+}
+
+private func makeModifierGroup(
+    key: String = "clinical_scenario",
+    label: String = "Clinical Scenario",
+    mode: ModifierSelectionMode = .single,
+    required: Bool = false,
+    modifiers: [ModifierOption] = [
+        ModifierOption(
+            key: "musculoskeletal",
+            label: "Musculoskeletal",
+            description: "Musculoskeletal injury or issue scenario",
+        ),
+        ModifierOption(
+            key: "respiratory",
+            label: "Respiratory",
+            description: "Respiratory issue",
+        ),
+    ],
+) -> ModifierGroup {
+    ModifierGroup(
+        key: key,
+        label: label,
+        description: "Type of clinical encounter",
+        selection: ModifierSelectionConfig(mode: mode, required: required),
+        modifiers: modifiers,
     )
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatPatientResultsTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatPatientResultsTests.swift
@@ -103,7 +103,7 @@ private final class PatientResultsService: ChatLabServiceProtocol, @unchecked Se
         fatalError("unused")
     }
 
-    func listModifierGroups(groups _: [String]?) async throws -> [ModifierGroup] {
+    func listModifierGroups(labType _: String) async throws -> [ModifierGroup] {
         fatalError("unused")
     }
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -118,7 +118,7 @@ private final class TestChatService: ChatLabServiceProtocol, @unchecked Sendable
         ChatLabOrdersResponse(status: "accepted", callID: "call-1", orders: request.orders)
     }
 
-    func listModifierGroups(groups _: [String]?) async throws -> [ModifierGroup] {
+    func listModifierGroups(labType _: String) async throws -> [ModifierGroup] {
         []
     }
 

--- a/apps/trainerlab-ios/Sources/Networking/APIClient.swift
+++ b/apps/trainerlab-ios/Sources/Networking/APIClient.swift
@@ -698,11 +698,8 @@ public enum ChatLabAPI {
         return Endpoint(path: "/api/v1/simulations/\(simulationID)/heartbeat/", method: .post, body: body)
     }
 
-    public static func listModifierGroups(groups: [String]?) -> Endpoint {
-        var queryItems: [URLQueryItem] = []
-        if let groups {
-            queryItems.append(contentsOf: groups.map { URLQueryItem(name: "groups", value: $0) })
-        }
+    public static func listModifierGroups(labType: String = "chatlab") -> Endpoint {
+        let queryItems = [URLQueryItem(name: "lab_type", value: labType)]
         return Endpoint(path: "/api/v1/config/modifier-groups/", query: queryItems)
     }
 }

--- a/apps/trainerlab-ios/Tests/NetworkingTests/BackendRoutesTests.swift
+++ b/apps/trainerlab-ios/Tests/NetworkingTests/BackendRoutesTests.swift
@@ -117,7 +117,7 @@ final class BackendRoutesTests: XCTestCase {
         XCTAssertEqual(ChatLabAPI.tool(simulationID: 7, toolName: "patient_results").path, "/api/v1/simulations/7/tools/patient_results/")
         XCTAssertEqual(ChatLabAPI.signOrders(simulationID: 7, body: body).path, "/api/v1/simulations/7/tools/patient_results/orders/")
         XCTAssertEqual(ChatLabAPI.submitLabOrders(simulationID: 7, body: body).path, "/api/v1/simulations/7/lab-orders/")
-        XCTAssertEqual(queryPairs(ChatLabAPI.listModifierGroups(groups: ["ClinicalScenario", "Difficulty"])), ["groups=ClinicalScenario", "groups=Difficulty"])
+        XCTAssertEqual(queryPairs(ChatLabAPI.listModifierGroups(labType: "chatlab")), ["lab_type=chatlab"])
     }
 
     func testRealtimeRoutesBuildExpectedRequests() throws {


### PR DESCRIPTION
## Summary
- Load ChatLab modifier groups from `lab_type=chatlab` at runtime instead of using hardcoded frontend options.
- Update contracts, service routing, and home-sheet rendering to support backend-driven group keys, labels, descriptions, selection modes, and required flags.
- Replace flat modifier selection with grouped state and backend-order flattening for simulation creation.
- Add recoverable modifier loading errors and generic handling for invalid selections.

## Testing
- Added contract tests for the new modifier API shape and `lab_type` query routing.
- Added store tests for dynamic hydration, optional/required single-select behavior, multiple-select handling, flattening, stale selection pruning, and error handling.
- Updated shared networking route tests for the new modifier-groups endpoint contract.
- `swift test` passed for `apps/chatlab-ios` and the relevant networking route tests in `apps/trainerlab-ios`.