### PR TITLE
refactor(runconsole): tighten SwiftUI view composition

### DIFF
--- a/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
+++ b/apps/chatlab-ios/Sources/ChatLabiOS/ChatRunView.swift
@@ -211,7 +211,6 @@ public struct ChatRunView: View {
         }
     }
 
-    @ViewBuilder
     private func compactGlassChrome(
         cornerRadius: CGFloat,
         tint: Color?,

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleLayoutSupport.swift
@@ -267,6 +267,25 @@ enum RunConsoleTimelineFilter: Hashable, CaseIterable, Identifiable {
     }
 }
 
+enum RunConsoleVitalsPresentation {
+    private static let preferredVitalKeyOrder: [String: Int] = [
+        "heart_rate": 0,
+        "spo2": 1,
+        "etco2": 2,
+        "blood_pressure": 3,
+        "blood_glucose": 4,
+        "blood_glucose_level": 5,
+    ]
+
+    static func orderedVitals(_ vitals: [VitalStatusSnapshot]) -> [VitalStatusSnapshot] {
+        vitals.sorted { lhs, rhs in
+            let lhsIndex = preferredVitalKeyOrder[lhs.key] ?? Int.max
+            let rhsIndex = preferredVitalKeyOrder[rhs.key] ?? Int.max
+            return lhsIndex == rhsIndex ? lhs.key < rhs.key : lhsIndex < rhsIndex
+        }
+    }
+}
+
 struct RunConsoleCompactMetrics {
     let sectionSpacing: CGFloat
     let cardPadding: CGFloat

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleOperationalLogPresentation.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleOperationalLogPresentation.swift
@@ -8,6 +8,23 @@ struct RunConsoleOperationalLogRow: Equatable {
 }
 
 enum RunConsoleOperationalLogPresentation {
+    static func recentUniqueItems(from events: [EventEnvelope], limit: Int = 30) -> [EventEnvelope] {
+        guard limit > 0 else { return [] }
+
+        var seen = Set<String>()
+        var result: [EventEnvelope] = []
+        result.reserveCapacity(min(events.count, limit))
+
+        for event in events.reversed() where seen.insert(event.eventID).inserted {
+            result.append(event)
+            if result.count == limit {
+                break
+            }
+        }
+
+        return result
+    }
+
     static func row(for event: EventEnvelope) -> RunConsoleOperationalLogRow {
         let canonicalEventType = SimulationEventRegistry.canonicalize(event.eventType)
         let title = SimulationEventRegistry.displayTitle(

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -266,13 +266,13 @@ public struct RunConsoleView: View {
         compactMetrics: RunConsoleCompactMetrics,
     ) -> some View {
         let regularVitalsMetrics = RunConsoleRegularVitalsMetrics.standard
-        let orderedVitals = self.orderedVitals
+        let vitals = orderedVitals
 
         return VStack(alignment: .leading, spacing: layoutMode == .compact ? compactMetrics.sectionSpacing : regularVitalsMetrics.sectionSpacing) {
             Text("Patient Vitals")
                 .font(.subheadline.bold())
 
-            if orderedVitals.isEmpty {
+            if vitals.isEmpty {
                 Text(
                     isSeedingSession
                         ? "Seeding scenario. Vital ranges will appear once the runtime is ready."
@@ -286,14 +286,14 @@ public struct RunConsoleView: View {
             } else if layoutMode == .regular {
                 regularVitalsContent(
                     metrics: regularVitalsMetrics,
-                    vitals: orderedVitals,
+                    vitals: vitals,
                 )
             } else {
                 LazyVGrid(
                     columns: compactVitalsColumns(for: compactMetrics),
                     spacing: compactMetrics.gridSpacing,
                 ) {
-                    ForEach(orderedVitals) { vital in
+                    ForEach(vitals) { vital in
                         compactVitalCell(vital, compactMetrics: compactMetrics)
                     }
                 }
@@ -1375,7 +1375,7 @@ public struct RunConsoleView: View {
     // MARK: - Operational log
 
     private func bottomLogPane(layoutMode _: RunConsoleLayoutMode) -> some View {
-        let operationalItems = self.operationalItems
+        let recentItems = operationalItems
 
         return VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -1409,7 +1409,7 @@ public struct RunConsoleView: View {
             }
 
             if isOperationalLogExpanded {
-                operationalLogEntries(items: operationalItems)
+                operationalLogEntries(items: recentItems)
             } else {
                 Text("Tap to view recent runtime events.")
                     .font(.caption)

--- a/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
+++ b/apps/trainerlab-ios/Sources/RunConsole/RunConsoleView.swift
@@ -32,7 +32,7 @@ public struct RunConsoleView: View {
     @State private var expandedTimelineEntryKey: String?
     @State private var activeInfoPanel: ActiveInfoPanel? = .scenarioBrief
     @State private var isLoadingRuntimeState = false
-    @State private var showScenarioBriefEditSheet = false
+    @State private var scenarioBriefEditDraft: ScenarioBriefEditDraft?
     @Namespace private var segmentNS
 
     @State private var interventionTargetProblemID: Int?
@@ -149,14 +149,11 @@ public struct RunConsoleView: View {
             }
             .presentationDetents([.fraction(0.55)])
         }
-        .sheet(isPresented: $showScenarioBriefEditSheet) {
-            if let brief = store.scenarioBrief {
-                ScenarioBriefEditSheet(brief: brief) { request in
-                    store.updateScenarioBrief(request)
-                    showScenarioBriefEditSheet = false
-                }
-                .presentationDetents([.fraction(0.65)])
+        .sheet(item: $scenarioBriefEditDraft) { draft in
+            ScenarioBriefEditSheet(brief: draft.brief) { request in
+                store.updateScenarioBrief(request)
             }
+            .presentationDetents([.fraction(0.65)])
         }
         .task {
             store.startConsole()
@@ -269,6 +266,7 @@ public struct RunConsoleView: View {
         compactMetrics: RunConsoleCompactMetrics,
     ) -> some View {
         let regularVitalsMetrics = RunConsoleRegularVitalsMetrics.standard
+        let orderedVitals = self.orderedVitals
 
         return VStack(alignment: .leading, spacing: layoutMode == .compact ? compactMetrics.sectionSpacing : regularVitalsMetrics.sectionSpacing) {
             Text("Patient Vitals")
@@ -286,7 +284,10 @@ public struct RunConsoleView: View {
                     regularAVPUInlineControl(metrics: regularVitalsMetrics)
                 }
             } else if layoutMode == .regular {
-                regularVitalsContent(metrics: regularVitalsMetrics)
+                regularVitalsContent(
+                    metrics: regularVitalsMetrics,
+                    vitals: orderedVitals,
+                )
             } else {
                 LazyVGrid(
                     columns: compactVitalsColumns(for: compactMetrics),
@@ -688,7 +689,7 @@ public struct RunConsoleView: View {
                 if canMutate {
                     HStack {
                         Spacer()
-                        Button { showScenarioBriefEditSheet = true } label: {
+                        Button { scenarioBriefEditDraft = ScenarioBriefEditDraft(brief: brief) } label: {
                             Label("Edit Brief", systemImage: "pencil.circle")
                                 .font(.caption)
                         }
@@ -1219,19 +1220,22 @@ public struct RunConsoleView: View {
     // MARK: - Timeline pane
 
     private func centerTimelinePane(layoutMode: RunConsoleLayoutMode) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
+        let entries = filteredTimelineEntries
+        let entryKeys = entries.map(\.dedupeKey)
+
+        return VStack(alignment: .leading, spacing: 10) {
             timelineHeader(layoutMode: layoutMode)
 
-            if filteredTimelineEntries.isEmpty {
+            if entries.isEmpty {
                 Text(selectedTimelineFilter == .all ? "No timeline entries yet" : "No matching timeline entries")
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, 8)
             } else {
-                timelineEntries
+                timelineEntries(entries: entries)
             }
         }
-        .onChange(of: filteredTimelineEntryKeys) { _, keys in
+        .onChange(of: entryKeys) { _, keys in
             guard
                 let expandedTimelineEntryKey,
                 !keys.contains(expandedTimelineEntryKey)
@@ -1243,9 +1247,9 @@ public struct RunConsoleView: View {
         .trainerCardStyle()
     }
 
-    private var timelineEntries: some View {
+    private func timelineEntries(entries: [ClinicalTimelineEntry]) -> some View {
         LazyVStack(alignment: .leading, spacing: 8) {
-            ForEach(filteredTimelineEntries.prefix(160)) { item in
+            ForEach(entries.prefix(160)) { item in
                 timelineEntryRow(item)
             }
         }
@@ -1371,7 +1375,9 @@ public struct RunConsoleView: View {
     // MARK: - Operational log
 
     private func bottomLogPane(layoutMode _: RunConsoleLayoutMode) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let operationalItems = self.operationalItems
+
+        return VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -1403,7 +1409,7 @@ public struct RunConsoleView: View {
             }
 
             if isOperationalLogExpanded {
-                operationalLogEntries
+                operationalLogEntries(items: operationalItems)
             } else {
                 Text("Tap to view recent runtime events.")
                     .font(.caption)
@@ -1414,30 +1420,16 @@ public struct RunConsoleView: View {
         .trainerCardStyle(background: TrainerLabTheme.tacticalSurfaceElevated)
     }
 
-    private var operationalLogEntries: some View {
+    private func operationalLogEntries(items: [EventEnvelope]) -> some View {
         LazyVStack(alignment: .leading, spacing: 6) {
-            if operationalItems.isEmpty {
+            if items.isEmpty {
                 Text("No runtime events yet")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
-                ForEach(operationalItems.prefix(30), id: \.eventID) { item in
-                    let row = RunConsoleOperationalLogPresentation.row(for: item)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("[\(item.createdAt.formatted(date: .omitted, time: .standard))] \(row.title)")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.white)
-                        if let detail = row.detail {
-                            Text(detail)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                        Text(row.canonicalEventType)
-                            .font(.caption2.monospaced())
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                ForEach(items) { item in
+                    OperationalLogRowView(item: item)
                 }
             }
         }
@@ -2098,10 +2090,6 @@ public struct RunConsoleView: View {
         )
     }
 
-    private var filteredTimelineEntryKeys: [String] {
-        filteredTimelineEntries.map(\.dedupeKey)
-    }
-
     private func annotationOutcomeColor(_ outcome: AnnotationOutcome) -> Color {
         switch outcome {
         case .correct:
@@ -2202,22 +2190,11 @@ public struct RunConsoleView: View {
     }
 
     private var orderedVitals: [VitalStatusSnapshot] {
-        let preferred = ["heart_rate", "spo2", "etco2", "blood_pressure", "blood_glucose", "blood_glucose_level"]
-        return store.state.vitals.sorted { lhs, rhs in
-            let li = preferred.firstIndex(of: lhs.key) ?? Int.max
-            let ri = preferred.firstIndex(of: rhs.key) ?? Int.max
-            return li == ri ? lhs.key < rhs.key : li < ri
-        }
+        RunConsoleVitalsPresentation.orderedVitals(store.state.vitals)
     }
 
     private var operationalItems: [EventEnvelope] {
-        var seen = Set<String>()
-        var result: [EventEnvelope] = []
-        for event in store.state.timeline.reversed() where !seen.contains(event.eventID) {
-            seen.insert(event.eventID)
-            result.append(event)
-        }
-        return result
+        RunConsoleOperationalLogPresentation.recentUniqueItems(from: store.state.timeline)
     }
 
     private var formattedStopwatch: String {
@@ -2439,23 +2416,29 @@ public struct RunConsoleView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func regularVitalsContent(metrics: RunConsoleRegularVitalsMetrics) -> some View {
+    private func regularVitalsContent(
+        metrics: RunConsoleRegularVitalsMetrics,
+        vitals: [VitalStatusSnapshot],
+    ) -> some View {
         ViewThatFits(in: .horizontal) {
             HStack(alignment: .center, spacing: metrics.inlineGroupSpacing) {
-                regularVitalsRow(metrics: metrics)
+                regularVitalsRow(metrics: metrics, vitals: vitals)
                 regularAVPUInlineControl(metrics: metrics)
             }
 
             VStack(alignment: .leading, spacing: metrics.fallbackRowSpacing) {
-                regularVitalsRow(metrics: metrics)
+                regularVitalsRow(metrics: metrics, vitals: vitals)
                 regularAVPUInlineControl(metrics: metrics)
             }
         }
     }
 
-    private func regularVitalsRow(metrics: RunConsoleRegularVitalsMetrics) -> some View {
+    private func regularVitalsRow(
+        metrics: RunConsoleRegularVitalsMetrics,
+        vitals: [VitalStatusSnapshot],
+    ) -> some View {
         HStack(alignment: .top, spacing: metrics.vitalsRowSpacing) {
-            ForEach(orderedVitals) { vital in
+            ForEach(vitals) { vital in
                 regularVitalCell(vital, metrics: metrics)
             }
         }
@@ -2541,6 +2524,36 @@ public struct RunConsoleView: View {
             simulationDisplayName: store.state.session.map { "Simulation #\($0.simulationID)" },
             simulationStatus: store.state.session?.status.rawValue,
         )
+    }
+}
+
+private struct ScenarioBriefEditDraft: Identifiable {
+    let id = UUID()
+    let brief: ScenarioBriefOut
+}
+
+private struct OperationalLogRowView: View {
+    let item: EventEnvelope
+
+    private var row: RunConsoleOperationalLogRow {
+        RunConsoleOperationalLogPresentation.row(for: item)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("[\(item.createdAt.formatted(date: .omitted, time: .standard))] \(row.title)")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white)
+            if let detail = row.detail {
+                Text(detail)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Text(row.canonicalEventType)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -3022,6 +3035,7 @@ private struct ScenarioBriefEditSheet: View {
                             evacuationTime: evacuationTime.isEmpty ? nil : evacuationTime,
                             specialConsiderations: parseList(from: specialConsiderations),
                         ))
+                        dismiss()
                     }
                     .disabled(readAloudBrief.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }

--- a/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
+++ b/apps/trainerlab-ios/Tests/RunConsoleTests/RunConsoleLayoutSupportTests.swift
@@ -209,6 +209,21 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         )
     }
 
+    func testVitalsPresentationOrdersPreferredKeysBeforeFallbacks() {
+        let vitals = [
+            makeVital(key: "temperature"),
+            makeVital(key: "blood_pressure"),
+            makeVital(key: "heart_rate"),
+            makeVital(key: "custom_alpha"),
+            makeVital(key: "spo2"),
+        ]
+
+        XCTAssertEqual(
+            RunConsoleVitalsPresentation.orderedVitals(vitals).map(\.key),
+            ["heart_rate", "spo2", "blood_pressure", "custom_alpha", "temperature"],
+        )
+    }
+
     func testLifecycleActionsMatchSessionStatus() {
         XCTAssertEqual(RunConsoleLifecycleAction.visibleActions(for: .seeding), [])
         XCTAssertEqual(RunConsoleLifecycleAction.visibleActions(for: .seeded), [.start])
@@ -281,6 +296,20 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
         XCTAssertEqual(row.title, "Summary Updated")
         XCTAssertNil(row.detail)
         XCTAssertEqual(row.canonicalEventType, SimulationEventType.simulationSummaryUpdated)
+    }
+
+    func testOperationalLogPresentationReturnsRecentUniqueItemsWithLimit() {
+        let events = [
+            makeEvent(id: "evt-1", createdAt: Date(timeIntervalSince1970: 1)),
+            makeEvent(id: "evt-2", createdAt: Date(timeIntervalSince1970: 2)),
+            makeEvent(id: "evt-1", createdAt: Date(timeIntervalSince1970: 3)),
+            makeEvent(id: "evt-3", createdAt: Date(timeIntervalSince1970: 4)),
+        ]
+
+        XCTAssertEqual(
+            RunConsoleOperationalLogPresentation.recentUniqueItems(from: events, limit: 2).map(\.eventID),
+            ["evt-3", "evt-1"],
+        )
     }
 
     func testAvailableAccessInventoryDerivesIVAndIOAvailability() {
@@ -1005,6 +1034,25 @@ final class RunConsoleLayoutSupportTests: XCTestCase {
 
 private func makeDictionary(_ types: [String]) -> [InterventionGroup] {
     types.map { InterventionGroup(interventionType: $0, label: $0, sites: []) }
+}
+
+private func makeEvent(id: String, createdAt: Date) -> EventEnvelope {
+    EventEnvelope(
+        eventID: id,
+        eventType: SimulationEventType.simulationStatusUpdated,
+        createdAt: createdAt,
+        correlationID: nil,
+        payload: [:],
+    )
+}
+
+private func makeVital(key: String) -> VitalStatusSnapshot {
+    VitalStatusSnapshot(
+        key: key,
+        minValue: 0,
+        maxValue: 100,
+        currentValue: 50,
+    )
 }
 
 private func makeInterventionAnnotation(


### PR DESCRIPTION
## Summary
- Precompute ordered vitals, filtered timeline entries, and operational log rows outside repeated view-builder paths
- Bound operational log deduping to the visible row limit and extract the log row into a dedicated subview
- Convert the Scenario Brief editor to item-driven sheet presentation and let the sheet dismiss itself after save
- Add tests for vitals ordering and recent unique operational log selection

## Testing
- `RunConsoleLayoutSupportTests` passed locally
- `git diff --check` passed