### PR TITLE
Implement stable typing user tracking with self-suppression

### DIFF
--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
@@ -1,9 +1,10 @@
 import Foundation
 import SharedModels
 
-/// Identity of the currently authenticated user, injected into ChatRunStore
-/// for self-typing suppression. All fields are optional so callers can supply
-/// only what they have available.
+/// Identity of the currently authenticated app user, injected into ChatRunStore
+/// for self-typing suppression. This may differ from `ChatSimulation.userID` in
+/// staff/admin or shared-access flows. All fields are optional so callers supply
+/// only what the auth layer provides.
 public struct ChatCurrentUserIdentity: Sendable, Equatable {
     public let id: Int?
     public let uuid: String?

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatLabContracts.swift
@@ -1,6 +1,21 @@
 import Foundation
 import SharedModels
 
+/// Identity of the currently authenticated user, injected into ChatRunStore
+/// for self-typing suppression. All fields are optional so callers can supply
+/// only what they have available.
+public struct ChatCurrentUserIdentity: Sendable, Equatable {
+    public let id: Int?
+    public let uuid: String?
+    public let email: String?
+
+    public init(id: Int? = nil, uuid: String? = nil, email: String? = nil) {
+        self.id = id
+        self.uuid = uuid
+        self.email = email
+    }
+}
+
 public enum SimulationTerminalState: String, Codable, Sendable, CaseIterable {
     case inProgress = "in_progress"
     case completed

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRealtimeProtocol.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRealtimeProtocol.swift
@@ -182,7 +182,7 @@ public struct ChatRealtimeTypingPayload: Codable, Sendable, Equatable {
     public func isFromCurrentUser(
         currentUserId: Int?,
         currentUserUuid: String?,
-        currentUserEmail: String?
+        currentUserEmail: String?,
     ) -> Bool {
         guard normalizedActorType == "user" else {
             return false

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRealtimeProtocol.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRealtimeProtocol.swift
@@ -147,10 +147,68 @@ public struct ChatRealtimeTypingPayload: Codable, Sendable, Equatable {
     public let user: String?
     public let displayInitials: String?
 
+    // Enriched identity fields from backend (optional; absent on older payloads)
+    public let actorType: String?
+    public let senderId: Int?
+    public let actorUserId: Int?
+    public let actorUserUuid: String?
+
     enum CodingKeys: String, CodingKey {
         case conversationID = "conversation_id"
         case user
         case displayInitials = "display_initials"
+        case actorType = "actor_type"
+        case senderId = "sender_id"
+        case actorUserId = "actor_user_id"
+        case actorUserUuid = "actor_user_uuid"
+    }
+
+    /// Stable key for store identity: prefers UUID > actorUserId > senderId > user email.
+    public var identityKey: String {
+        actorUserUuid
+            ?? actorUserId.map(String.init)
+            ?? senderId.map(String.init)
+            ?? user
+            ?? "unknown"
+    }
+
+    /// Treats a missing actor_type as "user" for backward compatibility.
+    public var normalizedActorType: String {
+        actorType ?? "user"
+    }
+
+    /// Returns true when the payload belongs to the currently authenticated user.
+    /// System/simulated-patient payloads (actor_type == "system") always return false.
+    public func isFromCurrentUser(
+        currentUserId: Int?,
+        currentUserUuid: String?,
+        currentUserEmail: String?
+    ) -> Bool {
+        guard normalizedActorType == "user" else {
+            return false
+        }
+
+        if let actorUserId, let currentUserId, actorUserId == currentUserId {
+            return true
+        }
+
+        if let senderId, let currentUserId, senderId == currentUserId {
+            return true
+        }
+
+        if let actorUserUuid, let currentUserUuid,
+           actorUserUuid.lowercased() == currentUserUuid.lowercased()
+        {
+            return true
+        }
+
+        if let user, let currentUserEmail,
+           user.lowercased() == currentUserEmail.lowercased()
+        {
+            return true
+        }
+
+        return false
     }
 }
 

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
@@ -102,6 +102,7 @@ public final class ChatRunStore: ObservableObject {
 
     private let service: ChatLabServiceProtocol
     private let realtimeClient: ChatRealtimeClientProtocol
+    private let currentUserIdentity: ChatCurrentUserIdentity
     private var eventTask: Task<Void, Never>?
     private var stateTask: Task<Void, Never>?
     private var heartbeatTask: Task<Void, Never>?
@@ -132,10 +133,12 @@ public final class ChatRunStore: ObservableObject {
         service: ChatLabServiceProtocol,
         realtimeClient: ChatRealtimeClientProtocol,
         simulation: ChatSimulation,
+        currentUserIdentity: ChatCurrentUserIdentity = ChatCurrentUserIdentity(),
     ) {
         self.service = service
         self.realtimeClient = realtimeClient
         self.simulation = simulation
+        self.currentUserIdentity = currentUserIdentity
         if simulation.status == .failed {
             simulationFailureText = simulation.terminalReasonText.isEmpty
                 ? "Initial patient generation failed."
@@ -799,9 +802,9 @@ public final class ChatRunStore: ObservableObject {
 
         // Defensively remove self-typing events regardless of backend suppression.
         if payload.isFromCurrentUser(
-            currentUserId: simulation.userID,
-            currentUserUuid: nil,
-            currentUserEmail: nil
+            currentUserId: currentUserIdentity.id,
+            currentUserUuid: currentUserIdentity.uuid,
+            currentUserEmail: currentUserIdentity.email
         ) {
             if var entries = typingEntries[conversationID], entries.contains(where: { $0.key == key }) {
                 entries.removeAll { $0.key == key }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
@@ -65,11 +65,11 @@ public final class ChatRunStore: ObservableObject {
     @Published public private(set) var typingUsersByConversation: [Int: [String]] = [:]
     @Published public private(set) var hasMoreByConversation: [Int: Bool] = [:]
 
-    // Internal stable-keyed store: identity key → display string, per conversation.
     private struct TypingEntry: Equatable {
         let key: String
         let display: String
     }
+
     private var typingEntries: [Int: [TypingEntry]] = [:]
 
     @Published public private(set) var isMessagesLoading = false
@@ -804,7 +804,7 @@ public final class ChatRunStore: ObservableObject {
         if payload.isFromCurrentUser(
             currentUserId: currentUserIdentity.id,
             currentUserUuid: currentUserIdentity.uuid,
-            currentUserEmail: currentUserIdentity.email
+            currentUserEmail: currentUserIdentity.email,
         ) {
             if var entries = typingEntries[conversationID], entries.contains(where: { $0.key == key }) {
                 entries.removeAll { $0.key == key }

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
@@ -133,7 +133,7 @@ public final class ChatRunStore: ObservableObject {
         service: ChatLabServiceProtocol,
         realtimeClient: ChatRealtimeClientProtocol,
         simulation: ChatSimulation,
-        currentUserIdentity: ChatCurrentUserIdentity = ChatCurrentUserIdentity(),
+        currentUserIdentity: ChatCurrentUserIdentity,
     ) {
         self.service = service
         self.realtimeClient = realtimeClient

--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunStore.swift
@@ -65,6 +65,13 @@ public final class ChatRunStore: ObservableObject {
     @Published public private(set) var typingUsersByConversation: [Int: [String]] = [:]
     @Published public private(set) var hasMoreByConversation: [Int: Bool] = [:]
 
+    // Internal stable-keyed store: identity key → display string, per conversation.
+    private struct TypingEntry: Equatable {
+        let key: String
+        let display: String
+    }
+    private var typingEntries: [Int: [TypingEntry]] = [:]
+
     @Published public private(set) var isMessagesLoading = false
     @Published public private(set) var isOlderLoading = false
     @Published public private(set) var socketDisconnected = false
@@ -518,13 +525,17 @@ public final class ChatRunStore: ObservableObject {
 
         if event.eventType == ChatRealtimeEventType.typingStarted {
             runStoreLogger.debug("Received transient typing.started event_id=\(event.eventID, privacy: .public)")
-            setTyping(event.payload, started: true)
+            if let payload = try? event.typingPayload() {
+                setTyping(payload, started: true)
+            }
             return
         }
 
         if event.eventType == ChatRealtimeEventType.typingStopped {
             runStoreLogger.debug("Received transient typing.stopped event_id=\(event.eventID, privacy: .public)")
-            setTyping(event.payload, started: false)
+            if let payload = try? event.typingPayload() {
+                setTyping(payload, started: false)
+            }
             return
         }
 
@@ -779,23 +790,41 @@ public final class ChatRunStore: ObservableObject {
         return false
     }
 
-    private func setTyping(_ payload: [String: JSONValue], started: Bool) {
-        guard let rawUser = string(payload, keys: ["user"]) else { return }
-        let conversationID = int(payload, keys: ["conversation_id"]) ?? activeConversationID ?? 0
-        guard conversationID > 0 else { return }
-        let user = rawUser == "system@medsim.local"
-            ? simulation.patientDisplayName
-            : rawUser
+    private func setTyping(_ payload: ChatRealtimeTypingPayload, started: Bool) {
+        let key = payload.identityKey
+        guard key != "unknown" else { return }
 
-        var users = typingUsersByConversation[conversationID] ?? []
+        let conversationID = payload.conversationID ?? activeConversationID ?? 0
+        guard conversationID > 0 else { return }
+
+        // Defensively remove self-typing events regardless of backend suppression.
+        if payload.isFromCurrentUser(
+            currentUserId: simulation.userID,
+            currentUserUuid: nil,
+            currentUserEmail: nil
+        ) {
+            if var entries = typingEntries[conversationID], entries.contains(where: { $0.key == key }) {
+                entries.removeAll { $0.key == key }
+                typingEntries[conversationID] = entries.isEmpty ? nil : entries
+                typingUsersByConversation[conversationID] = entries.map(\.display)
+            }
+            return
+        }
+
+        let isSystem = payload.normalizedActorType == "system"
+            || payload.user == "system@medsim.local"
+        let display = isSystem ? simulation.patientDisplayName : (payload.user ?? key)
+
+        var entries = typingEntries[conversationID] ?? []
         if started {
-            if !users.contains(user), user != localUserMarker {
-                users.append(user)
+            if !entries.contains(where: { $0.key == key }) {
+                entries.append(TypingEntry(key: key, display: display))
             }
         } else {
-            users.removeAll(where: { $0 == user })
+            entries.removeAll { $0.key == key }
         }
-        typingUsersByConversation[conversationID] = users
+        typingEntries[conversationID] = entries
+        typingUsersByConversation[conversationID] = entries.map(\.display)
     }
 
     private func handleSimulationStatusUpdated(_ payload: [String: JSONValue]) {
@@ -1366,6 +1395,7 @@ public final class ChatRunStore: ObservableObject {
     }
 
     private func clearRemoteTypingUsers() {
+        typingEntries.removeAll(keepingCapacity: true)
         typingUsersByConversation.removeAll(keepingCapacity: true)
     }
 

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRealtimeTypingPayloadTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRealtimeTypingPayloadTests.swift
@@ -7,21 +7,21 @@ final class ChatRealtimeTypingPayloadTests: XCTestCase {
 
     func testIdentityKeyPrefersActorUserUuid() {
         let payload = makePayload(
-            actorUserUuid: "uuid-abc",
-            actorUserId: 1,
+            user: "a@example.com",
             senderId: 2,
-            user: "a@example.com"
+            actorUserId: 1,
+            actorUserUuid: "uuid-abc",
         )
         XCTAssertEqual(payload.identityKey, "uuid-abc")
     }
 
     func testIdentityKeyFallsToActorUserIdWhenNoUuid() {
-        let payload = makePayload(actorUserId: 42, senderId: 99, user: "a@example.com")
+        let payload = makePayload(user: "a@example.com", senderId: 99, actorUserId: 42)
         XCTAssertEqual(payload.identityKey, "42")
     }
 
     func testIdentityKeyFallsToSenderIdWhenNoUuidOrActorUserId() {
-        let payload = makePayload(senderId: 99, user: "a@example.com")
+        let payload = makePayload(user: "a@example.com", senderId: 99)
         XCTAssertEqual(payload.identityKey, "99")
     }
 
@@ -112,30 +112,42 @@ final class ChatRealtimeTypingPayloadTests: XCTestCase {
 
     func testSystemActorTypeIsNeverSelf() {
         let payload = makePayload(
-            actorType: "system",
             user: "system@medsim.local",
-            displayInitials: "TP"
+            displayInitials: "TP",
+            actorType: "system",
         )
-        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: nil, currentUserEmail: "system@medsim.local"))
-        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: 0, currentUserUuid: nil, currentUserEmail: nil))
+        XCTAssertFalse(payload.isFromCurrentUser(
+            currentUserId: nil,
+            currentUserUuid: nil,
+            currentUserEmail: "system@medsim.local",
+        ))
+        XCTAssertFalse(payload.isFromCurrentUser(
+            currentUserId: 0,
+            currentUserUuid: nil,
+            currentUserEmail: nil,
+        ))
     }
 
     // MARK: - isFromCurrentUser: allows another user (Case F)
 
     func testAnotherUserIsNotSelf() {
         let payload = makePayload(
+            user: "other@example.com",
             actorType: "user",
             senderId: 55,
-            user: "other@example.com"
         )
-        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: 7, currentUserUuid: nil, currentUserEmail: "me@example.com"))
+        XCTAssertFalse(payload.isFromCurrentUser(
+            currentUserId: 7,
+            currentUserUuid: nil,
+            currentUserEmail: "me@example.com",
+        ))
     }
 
     // MARK: - identity does not use initials (Case G)
 
     func testTwoUsersWithSameInitialsGetDistinctKeys() {
-        let p1 = makePayload(actorUserId: 10, displayInitials: "JD")
-        let p2 = makePayload(actorUserId: 20, displayInitials: "JD")
+        let p1 = makePayload(displayInitials: "JD", actorUserId: 10)
+        let p2 = makePayload(displayInitials: "JD", actorUserId: 20)
         XCTAssertNotEqual(p1.identityKey, p2.identityKey)
     }
 
@@ -201,7 +213,7 @@ final class ChatRealtimeTypingPayloadTests: XCTestCase {
         XCTAssertFalse(payload.isFromCurrentUser(
             currentUserId: nil,
             currentUserUuid: nil,
-            currentUserEmail: "system@medsim.local"
+            currentUserEmail: "system@medsim.local",
         ))
     }
 
@@ -223,7 +235,7 @@ final class ChatRealtimeTypingPayloadTests: XCTestCase {
             actorType: actorType,
             senderId: senderId,
             actorUserId: actorUserId,
-            actorUserUuid: actorUserUuid
+            actorUserUuid: actorUserUuid,
         )
     }
 }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRealtimeTypingPayloadTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRealtimeTypingPayloadTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 final class ChatRealtimeTypingPayloadTests: XCTestCase {
-
     // MARK: - identityKey
 
     func testIdentityKeyPrefersActorUserUuid() {
@@ -226,7 +225,7 @@ final class ChatRealtimeTypingPayloadTests: XCTestCase {
         actorType: String? = nil,
         senderId: Int? = nil,
         actorUserId: Int? = nil,
-        actorUserUuid: String? = nil
+        actorUserUuid: String? = nil,
     ) -> ChatRealtimeTypingPayload {
         ChatRealtimeTypingPayload(
             conversationID: conversationID,

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRealtimeTypingPayloadTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRealtimeTypingPayloadTests.swift
@@ -1,0 +1,229 @@
+@testable import ChatLabiOS
+import XCTest
+
+final class ChatRealtimeTypingPayloadTests: XCTestCase {
+
+    // MARK: - identityKey
+
+    func testIdentityKeyPrefersActorUserUuid() {
+        let payload = makePayload(
+            actorUserUuid: "uuid-abc",
+            actorUserId: 1,
+            senderId: 2,
+            user: "a@example.com"
+        )
+        XCTAssertEqual(payload.identityKey, "uuid-abc")
+    }
+
+    func testIdentityKeyFallsToActorUserIdWhenNoUuid() {
+        let payload = makePayload(actorUserId: 42, senderId: 99, user: "a@example.com")
+        XCTAssertEqual(payload.identityKey, "42")
+    }
+
+    func testIdentityKeyFallsToSenderIdWhenNoUuidOrActorUserId() {
+        let payload = makePayload(senderId: 99, user: "a@example.com")
+        XCTAssertEqual(payload.identityKey, "99")
+    }
+
+    func testIdentityKeyFallsToUserEmailWhenNoIds() {
+        let payload = makePayload(user: "legacy@example.com")
+        XCTAssertEqual(payload.identityKey, "legacy@example.com")
+    }
+
+    func testIdentityKeyIsUnknownWhenAllNil() {
+        let payload = makePayload()
+        XCTAssertEqual(payload.identityKey, "unknown")
+    }
+
+    // MARK: - normalizedActorType
+
+    func testNormalizedActorTypeReturnsUserWhenAbsent() {
+        let payload = makePayload()
+        XCTAssertEqual(payload.normalizedActorType, "user")
+    }
+
+    func testNormalizedActorTypeReturnsSystemWhenPresent() {
+        let payload = makePayload(actorType: "system")
+        XCTAssertEqual(payload.normalizedActorType, "system")
+    }
+
+    // MARK: - isFromCurrentUser: suppressed by actor_user_id (Case A)
+
+    func testSuppressesSelfByActorUserId() {
+        let payload = makePayload(actorType: "user", actorUserId: 10)
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: 10, currentUserUuid: nil, currentUserEmail: nil))
+    }
+
+    func testDoesNotSuppressDifferentActorUserId() {
+        let payload = makePayload(actorType: "user", actorUserId: 10)
+        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: 99, currentUserUuid: nil, currentUserEmail: nil))
+    }
+
+    // MARK: - isFromCurrentUser: suppressed by sender_id (Case B)
+
+    func testSuppressesSelfBySenderId() {
+        let payload = makePayload(actorType: "user", senderId: 7)
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: 7, currentUserUuid: nil, currentUserEmail: nil))
+    }
+
+    func testDoesNotSuppressDifferentSenderId() {
+        let payload = makePayload(actorType: "user", senderId: 7)
+        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: 99, currentUserUuid: nil, currentUserEmail: nil))
+    }
+
+    // MARK: - isFromCurrentUser: suppressed by UUID (Case C)
+
+    func testSuppressesSelfByUuid() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000"
+        let payload = makePayload(actorType: "user", actorUserUuid: uuid)
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: uuid, currentUserEmail: nil))
+    }
+
+    func testUuidComparisonIsCaseInsensitive() {
+        let payload = makePayload(actorType: "user", actorUserUuid: "UPPER-UUID")
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: "upper-uuid", currentUserEmail: nil))
+    }
+
+    func testDoesNotSuppressDifferentUuid() {
+        let payload = makePayload(actorType: "user", actorUserUuid: "uuid-a")
+        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: "uuid-b", currentUserEmail: nil))
+    }
+
+    // MARK: - isFromCurrentUser: suppressed by legacy email (Case D)
+
+    func testSuppressesSelfByLegacyEmail() {
+        let payload = makePayload(user: "me@example.com")
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: nil, currentUserEmail: "me@example.com"))
+    }
+
+    func testEmailComparisonIsCaseInsensitive() {
+        let payload = makePayload(user: "Me@Example.COM")
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: nil, currentUserEmail: "me@example.com"))
+    }
+
+    func testLegacyEmailWithMissingActorTypeTreatedAsUser() {
+        // actor_type absent → treated as "user" → legacy check applies
+        let payload = makePayload(user: "me@example.com")
+        XCTAssertNil(payload.actorType)
+        XCTAssertTrue(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: nil, currentUserEmail: "me@example.com"))
+    }
+
+    // MARK: - isFromCurrentUser: allows system typing (Case E)
+
+    func testSystemActorTypeIsNeverSelf() {
+        let payload = makePayload(
+            actorType: "system",
+            user: "system@medsim.local",
+            displayInitials: "TP"
+        )
+        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: nil, currentUserUuid: nil, currentUserEmail: "system@medsim.local"))
+        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: 0, currentUserUuid: nil, currentUserEmail: nil))
+    }
+
+    // MARK: - isFromCurrentUser: allows another user (Case F)
+
+    func testAnotherUserIsNotSelf() {
+        let payload = makePayload(
+            actorType: "user",
+            senderId: 55,
+            user: "other@example.com"
+        )
+        XCTAssertFalse(payload.isFromCurrentUser(currentUserId: 7, currentUserUuid: nil, currentUserEmail: "me@example.com"))
+    }
+
+    // MARK: - identity does not use initials (Case G)
+
+    func testTwoUsersWithSameInitialsGetDistinctKeys() {
+        let p1 = makePayload(actorUserId: 10, displayInitials: "JD")
+        let p2 = makePayload(actorUserId: 20, displayInitials: "JD")
+        XCTAssertNotEqual(p1.identityKey, p2.identityKey)
+    }
+
+    // MARK: - Codable: new fields absent in old payloads
+
+    func testDecodesLegacyPayloadWithoutNewFields() throws {
+        let json = """
+        {
+            "conversation_id": 3,
+            "user": "legacy@example.com",
+            "display_initials": "LE"
+        }
+        """
+        let payload = try JSONDecoder().decode(ChatRealtimeTypingPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(payload.conversationID, 3)
+        XCTAssertEqual(payload.user, "legacy@example.com")
+        XCTAssertEqual(payload.displayInitials, "LE")
+        XCTAssertNil(payload.actorType)
+        XCTAssertNil(payload.senderId)
+        XCTAssertNil(payload.actorUserId)
+        XCTAssertNil(payload.actorUserUuid)
+        XCTAssertEqual(payload.identityKey, "legacy@example.com")
+    }
+
+    func testDecodesEnrichedPayload() throws {
+        let json = """
+        {
+            "conversation_id": 5,
+            "user": "doc@example.com",
+            "display_initials": "DC",
+            "actor_type": "user",
+            "sender_id": 7,
+            "actor_user_id": 7,
+            "actor_user_uuid": "abc-def-123"
+        }
+        """
+        let payload = try JSONDecoder().decode(ChatRealtimeTypingPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(payload.actorType, "user")
+        XCTAssertEqual(payload.senderId, 7)
+        XCTAssertEqual(payload.actorUserId, 7)
+        XCTAssertEqual(payload.actorUserUuid, "abc-def-123")
+        XCTAssertEqual(payload.identityKey, "abc-def-123")
+    }
+
+    func testDecodesSystemPayloadWithNullIds() throws {
+        let json = """
+        {
+            "conversation_id": 1,
+            "user": "system@medsim.local",
+            "display_initials": "TP",
+            "actor_type": "system",
+            "sender_id": null,
+            "actor_user_id": null,
+            "actor_user_uuid": null
+        }
+        """
+        let payload = try JSONDecoder().decode(ChatRealtimeTypingPayload.self, from: Data(json.utf8))
+        XCTAssertEqual(payload.actorType, "system")
+        XCTAssertNil(payload.senderId)
+        XCTAssertNil(payload.actorUserId)
+        XCTAssertNil(payload.actorUserUuid)
+        XCTAssertEqual(payload.identityKey, "system@medsim.local")
+        XCTAssertFalse(payload.isFromCurrentUser(
+            currentUserId: nil,
+            currentUserUuid: nil,
+            currentUserEmail: "system@medsim.local"
+        ))
+    }
+
+    // MARK: - Helpers
+
+    private func makePayload(
+        conversationID: Int? = nil,
+        user: String? = nil,
+        displayInitials: String? = nil,
+        actorType: String? = nil,
+        senderId: Int? = nil,
+        actorUserId: Int? = nil,
+        actorUserUuid: String? = nil
+    ) -> ChatRealtimeTypingPayload {
+        ChatRealtimeTypingPayload(
+            conversationID: conversationID,
+            user: user,
+            displayInitials: displayInitials,
+            actorType: actorType,
+            senderId: senderId,
+            actorUserId: actorUserId,
+            actorUserUuid: actorUserUuid
+        )
+    }
+}

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -805,7 +805,7 @@ final class ChatRunStoreTests: XCTestCase {
         ISO8601DateFormatter().string(from: Date())
     }
 
-    // MARK: - Self-typing suppression (simulation.userID == 7)
+    // MARK: - Self-typing suppression
 
     func testSelfTypingByActorUserIdIsNotDisplayed() async throws {
         let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
@@ -816,12 +816,17 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        // Identity explicitly set to match the payload's actor_user_id
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(id: 7),
+        )
         store.start()
         defer { store.stop() }
         try await waitUntil { store.activeConversationID == patientConversation.id }
 
-        // actor_user_id matches simulation.userID (7)
         realtime.pushEvent(makeEvent(
             id: "evt-self-typing-1",
             type: ChatRealtimeEventType.typingStarted,
@@ -846,12 +851,17 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        // Identity explicitly set to match the payload's sender_id
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(id: 7),
+        )
         store.start()
         defer { store.stop() }
         try await waitUntil { store.activeConversationID == patientConversation.id }
 
-        // sender_id matches simulation.userID (7)
         realtime.pushEvent(makeEvent(
             id: "evt-self-typing-2",
             type: ChatRealtimeEventType.typingStarted,
@@ -865,6 +875,115 @@ final class ChatRunStoreTests: XCTestCase {
 
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertTrue(store.activeTypingUsers.isEmpty, "Self typing via sender_id must not appear")
+    }
+
+    func testLegacyEmailOnlySelfTypingIsNotDisplayed() async throws {
+        // Older payloads have no actor_type or IDs; only the user email field.
+        // The store must still suppress them when the email matches the current user.
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(email: "me@example.com"),
+        )
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        // Legacy payload: only user field, no IDs, no actor_type
+        realtime.pushEvent(makeEvent(
+            id: "evt-legacy-self-typing",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("me@example.com"),
+                "display_initials": .string("ME"),
+            ],
+        ))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(store.activeTypingUsers.isEmpty, "Legacy email-only self typing must not appear")
+    }
+
+    func testUuidOnlySelfTypingIsNotDisplayed() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let myUUID = "abc-def-123"
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(uuid: myUUID),
+        )
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        realtime.pushEvent(makeEvent(
+            id: "evt-uuid-self-typing",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("me@example.com"),
+                "actor_type": .string("user"),
+                "actor_user_uuid": .string(myUUID),
+            ],
+        ))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(store.activeTypingUsers.isEmpty, "UUID-only self typing must not appear")
+    }
+
+    func testSimulationOwnerMismatchDoesNotSuppressOtherUser() async throws {
+        // If authenticated user ID differs from simulation.userID, a typing event
+        // whose sender_id matches simulation.userID must NOT be suppressed.
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        // Authenticated user is 99, but simulation.userID is 7
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(id: 99),
+        )
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        // Payload from user 7 (simulation owner, not the current authenticated user)
+        realtime.pushEvent(makeEvent(
+            id: "evt-owner-typing",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("owner@example.com"),
+                "actor_type": .string("user"),
+                "sender_id": .number(7),
+            ],
+        ))
+
+        try await waitUntil { store.activeTypingUsers.contains("owner@example.com") }
+        XCTAssertFalse(store.activeTypingUsers.isEmpty, "Typing from simulation owner must appear when current user differs")
     }
 
     func testSystemTypingIsDisplayed() async throws {

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -236,7 +236,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -254,7 +259,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -286,7 +296,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -317,7 +332,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -353,7 +373,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -382,7 +407,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -410,7 +440,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -440,7 +475,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -474,7 +514,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -541,7 +586,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -580,7 +630,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = [initialAIMessage]
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -613,7 +668,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -644,7 +704,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -669,7 +734,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
 
@@ -995,7 +1065,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
         try await waitUntil { store.activeConversationID == patientConversation.id }
@@ -1028,7 +1103,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
         try await waitUntil { store.activeConversationID == patientConversation.id }
@@ -1057,7 +1137,12 @@ final class ChatRunStoreTests: XCTestCase {
         service.messagesByConversation[patientConversation.id] = []
 
         let realtime = TestRealtimeClient()
-        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        let store = ChatRunStore(
+            service: service,
+            realtimeClient: realtime,
+            simulation: simulation,
+            currentUserIdentity: ChatCurrentUserIdentity(),
+        )
         store.start()
         defer { store.stop() }
         try await waitUntil { store.activeConversationID == patientConversation.id }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -839,7 +839,7 @@ final class ChatRunStoreTests: XCTestCase {
         ))
 
         try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertTrue(store.activeTypingUsers.isEmpty, "Self typing via actor_user_id must not appear")
+        XCTAssertNil(store.typingUsersByConversation[patientConversation.id], "Self typing via actor_user_id must not appear")
     }
 
     func testSelfTypingBySenderIdIsNotDisplayed() async throws {
@@ -874,7 +874,7 @@ final class ChatRunStoreTests: XCTestCase {
         ))
 
         try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertTrue(store.activeTypingUsers.isEmpty, "Self typing via sender_id must not appear")
+        XCTAssertNil(store.typingUsersByConversation[patientConversation.id], "Self typing via sender_id must not appear")
     }
 
     func testLegacyEmailOnlySelfTypingIsNotDisplayed() async throws {
@@ -910,7 +910,7 @@ final class ChatRunStoreTests: XCTestCase {
         ))
 
         try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertTrue(store.activeTypingUsers.isEmpty, "Legacy email-only self typing must not appear")
+        XCTAssertNil(store.typingUsersByConversation[patientConversation.id], "Legacy email-only self typing must not appear")
     }
 
     func testUuidOnlySelfTypingIsNotDisplayed() async throws {
@@ -945,7 +945,7 @@ final class ChatRunStoreTests: XCTestCase {
         ))
 
         try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertTrue(store.activeTypingUsers.isEmpty, "UUID-only self typing must not appear")
+        XCTAssertNil(store.typingUsersByConversation[patientConversation.id], "UUID-only self typing must not appear")
     }
 
     func testSimulationOwnerMismatchDoesNotSuppressOtherUser() async throws {
@@ -1086,7 +1086,9 @@ final class ChatRunStoreTests: XCTestCase {
             ],
         ))
 
-        try await waitUntil { store.activeTypingUsers.count == 2 }
+        try await waitUntil {
+            store.activeTypingUsers.contains("alpha@example.com") && store.activeTypingUsers.contains("beta@example.com")
+        }
         XCTAssertTrue(store.activeTypingUsers.contains("alpha@example.com"))
         XCTAssertTrue(store.activeTypingUsers.contains("beta@example.com"))
 
@@ -1103,7 +1105,9 @@ final class ChatRunStoreTests: XCTestCase {
             ],
         ))
 
-        try await waitUntil { store.activeTypingUsers.count == 1 }
+        try await waitUntil {
+            !store.activeTypingUsers.contains("alpha@example.com") && store.activeTypingUsers.contains("beta@example.com")
+        }
         XCTAssertFalse(store.activeTypingUsers.contains("alpha@example.com"))
         XCTAssertTrue(store.activeTypingUsers.contains("beta@example.com"))
     }

--- a/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
+++ b/apps/chatlab-ios/Tests/ChatLabiOSTests/ChatRunStoreTests.swift
@@ -804,4 +804,188 @@ final class ChatRunStoreTests: XCTestCase {
     private func isoTimestamp() -> String {
         ISO8601DateFormatter().string(from: Date())
     }
+
+    // MARK: - Self-typing suppression (simulation.userID == 7)
+
+    func testSelfTypingByActorUserIdIsNotDisplayed() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        // actor_user_id matches simulation.userID (7)
+        realtime.pushEvent(makeEvent(
+            id: "evt-self-typing-1",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("me@example.com"),
+                "actor_type": .string("user"),
+                "actor_user_id": .number(7),
+            ],
+        ))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(store.activeTypingUsers.isEmpty, "Self typing via actor_user_id must not appear")
+    }
+
+    func testSelfTypingBySenderIdIsNotDisplayed() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        // sender_id matches simulation.userID (7)
+        realtime.pushEvent(makeEvent(
+            id: "evt-self-typing-2",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("me@example.com"),
+                "actor_type": .string("user"),
+                "sender_id": .number(7),
+            ],
+        ))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertTrue(store.activeTypingUsers.isEmpty, "Self typing via sender_id must not appear")
+    }
+
+    func testSystemTypingIsDisplayed() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        realtime.pushEvent(makeEvent(
+            id: "evt-system-typing-1",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("system@medsim.local"),
+                "display_initials": .string("TP"),
+                "actor_type": .string("system"),
+                "sender_id": JSONValue.null,
+                "actor_user_id": JSONValue.null,
+                "actor_user_uuid": JSONValue.null,
+            ],
+        ))
+
+        try await waitUntil { !store.activeTypingUsers.isEmpty }
+        // System actor maps to patientDisplayName ("Jordan Lee" in test fixtures)
+        XCTAssertTrue(store.activeTypingUsers.contains(simulation.patientDisplayName))
+    }
+
+    func testAnotherUserTypingIsDisplayed() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        realtime.pushEvent(makeEvent(
+            id: "evt-other-typing-1",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("other@example.com"),
+                "actor_type": .string("user"),
+                "sender_id": .number(55),
+            ],
+        ))
+
+        try await waitUntil { store.activeTypingUsers.contains("other@example.com") }
+        XCTAssertFalse(store.activeTypingUsers.isEmpty)
+    }
+
+    func testTwoUsersWithSameInitialsTrackedSeparatelyByIdNotInitials() async throws {
+        let simulation = makeSimulation(status: .inProgress, retryable: nil, latestEventID: "evt-bootstrap")
+        let patientConversation = makeConversation()
+        let service = TestChatService()
+        service.simulations[simulation.id] = simulation
+        service.conversations = ChatConversationListResponse(items: [patientConversation])
+        service.messagesByConversation[patientConversation.id] = []
+
+        let realtime = TestRealtimeClient()
+        let store = ChatRunStore(service: service, realtimeClient: realtime, simulation: simulation)
+        store.start()
+        defer { store.stop() }
+        try await waitUntil { store.activeConversationID == patientConversation.id }
+
+        // Two different users, same initials
+        realtime.pushEvent(makeEvent(
+            id: "evt-user-a",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("alpha@example.com"),
+                "display_initials": .string("JD"),
+                "actor_type": .string("user"),
+                "sender_id": .number(10),
+            ],
+        ))
+        realtime.pushEvent(makeEvent(
+            id: "evt-user-b",
+            type: ChatRealtimeEventType.typingStarted,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("beta@example.com"),
+                "display_initials": .string("JD"),
+                "actor_type": .string("user"),
+                "sender_id": .number(20),
+            ],
+        ))
+
+        try await waitUntil { store.activeTypingUsers.count == 2 }
+        XCTAssertTrue(store.activeTypingUsers.contains("alpha@example.com"))
+        XCTAssertTrue(store.activeTypingUsers.contains("beta@example.com"))
+
+        // Stop one; the other should remain
+        realtime.pushEvent(makeEvent(
+            id: "evt-user-a-stop",
+            type: ChatRealtimeEventType.typingStopped,
+            payload: [
+                "conversation_id": .number(Double(patientConversation.id)),
+                "user": .string("alpha@example.com"),
+                "display_initials": .string("JD"),
+                "actor_type": .string("user"),
+                "sender_id": .number(10),
+            ],
+        ))
+
+        try await waitUntil { store.activeTypingUsers.count == 1 }
+        XCTAssertFalse(store.activeTypingUsers.contains("alpha@example.com"))
+        XCTAssertTrue(store.activeTypingUsers.contains("beta@example.com"))
+    }
 }

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
@@ -183,10 +183,16 @@ public final class AppShellModel: ObservableObject {
         let realtime = ChatRealtimeClient(
             authLoader: apiClient,
         )
+        let identity = ChatCurrentUserIdentity(
+            id: simulation.userID,
+            uuid: nil,
+            email: authViewModel.email.isEmpty ? nil : authViewModel.email,
+        )
         return ChatRunStore(
             service: chatService,
             realtimeClient: realtime,
             simulation: simulation,
+            currentUserIdentity: identity,
         )
     }
 

--- a/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
+++ b/apps/medsim-shell-ios/Sources/AppShell/AppShellModel.swift
@@ -184,8 +184,6 @@ public final class AppShellModel: ObservableObject {
             authLoader: apiClient,
         )
         let identity = ChatCurrentUserIdentity(
-            id: simulation.userID,
-            uuid: nil,
             email: authViewModel.email.isEmpty ? nil : authViewModel.email,
         )
         return ChatRunStore(


### PR DESCRIPTION
## Summary
Adds robust typing indicator management to prevent users from seeing their own typing events while properly tracking multiple users with the same display initials. Introduces enriched identity fields to the typing payload, a stable key-based tracking system, and compile-time enforcement that every `ChatRunStore` call site explicitly declares the authenticated user identity.

## Key Changes

### `ChatRealtimeTypingPayload` (ChatRealtimeProtocol.swift)
- Added optional identity fields: `actorType`, `senderId`, `actorUserId`, `actorUserUuid`
- `identityKey` property: stable key preferring UUID > actorUserId > senderId > email
- `normalizedActorType`: treats absent `actor_type` as `"user"` for backward compatibility
- `isFromCurrentUser(currentUserId:currentUserUuid:currentUserEmail:)`: detects self-typing via ID, UUID, or email; system actors always return false

### `ChatCurrentUserIdentity` (ChatLabContracts.swift)
- New `Sendable, Equatable` struct representing the **authenticated app user** (not the simulation owner — these can differ in staff/admin flows)
- Optional `id: Int?`, `uuid: String?`, `email: String?` so callers pass only what the auth layer provides

### `ChatRunStore` typing management (ChatRunStore.swift)
- Replaced string-based tracking with `TypingEntry` (key + display) to handle users with identical initials
- Defensive self-typing suppression via `isFromCurrentUser` before any entry is stored
- System payloads (`actor_type == "system"`) mapped to patient display name
- `currentUserIdentity: ChatCurrentUserIdentity` is now a **required** parameter — no default — enforcing that every call site makes an explicit decision

### Production wiring (AppShellModel.swift)
- `makeChatRunStore` builds identity from `authViewModel.email` only
- `simulation.userID` is deliberately **not** used: it is the simulation owner, not the authenticated user; in staff/admin flows those differ and using it would suppress the owner's typing indicator for observers

## Test Coverage

**`ChatRealtimeTypingPayloadTests`** (new file, 23 unit tests):
- Identity key resolution and fallback chain
- Actor type normalization
- Self-typing detection via actor_user_id, sender_id, UUID, and email
- Case-insensitive UUID and email comparison
- System actor always returns false
- Backward compatibility with legacy payloads (no new fields)

**`ChatRunStoreTests`** (8 new integration tests):
- Self-typing suppressed by `actor_user_id`
- Self-typing suppressed by `sender_id`
- Legacy email-only self-typing suppressed
- UUID-only self-typing suppressed
- Simulation owner mismatch: owner's typing is **not** suppressed when a different user is authenticated
- System typing displayed as patient display name
- Another user's typing displayed
- Two users with identical initials tracked separately by ID, not initials

## Implementation Notes

- Backward compatible: legacy payloads with only `user`/`display_initials` decode and display correctly
- System actors are never treated as the current user even if email matches
- No backend changes required; suppression is purely defensive at the store level

https://claude.ai/code/session_01LqF8dGskcmA91tWYfJdZ3b